### PR TITLE
Fix presence and occupancy command examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1873,11 +1873,11 @@ DESCRIPTION
   Enter presence on a channel and remain present until terminated
 
 EXAMPLES
-  $ ably channels presence:enter my-channel
+  $ ably channels presence enter my-channel
 
-  $ ably channels presence:enter my-channel --data '{"status":"online"}'
+  $ ably channels presence enter my-channel --data '{"status":"online"}'
 
-  $ ably channels presence:enter my-channel --client-id "user123"
+  $ ably channels presence enter my-channel --client-id "user123"
 ```
 
 _See code: [src/commands/channels/presence/enter.ts](https://github.com/ably/cli/blob/v0.2.3/src/commands/channels/presence/enter.ts)_
@@ -1910,9 +1910,9 @@ DESCRIPTION
   Subscribe to presence events on a channel
 
 EXAMPLES
-  $ ably channels presence:subscribe my-channel
+  $ ably channels presence subscribe my-channel
 
-  $ ably channels presence:subscribe my-channel --format json
+  $ ably channels presence subscribe my-channel --format json
 ```
 
 _See code: [src/commands/channels/presence/subscribe.ts](https://github.com/ably/cli/blob/v0.2.3/src/commands/channels/presence/subscribe.ts)_

--- a/README.md
+++ b/README.md
@@ -1782,9 +1782,9 @@ DESCRIPTION
   Get current occupancy metrics for a channel
 
 EXAMPLES
-  $ ably channels occupancy:get my-channel
+  $ ably channels occupancy get my-channel
 
-  $ ably channels occupancy:get --api-key "YOUR_API_KEY" my-channel
+  $ ably channels occupancy get --api-key "YOUR_API_KEY" my-channel
 ```
 
 _See code: [src/commands/channels/occupancy/get.ts](https://github.com/ably/cli/blob/v0.2.3/src/commands/channels/occupancy/get.ts)_

--- a/src/commands/channels/occupancy/get.ts
+++ b/src/commands/channels/occupancy/get.ts
@@ -15,8 +15,8 @@ export default class ChannelsOccupancyGet extends AblyBaseCommand {
   static description = 'Get current occupancy metrics for a channel'
 
   static examples = [
-    '$ ably channels occupancy:get my-channel',
-    '$ ably channels occupancy:get --api-key "YOUR_API_KEY" my-channel',
+    '$ ably channels occupancy get my-channel',
+    '$ ably channels occupancy get --api-key "YOUR_API_KEY" my-channel',
   ]
 
   static flags = {

--- a/src/commands/channels/presence/enter.ts
+++ b/src/commands/channels/presence/enter.ts
@@ -7,9 +7,9 @@ export default class ChannelsPresenceEnter extends AblyBaseCommand {
   static override description = 'Enter presence on a channel and remain present until terminated'
 
   static override examples = [
-    '$ ably channels presence:enter my-channel',
-    '$ ably channels presence:enter my-channel --data \'{"status":"online"}\'',
-    '$ ably channels presence:enter my-channel --client-id "user123"',
+    '$ ably channels presence enter my-channel',
+    '$ ably channels presence enter my-channel --data \'{"status":"online"}\'',
+    '$ ably channels presence enter my-channel --client-id "user123"',
   ]
 
   static override flags = {

--- a/src/commands/channels/presence/subscribe.ts
+++ b/src/commands/channels/presence/subscribe.ts
@@ -7,8 +7,8 @@ export default class ChannelsPresenceSubscribe extends AblyBaseCommand {
   static override description = 'Subscribe to presence events on a channel'
 
   static override examples = [
-    '$ ably channels presence:subscribe my-channel',
-    '$ ably channels presence:subscribe my-channel --format json',
+    '$ ably channels presence subscribe my-channel',
+    '$ ably channels presence subscribe my-channel --format json',
   ]
 
   static override flags = {


### PR DESCRIPTION
The examples for occupancy and presence commands were incorrectly listed as using colons as the separator. This PR fixes this for;

* presence.subscribe
* presence.enter
* occupancy.get