### PR TITLE
Fix: Remove messageId arg from room reactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ See [MCP Server section](#mcp-server) for more details on how to use the MCP Ser
 * [`ably rooms presence enter ROOMID`](#ably-rooms-presence-enter-roomid)
 * [`ably rooms presence subscribe ROOMID`](#ably-rooms-presence-subscribe-roomid)
 * [`ably rooms reactions`](#ably-rooms-reactions)
-* [`ably rooms reactions send ROOMID MESSAGEID EMOJI`](#ably-rooms-reactions-send-roomid-messageid-emoji)
+* [`ably rooms reactions send ROOMID EMOJI`](#ably-rooms-reactions-send-roomid-emoji)
 * [`ably rooms reactions subscribe ROOMID`](#ably-rooms-reactions-subscribe-roomid)
 * [`ably rooms typing`](#ably-rooms-typing)
 * [`ably rooms typing start ROOMID`](#ably-rooms-typing-start-roomid)
@@ -3871,20 +3871,19 @@ EXAMPLES
 
 _See code: [src/commands/rooms/reactions/index.ts](https://github.com/ably/cli/blob/v0.4.0/src/commands/rooms/reactions/index.ts)_
 
-## `ably rooms reactions send ROOMID MESSAGEID EMOJI`
+## `ably rooms reactions send ROOMID EMOJI`
 
-Send a reaction to a message in a chat room
+Send a reaction in a chat room
 
 ```
 USAGE
-  $ ably rooms reactions send ROOMID MESSAGEID EMOJI [--access-token <value>] [--api-key <value>] [--client-id <value>]
+  $ ably rooms reactions send ROOMID EMOJI [--access-token <value>] [--api-key <value>] [--client-id <value>]
     [--control-host <value>] [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v]
     [--metadata <value>]
 
 ARGUMENTS
-  ROOMID     The room ID to send the reaction to
-  MESSAGEID  The message ID to react to
-  EMOJI      The emoji reaction to send (e.g. 👍, ❤️, 😂)
+  ROOMID  The room ID to send the reaction to
+  EMOJI   The emoji reaction to send (e.g. 👍, ❤️, 😂)
 
 FLAGS
   -v, --verbose               Output verbose logs
@@ -3901,16 +3900,16 @@ FLAGS
       --token=<value>         Authenticate using an Ably Token or JWT Token instead of an API key
 
 DESCRIPTION
-  Send a reaction to a message in a chat room
+  Send a reaction in a chat room
 
 EXAMPLES
-  $ ably rooms reactions send my-room abc123 👍
+  $ ably rooms reactions send my-room 👍
 
-  $ ably rooms reactions send --api-key "YOUR_API_KEY" my-room abc123 🎉
+  $ ably rooms reactions send --api-key "YOUR_API_KEY" my-room 🎉
 
-  $ ably rooms reactions send my-room abc123 ❤️ --json
+  $ ably rooms reactions send my-room ❤️ --json
 
-  $ ably rooms reactions send my-room abc123 😂 --pretty-json
+  $ ably rooms reactions send my-room 😂 --pretty-json
 ```
 
 _See code: [src/commands/rooms/reactions/send.ts](https://github.com/ably/cli/blob/v0.4.0/src/commands/rooms/reactions/send.ts)_

--- a/src/commands/rooms/reactions/send.ts
+++ b/src/commands/rooms/reactions/send.ts
@@ -11,23 +11,19 @@ export default class RoomsReactionsSend extends ChatBaseCommand {
       description: "The room ID to send the reaction to",
       required: true,
     }),
-    messageId: Args.string({
-      description: "The message ID to react to",
-      required: true,
-    }),
     emoji: Args.string({
       description: "The emoji reaction to send (e.g. 👍, ❤️, 😂)",
       required: true,
     }),
   };
 
-  static override description = "Send a reaction to a message in a chat room";
+  static override description = "Send a reaction in a chat room";
 
   static override examples = [
-    "$ ably rooms reactions send my-room abc123 👍",
-    '$ ably rooms reactions send --api-key "YOUR_API_KEY" my-room abc123 🎉',
-    "$ ably rooms reactions send my-room abc123 ❤️ --json",
-    "$ ably rooms reactions send my-room abc123 😂 --pretty-json",
+    "$ ably rooms reactions send my-room 👍",
+    '$ ably rooms reactions send --api-key "YOUR_API_KEY" my-room 🎉',
+    "$ ably rooms reactions send my-room ❤️ --json",
+    "$ ably rooms reactions send my-room 😂 --pretty-json",
   ];
 
   static override flags = {
@@ -65,7 +61,7 @@ export default class RoomsReactionsSend extends ChatBaseCommand {
 
   async run(): Promise<void> {
     const { args, flags } = await this.parse(RoomsReactionsSend);
-    const { roomId, messageId, emoji } = args;
+    const { roomId, emoji } = args;
 
     try {
       // Parse metadata if provided
@@ -84,12 +80,11 @@ export default class RoomsReactionsSend extends ChatBaseCommand {
           this.logCliEvent(flags, "reaction", "metadataParseError", errorMsg, {
             error: errorMsg,
             roomId,
-            messageId,
           });
           if (this.shouldOutputJson(flags)) {
             this.log(
               this.formatJsonOutput(
-                { error: errorMsg, roomId, messageId, success: false },
+                { error: errorMsg, roomId, success: false },
                 flags,
               ),
             );
@@ -206,7 +201,7 @@ export default class RoomsReactionsSend extends ChatBaseCommand {
         flags,
         "reaction",
         "sending",
-        `Sending reaction ${emoji} to message ${messageId}`,
+        `Sending reaction ${emoji}`,
         { emoji, metadata: this.metadataObj || {} },
       );
       await room.reactions.send({
@@ -217,13 +212,12 @@ export default class RoomsReactionsSend extends ChatBaseCommand {
         flags,
         "reaction",
         "sent",
-        `Successfully sent reaction ${emoji} to message ${messageId}`,
+        `Successfully sent reaction ${emoji}`,
       );
 
       // Format the response
       const resultData = {
         emoji,
-        messageId,
         metadata: this.metadataObj,
         roomId,
         success: true,
@@ -233,7 +227,7 @@ export default class RoomsReactionsSend extends ChatBaseCommand {
         this.log(this.formatJsonOutput(resultData, flags));
       } else {
         this.log(
-          `${chalk.green("✓")} Sent reaction ${emoji} to message ${chalk.cyan(messageId)} in room ${chalk.cyan(roomId)}`,
+          `${chalk.green("✓")} Sent reaction ${emoji} in room ${chalk.cyan(roomId)}`,
         );
       }
 
@@ -262,7 +256,7 @@ export default class RoomsReactionsSend extends ChatBaseCommand {
         "reaction",
         "error",
         `Failed to send reaction: ${errorMsg}`,
-        { error: errorMsg, roomId, messageId, emoji },
+        { error: errorMsg, roomId, emoji },
       );
 
       // Close the connection in case of error
@@ -273,7 +267,7 @@ export default class RoomsReactionsSend extends ChatBaseCommand {
       if (this.shouldOutputJson(flags)) {
         this.log(
           this.formatJsonOutput(
-            { error: errorMsg, roomId, messageId, emoji, success: false },
+            { error: errorMsg, roomId, emoji, success: false },
             flags,
           ),
         );

--- a/src/commands/rooms/reactions/subscribe.ts
+++ b/src/commands/rooms/reactions/subscribe.ts
@@ -5,11 +5,6 @@ import chalk from "chalk";
 
 import { ChatBaseCommand } from "../../../chat-base-command.js";
 
-// interface ChatClients { // Remove ChatClients interface
-//   chatClient: ChatClient;
-//   realtimeClient: any;
-// }
-
 export default class RoomsReactionsSubscribe extends ChatBaseCommand {
   static override args = {
     roomId: Args.string({

--- a/test/e2e/web-cli/web-cli.test.ts
+++ b/test/e2e/web-cli/web-cli.test.ts
@@ -184,7 +184,7 @@ test.describe('Web CLI E2E Tests', () => {
     await page.keyboard.press('Enter');
 
     // Wait for specific output from 'ably --version'
-    const versionOutputText = '@ably/cli/0.3.3'; // Expected text
+    const versionOutputText = '@ably/cli/0.4.0'; // Expected text
     await expect(page.locator(terminalSelector)).toContainText(versionOutputText, { timeout: 15000 });
     console.log("'ably --version' output verified.");
 

--- a/test/integration/docker-container-security.test.ts
+++ b/test/integration/docker-container-security.test.ts
@@ -124,10 +124,14 @@ describe('Docker Container Security Features', function() {
     const { stdout } = await execAsync(`docker inspect ${containerName}`);
     const containerInfo = JSON.parse(stdout);
 
-    // Check that capabilities are dropped
-    const capDrop = containerInfo[0].HostConfig.CapDrop || [];
+    // Normalize entries by stripping 'CAP_' prefix if present so we can work across
+    // different systems
+    const capDrop = (containerInfo[0].HostConfig.CapDrop || []).map(
+      (cap: string) => cap.replace(/^CAP_/, '')
+    );
     expect(capDrop).to.include.members(['NET_ADMIN', 'NET_BIND_SERVICE', 'NET_RAW']);
   });
+
 
   it('should verify seccomp profile is applied', async function() {
     // Get container info in JSON format


### PR DESCRIPTION
## Description
Room reactions do not require a messageId, so this has been removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated documentation to reflect that sending a reaction in a chat room no longer requires specifying a message ID. Usage examples and descriptions now show reactions sent directly to a room with an emoji.

- **Refactor**
  - Simplified the reaction sending command to remove the message ID argument, making reactions apply at the room level.
  - Cleaned up unused, commented-out code for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->