### PR TITLE
Publish should not await, and help format fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,8 +216,8 @@ Show the current Ably account
 
 ```
 USAGE
-  $ ably accounts current [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host <value>]
-    [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v]
+  $ ably accounts current [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>] [--host
+    <value>] [--json | --pretty-json] [--token <value>] [-v]
 
 FLAGS
   -v, --verbose               Output verbose logs
@@ -225,7 +225,6 @@ FLAGS
       --api-key=<value>       Overrides any configured API key used for the product APIs
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
       --json                  Output in JSON format
@@ -251,8 +250,8 @@ List locally configured Ably accounts
 
 ```
 USAGE
-  $ ably accounts list [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host <value>]
-    [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v]
+  $ ably accounts list [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>] [--host
+    <value>] [--json | --pretty-json] [--token <value>] [-v]
 
 FLAGS
   -v, --verbose               Output verbose logs
@@ -260,7 +259,6 @@ FLAGS
       --api-key=<value>       Overrides any configured API key used for the product APIs
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
       --json                  Output in JSON format
@@ -286,9 +284,8 @@ Log in to your Ably account
 
 ```
 USAGE
-  $ ably accounts login [TOKEN] [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host
-    <value>] [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [-a <value>]
-    [--no-browser]
+  $ ably accounts login [TOKEN] [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
+    [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [-a <value>] [--no-browser]
 
 ARGUMENTS
   TOKEN  Access token (if not provided, will prompt for it)
@@ -300,7 +297,6 @@ FLAGS
       --api-key=<value>       Overrides any configured API key used for the product APIs
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
       --json                  Output in JSON format
@@ -329,8 +325,8 @@ Log out from an Ably account
 
 ```
 USAGE
-  $ ably accounts logout [ALIAS] [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host
-    <value>] [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [-f]
+  $ ably accounts logout [ALIAS] [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
+    [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [-f]
 
 ARGUMENTS
   ALIAS  Alias of the account to log out from (defaults to current account)
@@ -342,7 +338,6 @@ FLAGS
       --api-key=<value>       Overrides any configured API key used for the product APIs
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
       --json                  Output in JSON format
@@ -370,9 +365,9 @@ Get account stats with optional live updates
 
 ```
 USAGE
-  $ ably accounts stats [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host <value>]
-    [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--debug] [--end <value>]
-    [--interval <value>] [--limit <value>] [--live] [--start <value>] [--unit minute|hour|day|month]
+  $ ably accounts stats [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>] [--host
+    <value>] [--json | --pretty-json] [--token <value>] [-v] [--debug] [--end <value>] [--interval <value>] [--limit
+    <value>] [--live] [--start <value>] [--unit minute|hour|day|month]
 
 FLAGS
   -v, --verbose               Output verbose logs
@@ -380,7 +375,6 @@ FLAGS
       --api-key=<value>       Overrides any configured API key used for the product APIs
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --debug                 Show debug information for live stats polling
       --end=<value>           End time in milliseconds since epoch
       --env=<value>           Override the environment for all product API calls
@@ -424,8 +418,8 @@ Switch to a different Ably account
 
 ```
 USAGE
-  $ ably accounts switch [ALIAS] [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host
-    <value>] [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v]
+  $ ably accounts switch [ALIAS] [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
+    [--host <value>] [--json | --pretty-json] [--token <value>] [-v]
 
 ARGUMENTS
   ALIAS  Alias of the account to switch to
@@ -436,7 +430,6 @@ FLAGS
       --api-key=<value>       Overrides any configured API key used for the product APIs
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
       --json                  Output in JSON format
@@ -518,11 +511,11 @@ Create a channel rule
 
 ```
 USAGE
-  $ ably apps channel-rules create --name <value> [--access-token <value>] [--api-key <value>] [--client-id <value>]
-    [--control-host <value>] [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--app
-    <value>] [--authenticated] [--batching-enabled] [--batching-interval <value>] [--conflation-enabled]
-    [--conflation-interval <value>] [--conflation-key <value>] [--expose-time-serial] [--persist-last] [--persisted]
-    [--populate-channel-registry] [--push-enabled] [--tls-only]
+  $ ably apps channel-rules create --name <value> [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env
+    <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--app <value>] [--authenticated]
+    [--batching-enabled] [--batching-interval <value>] [--conflation-enabled] [--conflation-interval <value>]
+    [--conflation-key <value>] [--expose-time-serial] [--persist-last] [--persisted] [--populate-channel-registry]
+    [--push-enabled] [--tls-only]
 
 FLAGS
   -v, --verbose                      Output verbose logs
@@ -537,7 +530,6 @@ FLAGS
       --conflation-enabled           Whether to enable conflation for messages on channels matching this rule
       --conflation-interval=<value>  The conflation interval for messages on channels matching this rule
       --conflation-key=<value>       The conflation key for messages on channels matching this rule
-      --control-host=<value>         Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>                  Override the environment for all product API calls
       --expose-time-serial           Whether to expose the time serial for messages on channels matching this rule
       --host=<value>                 Override the host endpoint for all product API calls
@@ -570,8 +562,8 @@ Delete a channel rule
 
 ```
 USAGE
-  $ ably apps channel-rules delete NAMEORID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host
-    <value>] [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--app <value>] [-f]
+  $ ably apps channel-rules delete NAMEORID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
+    [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--app <value>] [-f]
 
 ARGUMENTS
   NAMEORID  Name or ID of the channel rule to delete
@@ -584,7 +576,6 @@ FLAGS
       --app=<value>           App ID or name to delete the channel rule from
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
       --json                  Output in JSON format
@@ -637,11 +628,11 @@ Update a channel rule
 
 ```
 USAGE
-  $ ably apps channel-rules update NAMEORID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host
-    <value>] [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--app <value>]
-    [--authenticated] [--batching-enabled] [--batching-interval <value>] [--conflation-enabled] [--conflation-interval
-    <value>] [--conflation-key <value>] [--expose-time-serial] [--persist-last] [--persisted]
-    [--populate-channel-registry] [--push-enabled] [--tls-only]
+  $ ably apps channel-rules update NAMEORID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
+    [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--app <value>] [--authenticated]
+    [--batching-enabled] [--batching-interval <value>] [--conflation-enabled] [--conflation-interval <value>]
+    [--conflation-key <value>] [--expose-time-serial] [--persist-last] [--persisted] [--populate-channel-registry]
+    [--push-enabled] [--tls-only]
 
 ARGUMENTS
   NAMEORID  Name or ID of the channel rule to update
@@ -659,8 +650,6 @@ FLAGS
       --[no-]conflation-enabled         Whether to enable conflation for messages on channels matching this rule
       --conflation-interval=<value>     The conflation interval for messages on channels matching this rule
       --conflation-key=<value>          The conflation key for messages on channels matching this rule
-      --control-host=<value>            Override the host endpoint for the control API, which defaults to
-                                        control.ably.net
       --env=<value>                     Override the environment for all product API calls
       --[no-]expose-time-serial         Whether to expose the time serial for messages on channels matching this rule
       --host=<value>                    Override the host endpoint for all product API calls
@@ -692,9 +681,8 @@ Create a new app
 
 ```
 USAGE
-  $ ably apps create --name <value> [--access-token <value>] [--api-key <value>] [--client-id <value>]
-    [--control-host <value>] [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v]
-    [--tls-only]
+  $ ably apps create --name <value> [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env
+    <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--tls-only]
 
 FLAGS
   -v, --verbose               Output verbose logs
@@ -702,7 +690,6 @@ FLAGS
       --api-key=<value>       Overrides any configured API key used for the product APIs
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
       --json                  Output in JSON format
@@ -730,8 +717,8 @@ Show the currently selected app
 
 ```
 USAGE
-  $ ably apps current [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host <value>]
-    [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v]
+  $ ably apps current [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>] [--host
+    <value>] [--json | --pretty-json] [--token <value>] [-v]
 
 FLAGS
   -v, --verbose               Output verbose logs
@@ -739,7 +726,6 @@ FLAGS
       --api-key=<value>       Overrides any configured API key used for the product APIs
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
       --json                  Output in JSON format
@@ -765,8 +751,8 @@ Delete an app
 
 ```
 USAGE
-  $ ably apps delete [ID] [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host
-    <value>] [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [-f]
+  $ ably apps delete [ID] [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
+    [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [-f]
 
 ARGUMENTS
   ID  App ID to delete (uses current app if not specified)
@@ -778,7 +764,6 @@ FLAGS
       --api-key=<value>       Overrides any configured API key used for the product APIs
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
       --json                  Output in JSON format
@@ -810,8 +795,8 @@ List all apps in the current account
 
 ```
 USAGE
-  $ ably apps list [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host <value>]
-    [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v]
+  $ ably apps list [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>] [--host
+    <value>] [--json | --pretty-json] [--token <value>] [-v]
 
 FLAGS
   -v, --verbose               Output verbose logs
@@ -819,7 +804,6 @@ FLAGS
       --api-key=<value>       Overrides any configured API key used for the product APIs
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
       --json                  Output in JSON format
@@ -866,9 +850,8 @@ Alias for `ably logs app history`
 
 ```
 USAGE
-  $ ably apps logs history [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host <value>]
-    [--env <value>] [--host <value>] [--pretty-json | --json] [--token <value>] [-v] [--direction backwards|forwards]
-    [--limit <value>]
+  $ ably apps logs history [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>] [--host
+    <value>] [--pretty-json | --json] [--token <value>] [-v] [--direction backwards|forwards] [--limit <value>]
 
 FLAGS
   -v, --verbose               Output verbose logs
@@ -876,7 +859,6 @@ FLAGS
       --api-key=<value>       Overrides any configured API key used for the product APIs
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --direction=<option>    [default: backwards] Direction of message retrieval
                               <options: backwards|forwards>
       --env=<value>           Override the environment for all product API calls
@@ -909,8 +891,8 @@ Alias for ably logs app subscribe
 
 ```
 USAGE
-  $ ably apps logs subscribe [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host <value>]
-    [--env <value>] [--host <value>] [--pretty-json | --json] [--token <value>] [-v] [--rewind <value>]
+  $ ably apps logs subscribe [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>] [--host
+    <value>] [--pretty-json | --json] [--token <value>] [-v] [--rewind <value>]
 
 FLAGS
   -v, --verbose               Output verbose logs
@@ -918,7 +900,6 @@ FLAGS
       --api-key=<value>       Overrides any configured API key used for the product APIs
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
       --json                  Output results as JSON
@@ -944,8 +925,8 @@ Upload Apple Push Notification Service P12 certificate for an app
 ```
 USAGE
   $ ably apps set-apns-p12 ID --certificate <value> [--access-token <value>] [--api-key <value>] [--client-id <value>]
-    [--control-host <value>] [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v]
-    [--password <value>] [--use-for-sandbox]
+    [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--password <value>]
+    [--use-for-sandbox]
 
 ARGUMENTS
   ID  App ID to set the APNS certificate for
@@ -957,7 +938,6 @@ FLAGS
       --certificate=<value>   (required) Path to the P12 certificate file
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
       --json                  Output in JSON format
@@ -985,9 +965,9 @@ Get app stats with optional live updates
 
 ```
 USAGE
-  $ ably apps stats [ID] [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host
-    <value>] [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--debug] [--end <value>]
-    [--interval <value>] [--limit <value>] [--live] [--start <value>] [--unit minute|hour|day|month]
+  $ ably apps stats [ID] [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
+    [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--debug] [--end <value>] [--interval <value>]
+    [--limit <value>] [--live] [--start <value>] [--unit minute|hour|day|month]
 
 ARGUMENTS
   ID  App ID to get stats for (uses default app if not provided)
@@ -998,7 +978,6 @@ FLAGS
       --api-key=<value>       Overrides any configured API key used for the product APIs
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --debug                 Show debug information for live stats polling
       --end=<value>           End time in milliseconds since epoch
       --env=<value>           Override the environment for all product API calls
@@ -1048,8 +1027,8 @@ Switch to a different Ably app
 
 ```
 USAGE
-  $ ably apps switch [APPID] [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host
-    <value>] [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v]
+  $ ably apps switch [APPID] [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
+    [--host <value>] [--json | --pretty-json] [--token <value>] [-v]
 
 ARGUMENTS
   APPID  ID of the app to switch to
@@ -1060,7 +1039,6 @@ FLAGS
       --api-key=<value>       Overrides any configured API key used for the product APIs
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
       --json                  Output in JSON format
@@ -1084,9 +1062,8 @@ Update an app
 
 ```
 USAGE
-  $ ably apps update ID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host
-    <value>] [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--name <value>]
-    [--tls-only]
+  $ ably apps update ID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
+    [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--name <value>] [--tls-only]
 
 ARGUMENTS
   ID  App ID to update
@@ -1097,7 +1074,6 @@ FLAGS
       --api-key=<value>       Overrides any configured API key used for the product APIs
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
       --json                  Output in JSON format
@@ -1158,9 +1134,9 @@ Creates an Ably Token with capabilities
 
 ```
 USAGE
-  $ ably auth issue-ably-token [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host <value>]
-    [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--app <value>] [--capability
-    <value>] [--token-only] [--ttl <value>]
+  $ ably auth issue-ably-token [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>] [--host
+    <value>] [--json | --pretty-json] [--token <value>] [-v] [--app <value>] [--capability <value>] [--token-only]
+    [--ttl <value>]
 
 FLAGS
   -v, --verbose               Output verbose logs
@@ -1170,7 +1146,6 @@ FLAGS
       --capability=<value>    [default: {"*":["*"]}] Capabilities JSON string (e.g. {"channel":["publish","subscribe"]})
       --client-id=<value>     Client ID to associate with the token. Use "none" to explicitly issue a token with no
                               client ID, otherwise a default will be generated.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
       --json                  Output in JSON format
@@ -1210,9 +1185,9 @@ Creates an Ably JWT token with capabilities
 
 ```
 USAGE
-  $ ably auth issue-jwt-token [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host <value>]
-    [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--app <value>] [--capability
-    <value>] [--token-only] [--ttl <value>]
+  $ ably auth issue-jwt-token [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>] [--host
+    <value>] [--json | --pretty-json] [--token <value>] [-v] [--app <value>] [--capability <value>] [--token-only]
+    [--ttl <value>]
 
 FLAGS
   -v, --verbose               Output verbose logs
@@ -1222,7 +1197,6 @@ FLAGS
       --capability=<value>    [default: {"*":["*"]}] Capabilities JSON string (e.g. {"channel":["publish","subscribe"]})
       --client-id=<value>     Client ID to associate with the token. Use "none" to explicitly issue a token with no
                               client ID, otherwise a default will be generated.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
       --json                  Output in JSON format
@@ -1287,9 +1261,8 @@ Create a new API key for an app
 
 ```
 USAGE
-  $ ably auth keys create --name <value> [--access-token <value>] [--api-key <value>] [--client-id <value>]
-    [--control-host <value>] [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--app
-    <value>] [--capabilities <value>]
+  $ ably auth keys create --name <value> [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env
+    <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--app <value>] [--capabilities <value>]
 
 FLAGS
   -v, --verbose               Output verbose logs
@@ -1300,7 +1273,6 @@ FLAGS
                               '{"channel:*":["publish"]}'
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
       --json                  Output in JSON format
@@ -1339,8 +1311,8 @@ Show the current API key for the selected app
 
 ```
 USAGE
-  $ ably auth keys current [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host <value>]
-    [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--app <value>]
+  $ ably auth keys current [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>] [--host
+    <value>] [--json | --pretty-json] [--token <value>] [-v] [--app <value>]
 
 FLAGS
   -v, --verbose               Output verbose logs
@@ -1349,7 +1321,6 @@ FLAGS
       --app=<value>           App ID to check key for (uses current app if not specified)
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
       --json                  Output in JSON format
@@ -1377,9 +1348,8 @@ Get details for a specific key
 
 ```
 USAGE
-  $ ably auth keys get KEYNAMEORVALUE [--access-token <value>] [--api-key <value>] [--client-id <value>]
-    [--control-host <value>] [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--app
-    <value>]
+  $ ably auth keys get KEYNAMEORVALUE [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env
+    <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--app <value>]
 
 ARGUMENTS
   KEYNAMEORVALUE  Key name (APP_ID.KEY_ID) or full value of the key to get details for
@@ -1391,7 +1361,6 @@ FLAGS
       --app=<value>           App ID the key belongs to (uses current app if not specified)
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
       --json                  Output in JSON format
@@ -1419,8 +1388,8 @@ List all keys in the app
 
 ```
 USAGE
-  $ ably auth keys list [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host <value>]
-    [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--app <value>]
+  $ ably auth keys list [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>] [--host
+    <value>] [--json | --pretty-json] [--token <value>] [-v] [--app <value>]
 
 FLAGS
   -v, --verbose               Output verbose logs
@@ -1429,7 +1398,6 @@ FLAGS
       --app=<value>           App ID to list keys for (uses current app if not specified)
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
       --json                  Output in JSON format
@@ -1457,8 +1425,8 @@ Revoke an API key (permanently disables the key)
 
 ```
 USAGE
-  $ ably auth keys revoke KEYNAME [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host
-    <value>] [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--app <value>] [--force]
+  $ ably auth keys revoke KEYNAME [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
+    [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--app <value>] [--force]
 
 ARGUMENTS
   KEYNAME  Key name (APP_ID.KEY_ID) of the key to revoke
@@ -1470,7 +1438,6 @@ FLAGS
       --app=<value>           App ID the key belongs to (uses current app if not specified)
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>           Override the environment for all product API calls
       --force                 Skip confirmation prompt
       --host=<value>          Override the host endpoint for all product API calls
@@ -1501,9 +1468,8 @@ Switch to a different API key for the current app
 
 ```
 USAGE
-  $ ably auth keys switch [KEYNAMEORVALUE] [--access-token <value>] [--api-key <value>] [--client-id <value>]
-    [--control-host <value>] [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--app
-    <value>]
+  $ ably auth keys switch [KEYNAMEORVALUE] [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env
+    <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--app <value>]
 
 ARGUMENTS
   KEYNAMEORVALUE  Key name (APP_ID.KEY_ID) or full value of the key to switch to
@@ -1515,7 +1481,6 @@ FLAGS
       --app=<value>           App ID to switch keys for (uses current app if not specified)
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
       --json                  Output in JSON format
@@ -1541,9 +1506,9 @@ Update a key's properties
 
 ```
 USAGE
-  $ ably auth keys update KEYNAME [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host
-    <value>] [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--app <value>]
-    [--capabilities <value>] [--name <value>]
+  $ ably auth keys update KEYNAME [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
+    [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--app <value>] [--capabilities <value>] [--name
+    <value>]
 
 ARGUMENTS
   KEYNAME  Key name (APP_ID.KEY_ID) of the key to update
@@ -1556,7 +1521,6 @@ FLAGS
       --capabilities=<value>  New capabilities for the key (comma-separated list)
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
       --json                  Output in JSON format
@@ -1583,8 +1547,8 @@ Revokes the token provided
 
 ```
 USAGE
-  $ ably auth revoke-token TOKEN [--access-token <value>] [--api-key <value>] [-c <value>] [--control-host <value>]
-    [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--app <value>] [--debug]
+  $ ably auth revoke-token TOKEN [--access-token <value>] [--api-key <value>] [-c <value>] [--env <value>] [--host
+    <value>] [--json | --pretty-json] [--token <value>] [-v] [--app <value>] [--debug]
 
 ARGUMENTS
   TOKEN  Token to revoke
@@ -1595,7 +1559,6 @@ FLAGS
       --access-token=<value>  Overrides any configured access token used for the Control API
       --api-key=<value>       Overrides any configured API key used for the product APIs
       --app=<value>           App ID to use (uses current app if not specified)
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --debug                 Show debug information
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
@@ -1642,9 +1605,9 @@ Run a publisher benchmark test
 
 ```
 USAGE
-  $ ably bench publisher CHANNEL [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host
-    <value>] [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--message-size <value>]
-    [-m <value>] [-r <value>] [-t rest|realtime] [--wait-for-subscribers]
+  $ ably bench publisher CHANNEL [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
+    [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--message-size <value>] [-m <value>] [-r <value>]
+    [-t rest|realtime] [--wait-for-subscribers]
 
 ARGUMENTS
   CHANNEL  The channel name to publish to
@@ -1659,7 +1622,6 @@ FLAGS
       --api-key=<value>       Overrides any configured API key used for the product APIs
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
       --json                  Output in JSON format
@@ -1687,8 +1649,8 @@ Run a subscriber benchmark test
 
 ```
 USAGE
-  $ ably bench subscriber CHANNEL [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host
-    <value>] [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v]
+  $ ably bench subscriber CHANNEL [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
+    [--host <value>] [--json | --pretty-json] [--token <value>] [-v]
 
 ARGUMENTS
   CHANNEL  The channel name to subscribe to
@@ -1699,7 +1661,6 @@ FLAGS
       --api-key=<value>       Overrides any configured API key used for the product APIs
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
       --json                  Output in JSON format
@@ -1746,9 +1707,9 @@ Publish messages to multiple Ably channels with a single request
 
 ```
 USAGE
-  $ ably channels batch-publish [MESSAGE] [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host
-    <value>] [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--channels <value> |
-    --channels-json <value> | --spec <value>] [-e <value> | ] [-n <value> | ]
+  $ ably channels batch-publish [MESSAGE] [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
+    [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--channels <value> | --channels-json <value> |
+    --spec <value>] [-e <value> | ] [-n <value> | ]
 
 ARGUMENTS
   MESSAGE  The message to publish (JSON format or plain text, not needed if using --spec)
@@ -1763,7 +1724,6 @@ FLAGS
       --channels-json=<value>  JSON array of channel names to publish to
       --client-id=<value>      Overrides any default client ID when using API authentication. Use "none" to explicitly
                                set no client ID. Not applicable when using token authentication.
-      --control-host=<value>   Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>            Override the environment for all product API calls
       --host=<value>           Override the host endpoint for all product API calls
       --json                   Output in JSON format
@@ -1799,9 +1759,9 @@ Retrieve message history for a channel
 
 ```
 USAGE
-  $ ably channels history CHANNEL [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host
-    <value>] [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--cipher <value>]
-    [--direction backwards|forwards] [--end <value>] [--limit <value>] [--start <value>]
+  $ ably channels history CHANNEL [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
+    [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--cipher <value>] [--direction backwards|forwards]
+    [--end <value>] [--limit <value>] [--start <value>]
 
 ARGUMENTS
   CHANNEL  Channel name to retrieve history for
@@ -1813,7 +1773,6 @@ FLAGS
       --cipher=<value>        Decryption key for encrypted messages (AES-128)
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --direction=<option>    [default: backwards] Direction of message retrieval
                               <options: backwards|forwards>
       --end=<value>           End time for the history query (ISO 8601 format)
@@ -1850,8 +1809,8 @@ List active channels using the channel enumeration API
 
 ```
 USAGE
-  $ ably channels list [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host <value>]
-    [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--limit <value>] [-p <value>]
+  $ ably channels list [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>] [--host
+    <value>] [--json | --pretty-json] [--token <value>] [-v] [--limit <value>] [-p <value>]
 
 FLAGS
   -p, --prefix=<value>        Filter channels by prefix
@@ -1860,7 +1819,6 @@ FLAGS
       --api-key=<value>       Overrides any configured API key used for the product APIs
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
       --json                  Output in JSON format
@@ -1891,8 +1849,8 @@ Alias for ably logs channel-lifecycle subscribe
 
 ```
 USAGE
-  $ ably channels logs [TOPIC] [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host
-    <value>] [--env <value>] [--host <value>] [--pretty-json | --json] [--token <value>] [-v] [--rewind <value>]
+  $ ably channels logs [TOPIC] [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
+    [--host <value>] [--pretty-json | --json] [--token <value>] [-v] [--rewind <value>]
 
 ARGUMENTS
   TOPIC  [default: channel-lifecycle] Log topic to subscribe to (currently only channel-lifecycle is supported)
@@ -1903,7 +1861,6 @@ FLAGS
       --api-key=<value>       Overrides any configured API key used for the product APIs
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
       --json                  Output results as JSON
@@ -1947,8 +1904,8 @@ Get current occupancy metrics for a channel
 
 ```
 USAGE
-  $ ably channels occupancy get CHANNEL [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host
-    <value>] [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v]
+  $ ably channels occupancy get CHANNEL [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
+    [--host <value>] [--json | --pretty-json] [--token <value>] [-v]
 
 ARGUMENTS
   CHANNEL  Channel name to get occupancy for
@@ -1959,7 +1916,6 @@ FLAGS
       --api-key=<value>       Overrides any configured API key used for the product APIs
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
       --json                  Output in JSON format
@@ -1987,8 +1943,8 @@ Subscribe to real-time occupancy metrics for a channel
 
 ```
 USAGE
-  $ ably channels occupancy subscribe CHANNEL [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host
-    <value>] [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v]
+  $ ably channels occupancy subscribe CHANNEL [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
+    [--host <value>] [--json | --pretty-json] [--token <value>] [-v]
 
 ARGUMENTS
   CHANNEL  Channel name to subscribe to occupancy for
@@ -1999,7 +1955,6 @@ FLAGS
       --api-key=<value>       Overrides any configured API key used for the product APIs
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
       --json                  Output in JSON format
@@ -2044,9 +1999,8 @@ Enter presence on a channel and remain present until terminated
 
 ```
 USAGE
-  $ ably channels presence enter CHANNEL [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host
-    <value>] [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--data <value>]
-    [--show-others]
+  $ ably channels presence enter CHANNEL [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
+    [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--data <value>] [--show-others]
 
 ARGUMENTS
   CHANNEL  Channel name to enter presence on
@@ -2057,7 +2011,6 @@ FLAGS
       --api-key=<value>       Overrides any configured API key used for the product APIs
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --data=<value>          [default: {}] Presence data to publish (JSON string)
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
@@ -2085,8 +2038,8 @@ Subscribe to presence events on a channel
 
 ```
 USAGE
-  $ ably channels presence subscribe CHANNEL [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host
-    <value>] [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v]
+  $ ably channels presence subscribe CHANNEL [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
+    [--host <value>] [--json | --pretty-json] [--token <value>] [-v]
 
 ARGUMENTS
   CHANNEL  Channel name to subscribe to presence on
@@ -2097,7 +2050,6 @@ FLAGS
       --api-key=<value>       Overrides any configured API key used for the product APIs
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
       --json                  Output in JSON format
@@ -2123,9 +2075,9 @@ Publish a message to an Ably channel
 
 ```
 USAGE
-  $ ably channels publish CHANNEL MESSAGE [--access-token <value>] [--api-key <value>] [--client-id <value>]
-    [--control-host <value>] [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [-c
-    <value>] [-d <value>] [-e <value>] [-n <value>] [--transport rest|realtime]
+  $ ably channels publish CHANNEL MESSAGE [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env
+    <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [-c <value>] [-d <value>] [-e <value>] [-n
+    <value>] [--transport rest|realtime]
 
 ARGUMENTS
   CHANNEL  The channel name to publish to
@@ -2133,7 +2085,7 @@ ARGUMENTS
 
 FLAGS
   -c, --count=<value>         [default: 1] Number of messages to publish
-  -d, --delay=<value>         Delay between messages in milliseconds (min 10ms when count > 1)
+  -d, --delay=<value>         Delay between messages in milliseconds
   -e, --encoding=<value>      The encoding for the message
   -n, --name=<value>          The event name (if not specified in the message JSON)
   -v, --verbose               Output verbose logs
@@ -2141,7 +2093,6 @@ FLAGS
       --api-key=<value>       Overrides any configured API key used for the product APIs
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
       --json                  Output in JSON format
@@ -2185,10 +2136,9 @@ Subscribe to messages published on one or more Ably channels
 
 ```
 USAGE
-  $ ably channels subscribe CHANNELS... [--access-token <value>] [--api-key <value>] [--client-id <value>]
-    [--control-host <value>] [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v]
-    [--cipher-algorithm <value>] [--cipher-key <value>] [--cipher-key-length <value>] [--cipher-mode <value>] [--delta]
-    [--rewind <value>]
+  $ ably channels subscribe CHANNELS... [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env
+    <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--cipher-algorithm <value>] [--cipher-key
+    <value>] [--cipher-key-length <value>] [--cipher-mode <value>] [--delta] [--rewind <value>]
 
 ARGUMENTS
   CHANNELS...  Channel name(s) to subscribe to
@@ -2203,7 +2153,6 @@ FLAGS
       --cipher-mode=<value>        [default: cbc] Cipher mode to use
       --client-id=<value>          Overrides any default client ID when using API authentication. Use "none" to
                                    explicitly set no client ID. Not applicable when using token authentication.
-      --control-host=<value>       Override the host endpoint for the control API, which defaults to control.ably.net
       --delta                      Enable delta compression for messages
       --env=<value>                Override the environment for all product API calls
       --host=<value>               Override the host endpoint for all product API calls
@@ -2243,8 +2192,8 @@ Open the Ably config file in the default text editor
 
 ```
 USAGE
-  $ ably config [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host <value>]
-    [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [-e <value>]
+  $ ably config [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>] [--host
+    <value>] [--json | --pretty-json] [--token <value>] [-v] [-e <value>]
 
 FLAGS
   -e, --editor=<value>        Text editor to use (defaults to $EDITOR environment variable)
@@ -2253,7 +2202,6 @@ FLAGS
       --api-key=<value>       Overrides any configured API key used for the product APIs
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
       --json                  Output in JSON format
@@ -2296,8 +2244,8 @@ Alias for ably logs connection-lifecycle subscribe
 
 ```
 USAGE
-  $ ably connections logs [TOPIC] [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host
-    <value>] [--env <value>] [--host <value>] [--pretty-json | --json] [--token <value>] [-v] [--rewind <value>]
+  $ ably connections logs [TOPIC] [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
+    [--host <value>] [--pretty-json | --json] [--token <value>] [-v] [--rewind <value>]
 
 ARGUMENTS
   TOPIC  [default: connections-lifecycle] Log topic to subscribe to (currently only connections-lifecycle is supported)
@@ -2308,7 +2256,6 @@ FLAGS
       --api-key=<value>       Overrides any configured API key used for the product APIs
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
       --json                  Output results as JSON
@@ -2333,9 +2280,9 @@ View connection statistics for an Ably app
 
 ```
 USAGE
-  $ ably connections stats [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host <value>]
-    [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--debug] [--end <value>]
-    [--interval <value>] [--limit <value>] [--live] [--start <value>] [--unit minute|hour|day|month]
+  $ ably connections stats [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>] [--host
+    <value>] [--json | --pretty-json] [--token <value>] [-v] [--debug] [--end <value>] [--interval <value>] [--limit
+    <value>] [--live] [--start <value>] [--unit minute|hour|day|month]
 
 FLAGS
   -v, --verbose               Output verbose logs
@@ -2343,7 +2290,6 @@ FLAGS
       --api-key=<value>       Overrides any configured API key used for the product APIs
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --debug                 Show debug information for live stats polling
       --end=<value>           End time in milliseconds since epoch
       --env=<value>           Override the environment for all product API calls
@@ -2385,8 +2331,8 @@ Test connection to Ably
 
 ```
 USAGE
-  $ ably connections test [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host <value>]
-    [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--transport ws|xhr|all]
+  $ ably connections test [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>] [--host
+    <value>] [--json | --pretty-json] [--token <value>] [-v] [--transport ws|xhr|all]
 
 FLAGS
   -v, --verbose               Output verbose logs
@@ -2394,7 +2340,6 @@ FLAGS
       --api-key=<value>       Overrides any configured API key used for the product APIs
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
       --json                  Output in JSON format
@@ -2448,8 +2393,8 @@ Ask a question to the Ably AI agent for help
 
 ```
 USAGE
-  $ ably help ask QUESTION [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host
-    <value>] [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--continue] [-h]
+  $ ably help ask QUESTION [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
+    [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--continue] [-h]
 
 ARGUMENTS
   QUESTION  The question to ask the Ably AI agent
@@ -2462,7 +2407,6 @@ FLAGS
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
       --continue              Continue the previous conversation with the Ably AI agent
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
       --json                  Output in JSON format
@@ -2576,9 +2520,9 @@ Create an integration rule
 USAGE
   $ ably integrations create --rule-type http|amqp|kinesis|firehose|pulsar|kafka|azure|azure-functions|mqtt|cloudmqtt
     --source-type channel.message|channel.presence|channel.lifecycle|presence.message [--access-token <value>]
-    [--api-key <value>] [--client-id <value>] [--control-host <value>] [--env <value>] [--host <value>] [--json |
-    --pretty-json] [--token <value>] [-v] [--app <value>] [--channel-filter <value>] [--request-mode single|batch]
-    [--status enabled|disabled] [--target-url <value>]
+    [--api-key <value>] [--client-id <value>] [--env <value>] [--host <value>] [--json | --pretty-json] [--token
+    <value>] [-v] [--app <value>] [--channel-filter <value>] [--request-mode single|batch] [--status enabled|disabled]
+    [--target-url <value>]
 
 FLAGS
   -v, --verbose                 Output verbose logs
@@ -2588,7 +2532,6 @@ FLAGS
       --channel-filter=<value>  Channel filter pattern
       --client-id=<value>       Overrides any default client ID when using API authentication. Use "none" to explicitly
                                 set no client ID. Not applicable when using token authentication.
-      --control-host=<value>    Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>             Override the environment for all product API calls
       --host=<value>            Override the host endpoint for all product API calls
       --json                    Output in JSON format
@@ -2621,8 +2564,8 @@ Delete an integration rule
 
 ```
 USAGE
-  $ ably integrations delete RULEID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host
-    <value>] [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--app <value>] [-f]
+  $ ably integrations delete RULEID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
+    [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--app <value>] [-f]
 
 ARGUMENTS
   RULEID  The rule ID to delete
@@ -2635,7 +2578,6 @@ FLAGS
       --app=<value>           App ID or name to delete the integration rule from
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
       --json                  Output in JSON format
@@ -2661,8 +2603,8 @@ Get an integration rule by ID
 
 ```
 USAGE
-  $ ably integrations get RULEID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host
-    <value>] [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--app <value>]
+  $ ably integrations get RULEID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
+    [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--app <value>]
 
 ARGUMENTS
   RULEID  The rule ID to get
@@ -2674,7 +2616,6 @@ FLAGS
       --app=<value>           App ID or name to get the integration rule from
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
       --json                  Output in JSON format
@@ -2700,8 +2641,8 @@ List all integration rules
 
 ```
 USAGE
-  $ ably integrations list [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host <value>]
-    [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--app <value>]
+  $ ably integrations list [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>] [--host
+    <value>] [--json | --pretty-json] [--token <value>] [-v] [--app <value>]
 
 FLAGS
   -v, --verbose               Output verbose logs
@@ -2710,7 +2651,6 @@ FLAGS
       --app=<value>           App ID or name to list integration rules for
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
       --json                  Output in JSON format
@@ -2736,10 +2676,9 @@ Update an integration rule
 
 ```
 USAGE
-  $ ably integrations update RULEID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host
-    <value>] [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--app <value>]
-    [--channel-filter <value>] [--status enabled|disabled] [--target-url <value>] [--request-mode <value>] [--source
-    <value>] [--target <value>]
+  $ ably integrations update RULEID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
+    [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--app <value>] [--channel-filter <value>]
+    [--status enabled|disabled] [--target-url <value>] [--request-mode <value>] [--source <value>] [--target <value>]
 
 ARGUMENTS
   RULEID  The rule ID to update
@@ -2752,7 +2691,6 @@ FLAGS
       --channel-filter=<value>  Channel filter pattern
       --client-id=<value>       Overrides any default client ID when using API authentication. Use "none" to explicitly
                                 set no client ID. Not applicable when using token authentication.
-      --control-host=<value>    Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>             Override the environment for all product API calls
       --host=<value>            Override the host endpoint for all product API calls
       --json                    Output in JSON format
@@ -2784,9 +2722,8 @@ Log in to your Ably account (alias for "ably accounts login")
 
 ```
 USAGE
-  $ ably login [TOKEN] [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host
-    <value>] [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [-a <value>]
-    [--no-browser]
+  $ ably login [TOKEN] [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
+    [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [-a <value>] [--no-browser]
 
 ARGUMENTS
   TOKEN  Access token (if not provided, will prompt for it)
@@ -2798,7 +2735,6 @@ FLAGS
       --api-key=<value>       Overrides any configured API key used for the product APIs
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
       --json                  Output in JSON format
@@ -2871,9 +2807,8 @@ Retrieve application log history
 
 ```
 USAGE
-  $ ably logs app history [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host <value>]
-    [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--direction backwards|forwards]
-    [--limit <value>]
+  $ ably logs app history [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>] [--host
+    <value>] [--json | --pretty-json] [--token <value>] [-v] [--direction backwards|forwards] [--limit <value>]
 
 FLAGS
   -v, --verbose               Output verbose logs
@@ -2881,7 +2816,6 @@ FLAGS
       --api-key=<value>       Overrides any configured API key used for the product APIs
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --direction=<option>    [default: backwards] Direction of log retrieval
                               <options: backwards|forwards>
       --env=<value>           Override the environment for all product API calls
@@ -2914,8 +2848,8 @@ Stream logs from the app-wide meta channel [meta]log
 
 ```
 USAGE
-  $ ably logs app subscribe [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host <value>]
-    [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--rewind <value>]
+  $ ably logs app subscribe [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>] [--host
+    <value>] [--json | --pretty-json] [--token <value>] [-v] [--rewind <value>]
 
 FLAGS
   -v, --verbose               Output verbose logs
@@ -2923,7 +2857,6 @@ FLAGS
       --api-key=<value>       Overrides any configured API key used for the product APIs
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
       --json                  Output in JSON format
@@ -2952,8 +2885,8 @@ Stream logs from [meta]channel.lifecycle meta channel
 
 ```
 USAGE
-  $ ably logs channel-lifecycle [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host <value>]
-    [--env <value>] [--host <value>] [--pretty-json | --json] [--token <value>] [-v] [--rewind <value>]
+  $ ably logs channel-lifecycle [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>] [--host
+    <value>] [--pretty-json | --json] [--token <value>] [-v] [--rewind <value>]
 
 FLAGS
   -v, --verbose               Output verbose logs
@@ -2961,7 +2894,6 @@ FLAGS
       --api-key=<value>       Overrides any configured API key used for the product APIs
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
       --json                  Output results as JSON
@@ -2986,8 +2918,8 @@ Stream logs from [meta]channel.lifecycle meta channel
 
 ```
 USAGE
-  $ ably logs channel-lifecycle subscribe [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host <value>]
-    [--env <value>] [--host <value>] [--pretty-json | --json] [--token <value>] [-v] [--rewind <value>]
+  $ ably logs channel-lifecycle subscribe [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>] [--host
+    <value>] [--pretty-json | --json] [--token <value>] [-v] [--rewind <value>]
 
 FLAGS
   -v, --verbose               Output verbose logs
@@ -2995,7 +2927,6 @@ FLAGS
       --api-key=<value>       Overrides any configured API key used for the product APIs
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
       --json                  Output results as JSON
@@ -3039,9 +2970,8 @@ Retrieve connection lifecycle log history
 
 ```
 USAGE
-  $ ably logs connection-lifecycle history [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host <value>]
-    [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--direction backwards|forwards]
-    [--limit <value>]
+  $ ably logs connection-lifecycle history [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>] [--host
+    <value>] [--json | --pretty-json] [--token <value>] [-v] [--direction backwards|forwards] [--limit <value>]
 
 FLAGS
   -v, --verbose               Output verbose logs
@@ -3049,7 +2979,6 @@ FLAGS
       --api-key=<value>       Overrides any configured API key used for the product APIs
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --direction=<option>    [default: backwards] Direction of log retrieval
                               <options: backwards|forwards>
       --env=<value>           Override the environment for all product API calls
@@ -3082,8 +3011,8 @@ Stream logs from [meta]connection.lifecycle meta channel
 
 ```
 USAGE
-  $ ably logs connection-lifecycle subscribe [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host <value>]
-    [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--rewind <value>]
+  $ ably logs connection-lifecycle subscribe [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>] [--host
+    <value>] [--json | --pretty-json] [--token <value>] [-v] [--rewind <value>]
 
 FLAGS
   -v, --verbose               Output verbose logs
@@ -3091,7 +3020,6 @@ FLAGS
       --api-key=<value>       Overrides any configured API key used for the product APIs
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
       --json                  Output in JSON format
@@ -3120,8 +3048,8 @@ Stream logs from [meta]connection meta channel
 
 ```
 USAGE
-  $ ably logs connection subscribe [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host <value>]
-    [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--rewind <value>]
+  $ ably logs connection subscribe [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>] [--host
+    <value>] [--json | --pretty-json] [--token <value>] [-v] [--rewind <value>]
 
 FLAGS
   -v, --verbose               Output verbose logs
@@ -3129,7 +3057,6 @@ FLAGS
       --api-key=<value>       Overrides any configured API key used for the product APIs
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
       --json                  Output in JSON format
@@ -3179,9 +3106,8 @@ Retrieve push notification log history
 
 ```
 USAGE
-  $ ably logs push history [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host <value>]
-    [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--direction backwards|forwards]
-    [--limit <value>]
+  $ ably logs push history [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>] [--host
+    <value>] [--json | --pretty-json] [--token <value>] [-v] [--direction backwards|forwards] [--limit <value>]
 
 FLAGS
   -v, --verbose               Output verbose logs
@@ -3189,7 +3115,6 @@ FLAGS
       --api-key=<value>       Overrides any configured API key used for the product APIs
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --direction=<option>    [default: backwards] Direction of log retrieval
                               <options: backwards|forwards>
       --env=<value>           Override the environment for all product API calls
@@ -3222,8 +3147,8 @@ Stream logs from the push notifications meta channel [meta]log:push
 
 ```
 USAGE
-  $ ably logs push subscribe [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host <value>]
-    [--env <value>] [--host <value>] [--pretty-json | --json] [--token <value>] [-v] [--rewind <value>]
+  $ ably logs push subscribe [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>] [--host
+    <value>] [--pretty-json | --json] [--token <value>] [-v] [--rewind <value>]
 
 FLAGS
   -v, --verbose               Output verbose logs
@@ -3231,7 +3156,6 @@ FLAGS
       --api-key=<value>       Overrides any configured API key used for the product APIs
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
       --json                  Output results as JSON
@@ -3311,9 +3235,9 @@ Create a queue
 
 ```
 USAGE
-  $ ably queues create --name <value> [--access-token <value>] [--api-key <value>] [--client-id <value>]
-    [--control-host <value>] [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--app
-    <value>] [--max-length <value>] [--region <value>] [--ttl <value>]
+  $ ably queues create --name <value> [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env
+    <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--app <value>] [--max-length <value>]
+    [--region <value>] [--ttl <value>]
 
 FLAGS
   -v, --verbose               Output verbose logs
@@ -3322,7 +3246,6 @@ FLAGS
       --app=<value>           App ID or name to create the queue in
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
       --json                  Output in JSON format
@@ -3352,8 +3275,8 @@ Delete a queue
 
 ```
 USAGE
-  $ ably queues delete QUEUENAME [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host
-    <value>] [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--app <value>] [-f]
+  $ ably queues delete QUEUENAME [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
+    [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--app <value>] [-f]
 
 ARGUMENTS
   QUEUENAME  Name of the queue to delete
@@ -3366,7 +3289,6 @@ FLAGS
       --app=<value>           App ID or name to delete the queue from
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
       --json                  Output in JSON format
@@ -3392,8 +3314,8 @@ List all queues
 
 ```
 USAGE
-  $ ably queues list [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host <value>]
-    [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--app <value>]
+  $ ably queues list [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>] [--host
+    <value>] [--json | --pretty-json] [--token <value>] [-v] [--app <value>]
 
 FLAGS
   -v, --verbose               Output verbose logs
@@ -3402,7 +3324,6 @@ FLAGS
       --app=<value>           App ID or name to list queues for
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
       --json                  Output in JSON format
@@ -3455,8 +3376,8 @@ List active chat rooms
 
 ```
 USAGE
-  $ ably rooms list [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host <value>]
-    [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--limit <value>] [-p <value>]
+  $ ably rooms list [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>] [--host
+    <value>] [--json | --pretty-json] [--token <value>] [-v] [--limit <value>] [-p <value>]
 
 FLAGS
   -p, --prefix=<value>        Filter rooms by prefix
@@ -3465,7 +3386,6 @@ FLAGS
       --api-key=<value>       Overrides any configured API key used for the product APIs
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
       --json                  Output in JSON format
@@ -3517,9 +3437,8 @@ Get historical messages from an Ably Chat room
 
 ```
 USAGE
-  $ ably rooms messages get ROOMID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host
-    <value>] [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [-l <value>]
-    [--show-metadata]
+  $ ably rooms messages get ROOMID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
+    [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [-l <value>] [--show-metadata]
 
 ARGUMENTS
   ROOMID  The room ID to get messages from
@@ -3531,7 +3450,6 @@ FLAGS
       --api-key=<value>       Overrides any configured API key used for the product APIs
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
       --json                  Output in JSON format
@@ -3564,9 +3482,9 @@ Send a message to an Ably Chat room
 
 ```
 USAGE
-  $ ably rooms messages send ROOMID TEXT [--access-token <value>] [--api-key <value>] [--client-id <value>]
-    [--control-host <value>] [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [-c
-    <value>] [-d <value>] [--metadata <value>]
+  $ ably rooms messages send ROOMID TEXT [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env
+    <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [-c <value>] [-d <value>] [--metadata
+    <value>]
 
 ARGUMENTS
   ROOMID  The room ID to send the message to
@@ -3580,7 +3498,6 @@ FLAGS
       --api-key=<value>       Overrides any configured API key used for the product APIs
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
       --json                  Output in JSON format
@@ -3615,8 +3532,8 @@ Subscribe to messages in an Ably Chat room
 
 ```
 USAGE
-  $ ably rooms messages subscribe ROOMID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host
-    <value>] [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--show-metadata]
+  $ ably rooms messages subscribe ROOMID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
+    [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--show-metadata]
 
 ARGUMENTS
   ROOMID  The room ID to subscribe to messages from
@@ -3627,7 +3544,6 @@ FLAGS
       --api-key=<value>       Overrides any configured API key used for the product APIs
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
       --json                  Output in JSON format
@@ -3677,8 +3593,8 @@ Get current occupancy metrics for a room
 
 ```
 USAGE
-  $ ably rooms occupancy get ROOMID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host
-    <value>] [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v]
+  $ ably rooms occupancy get ROOMID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
+    [--host <value>] [--json | --pretty-json] [--token <value>] [-v]
 
 ARGUMENTS
   ROOMID  Room ID to get occupancy for
@@ -3689,7 +3605,6 @@ FLAGS
       --api-key=<value>       Overrides any configured API key used for the product APIs
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
       --json                  Output in JSON format
@@ -3717,8 +3632,8 @@ Subscribe to real-time occupancy metrics for a room
 
 ```
 USAGE
-  $ ably rooms occupancy subscribe ROOMID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host
-    <value>] [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v]
+  $ ably rooms occupancy subscribe ROOMID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
+    [--host <value>] [--json | --pretty-json] [--token <value>] [-v]
 
 ARGUMENTS
   ROOMID  Room ID to subscribe to occupancy for
@@ -3729,7 +3644,6 @@ FLAGS
       --api-key=<value>       Overrides any configured API key used for the product APIs
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
       --json                  Output in JSON format
@@ -3774,9 +3688,9 @@ Enter presence in a chat room and remain present until terminated
 
 ```
 USAGE
-  $ ably rooms presence enter ROOMID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host
-    <value>] [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--data <value>]
-    [--show-others] [--profile-data <value>]
+  $ ably rooms presence enter ROOMID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
+    [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--data <value>] [--show-others] [--profile-data
+    <value>]
 
 ARGUMENTS
   ROOMID  Room ID to enter presence on
@@ -3787,7 +3701,6 @@ FLAGS
       --api-key=<value>       Overrides any configured API key used for the product APIs
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --data=<value>          [default: {}] Presence data to publish (JSON string)
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
@@ -3820,8 +3733,8 @@ Subscribe to presence events in a chat room
 
 ```
 USAGE
-  $ ably rooms presence subscribe ROOMID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host
-    <value>] [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v]
+  $ ably rooms presence subscribe ROOMID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
+    [--host <value>] [--json | --pretty-json] [--token <value>] [-v]
 
 ARGUMENTS
   ROOMID  Room ID to subscribe to presence for
@@ -3832,7 +3745,6 @@ FLAGS
       --api-key=<value>       Overrides any configured API key used for the product APIs
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
       --json                  Output in JSON format
@@ -3877,9 +3789,8 @@ Send a reaction in a chat room
 
 ```
 USAGE
-  $ ably rooms reactions send ROOMID EMOJI [--access-token <value>] [--api-key <value>] [--client-id <value>]
-    [--control-host <value>] [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v]
-    [--metadata <value>]
+  $ ably rooms reactions send ROOMID EMOJI [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env
+    <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--metadata <value>]
 
 ARGUMENTS
   ROOMID  The room ID to send the reaction to
@@ -3891,7 +3802,6 @@ FLAGS
       --api-key=<value>       Overrides any configured API key used for the product APIs
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
       --json                  Output in JSON format
@@ -3920,8 +3830,8 @@ Subscribe to reactions in a chat room
 
 ```
 USAGE
-  $ ably rooms reactions subscribe ROOMID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host
-    <value>] [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v]
+  $ ably rooms reactions subscribe ROOMID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
+    [--host <value>] [--json | --pretty-json] [--token <value>] [-v]
 
 ARGUMENTS
   ROOMID  Room ID to subscribe to reactions in
@@ -3932,7 +3842,6 @@ FLAGS
       --api-key=<value>       Overrides any configured API key used for the product APIs
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
       --json                  Output in JSON format
@@ -3977,8 +3886,8 @@ Send a typing indicator in an Ably Chat room (use --autoType to keep typing auto
 
 ```
 USAGE
-  $ ably rooms typing keystroke ROOMID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host
-    <value>] [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--autoType]
+  $ ably rooms typing keystroke ROOMID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
+    [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--autoType]
 
 ARGUMENTS
   ROOMID  The room ID to start typing in
@@ -3990,7 +3899,6 @@ FLAGS
       --autoType              Automatically keep typing indicator active
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
       --json                  Output in JSON format
@@ -4020,8 +3928,8 @@ Subscribe to typing indicators in an Ably Chat room
 
 ```
 USAGE
-  $ ably rooms typing subscribe ROOMID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host
-    <value>] [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v]
+  $ ably rooms typing subscribe ROOMID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
+    [--host <value>] [--json | --pretty-json] [--token <value>] [-v]
 
 ARGUMENTS
   ROOMID  The room ID to subscribe to typing indicators from
@@ -4032,7 +3940,6 @@ FLAGS
       --api-key=<value>       Overrides any configured API key used for the product APIs
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
       --json                  Output in JSON format
@@ -4125,8 +4032,8 @@ Get all current cursors in a space
 
 ```
 USAGE
-  $ ably spaces cursors get-all SPACEID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host
-    <value>] [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v]
+  $ ably spaces cursors get-all SPACEID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
+    [--host <value>] [--json | --pretty-json] [--token <value>] [-v]
 
 ARGUMENTS
   SPACEID  Space ID to get cursors from
@@ -4137,7 +4044,6 @@ FLAGS
       --api-key=<value>       Overrides any configured API key used for the product APIs
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
       --json                  Output in JSON format
@@ -4164,7 +4070,7 @@ Set a cursor with position data in a space
 ```
 USAGE
   $ ably spaces cursors set SPACEID --data <value> [--access-token <value>] [--api-key <value>] [--client-id <value>]
-    [--control-host <value>] [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v]
+    [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v]
 
 ARGUMENTS
   SPACEID  The space ID to set cursor in
@@ -4175,7 +4081,6 @@ FLAGS
       --api-key=<value>       Overrides any configured API key used for the product APIs
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --data=<value>          (required) The cursor data to set (as JSON string)
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
@@ -4206,8 +4111,8 @@ Subscribe to cursor movements in a space
 
 ```
 USAGE
-  $ ably spaces cursors subscribe SPACEID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host
-    <value>] [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v]
+  $ ably spaces cursors subscribe SPACEID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
+    [--host <value>] [--json | --pretty-json] [--token <value>] [-v]
 
 ARGUMENTS
   SPACEID  Space ID to subscribe to cursors for
@@ -4218,7 +4123,6 @@ FLAGS
       --api-key=<value>       Overrides any configured API key used for the product APIs
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
       --json                  Output in JSON format
@@ -4244,8 +4148,8 @@ List active spaces
 
 ```
 USAGE
-  $ ably spaces list [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host <value>]
-    [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--limit <value>] [-p <value>]
+  $ ably spaces list [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>] [--host
+    <value>] [--json | --pretty-json] [--token <value>] [-v] [--limit <value>] [-p <value>]
 
 FLAGS
   -p, --prefix=<value>        Filter spaces by prefix
@@ -4254,7 +4158,6 @@ FLAGS
       --api-key=<value>       Overrides any configured API key used for the product APIs
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
       --json                  Output in JSON format
@@ -4285,8 +4188,8 @@ Spaces Locations API commands (Ably Spaces client-to-client location sharing)
 
 ```
 USAGE
-  $ ably spaces locations [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host <value>]
-    [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v]
+  $ ably spaces locations [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>] [--host
+    <value>] [--json | --pretty-json] [--token <value>] [-v]
 
 FLAGS
   -v, --verbose               Output verbose logs
@@ -4294,7 +4197,6 @@ FLAGS
       --api-key=<value>       Overrides any configured API key used for the product APIs
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
       --json                  Output in JSON format
@@ -4313,8 +4215,8 @@ Get all current locations in a space
 
 ```
 USAGE
-  $ ably spaces locations get-all SPACEID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host
-    <value>] [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [-f text|json]
+  $ ably spaces locations get-all SPACEID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
+    [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [-f text|json]
 
 ARGUMENTS
   SPACEID  Space ID to get locations from
@@ -4327,7 +4229,6 @@ FLAGS
       --api-key=<value>       Overrides any configured API key used for the product APIs
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
       --json                  Output in JSON format
@@ -4354,7 +4255,7 @@ Set your location in a space
 ```
 USAGE
   $ ably spaces locations set SPACEID --location <value> [--access-token <value>] [--api-key <value>] [--client-id
-    <value>] [--control-host <value>] [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v]
+    <value>] [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v]
 
 ARGUMENTS
   SPACEID  Space ID to set location in
@@ -4365,7 +4266,6 @@ FLAGS
       --api-key=<value>       Overrides any configured API key used for the product APIs
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
       --json                  Output in JSON format
@@ -4390,8 +4290,8 @@ Subscribe to location changes in a space
 
 ```
 USAGE
-  $ ably spaces locations subscribe SPACEID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host
-    <value>] [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v]
+  $ ably spaces locations subscribe SPACEID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
+    [--host <value>] [--json | --pretty-json] [--token <value>] [-v]
 
 ARGUMENTS
   SPACEID  Space ID to subscribe to locations for
@@ -4402,7 +4302,6 @@ FLAGS
       --api-key=<value>       Overrides any configured API key used for the product APIs
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
       --json                  Output in JSON format
@@ -4451,9 +4350,8 @@ Acquire a lock in a space
 
 ```
 USAGE
-  $ ably spaces locks acquire SPACEID LOCKID [--access-token <value>] [--api-key <value>] [--client-id <value>]
-    [--control-host <value>] [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--data
-    <value>]
+  $ ably spaces locks acquire SPACEID LOCKID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env
+    <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--data <value>]
 
 ARGUMENTS
   SPACEID  Space ID to acquire lock in
@@ -4465,7 +4363,6 @@ FLAGS
       --api-key=<value>       Overrides any configured API key used for the product APIs
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --data=<value>          Optional data to associate with the lock (JSON format)
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
@@ -4490,8 +4387,8 @@ Get a lock in a space
 
 ```
 USAGE
-  $ ably spaces locks get SPACEID LOCKID [--access-token <value>] [--api-key <value>] [--client-id <value>]
-    [--control-host <value>] [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v]
+  $ ably spaces locks get SPACEID LOCKID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env
+    <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v]
 
 ARGUMENTS
   SPACEID  Space ID to get lock from
@@ -4503,7 +4400,6 @@ FLAGS
       --api-key=<value>       Overrides any configured API key used for the product APIs
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
       --json                  Output in JSON format
@@ -4529,8 +4425,8 @@ Get all current locks in a space
 
 ```
 USAGE
-  $ ably spaces locks get-all SPACEID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host
-    <value>] [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v]
+  $ ably spaces locks get-all SPACEID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
+    [--host <value>] [--json | --pretty-json] [--token <value>] [-v]
 
 ARGUMENTS
   SPACEID  Space ID to get locks from
@@ -4541,7 +4437,6 @@ FLAGS
       --api-key=<value>       Overrides any configured API key used for the product APIs
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
       --json                  Output in JSON format
@@ -4567,8 +4462,8 @@ Subscribe to lock changes in a space
 
 ```
 USAGE
-  $ ably spaces locks subscribe SPACEID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host
-    <value>] [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v]
+  $ ably spaces locks subscribe SPACEID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
+    [--host <value>] [--json | --pretty-json] [--token <value>] [-v]
 
 ARGUMENTS
   SPACEID  Space ID to subscribe for locks from
@@ -4579,7 +4474,6 @@ FLAGS
       --api-key=<value>       Overrides any configured API key used for the product APIs
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
       --json                  Output in JSON format
@@ -4624,8 +4518,8 @@ Enter a space and remain present until terminated
 
 ```
 USAGE
-  $ ably spaces members enter SPACEID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host
-    <value>] [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--profile <value>]
+  $ ably spaces members enter SPACEID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
+    [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--profile <value>]
 
 ARGUMENTS
   SPACEID  Space ID to enter
@@ -4636,7 +4530,6 @@ FLAGS
       --api-key=<value>       Overrides any configured API key used for the product APIs
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
       --json                  Output in JSON format
@@ -4661,8 +4554,8 @@ Subscribe to member presence events in a space
 
 ```
 USAGE
-  $ ably spaces members subscribe SPACEID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--control-host
-    <value>] [--env <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v]
+  $ ably spaces members subscribe SPACEID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
+    [--host <value>] [--json | --pretty-json] [--token <value>] [-v]
 
 ARGUMENTS
   SPACEID  Space ID to subscribe to members for
@@ -4673,7 +4566,6 @@ FLAGS
       --api-key=<value>       Overrides any configured API key used for the product APIs
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
-      --control-host=<value>  Override the host endpoint for the control API, which defaults to control.ably.net
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
       --json                  Output in JSON format

--- a/src/base-command.ts
+++ b/src/base-command.ts
@@ -54,6 +54,7 @@ export abstract class AblyBaseCommand extends Command {
     "control-host": Flags.string({
       description:
         "Override the host endpoint for the control API, which defaults to control.ably.net",
+      hidden: process.env.ABLY_SHOW_DEV_FLAGS !== 'true',
     }),
     env: Flags.string({
       description: "Override the environment for all product API calls",
@@ -63,12 +64,15 @@ export abstract class AblyBaseCommand extends Command {
     }),
     port: Flags.integer({
       description: "Override the port for product API calls",
+      hidden: process.env.ABLY_SHOW_DEV_FLAGS !== 'true',
     }),
     tlsPort: Flags.integer({
       description: "Override the TLS port for product API calls",
+      hidden: process.env.ABLY_SHOW_DEV_FLAGS !== 'true',
     }),
     tls: Flags.string({
       description: "Use TLS for product API calls (default is true)",
+      hidden: process.env.ABLY_SHOW_DEV_FLAGS !== 'true',
     }),
     json: Flags.boolean({
       description: "Output in JSON format",

--- a/src/base-command.ts
+++ b/src/base-command.ts
@@ -61,6 +61,15 @@ export abstract class AblyBaseCommand extends Command {
     host: Flags.string({
       description: "Override the host endpoint for all product API calls",
     }),
+    port: Flags.integer({
+      description: "Override the port for product API calls",
+    }),
+    tlsPort: Flags.integer({
+      description: "Override the TLS port for product API calls",
+    }),
+    tls: Flags.string({
+      description: "Use TLS for product API calls (default is true)",
+    }),
     json: Flags.boolean({
       description: "Output in JSON format",
       exclusive: ["pretty-json"], // Cannot use with pretty-json
@@ -630,6 +639,18 @@ export abstract class AblyBaseCommand extends Command {
 
     if (flags.env) {
       options.environment = flags.env;
+    }
+
+    if (flags.port) {
+      options.port = flags.port;
+    }
+
+    if (flags.tlsPort) {
+      options.tlsPort = flags.tlsPort;
+    }
+
+    if (flags.tls) {
+      options.tls = flags.tls === "true";
     }
 
     // Always add a log handler to control SDK output formatting and destination

--- a/src/commands/channels/publish.ts
+++ b/src/commands/channels/publish.ts
@@ -43,7 +43,7 @@ export default class ChannelsPublish extends AblyBaseCommand {
       char: "d",
       default: 0,
       description:
-        "Delay between messages in milliseconds (min 10ms when count > 1)",
+        "Delay between messages in milliseconds",
     }),
     encoding: Flags.string({
       char: "e",

--- a/src/commands/channels/publish.ts
+++ b/src/commands/channels/publish.ts
@@ -283,7 +283,7 @@ export default class ChannelsPublish extends AblyBaseCommand {
       () => errorCount,
     );
 
-      const publishes = [];
+    const publishes = [];
 
     for (let i = 0; i < count; i++) {
       if (delay > 0 && i > 0) {

--- a/src/help.ts
+++ b/src/help.ts
@@ -38,7 +38,21 @@ export default class CustomHelp extends Help {
 
   // Override the display method to clean up trailing whitespace and exit cleanly
   async showHelp(argv: string[]): Promise<void> {
-    const command = this.config.findCommand(argv[0]);
+    // Get the help subject which is the last argument that is not a flag
+    if (argv.length === 0) {
+      return super.showHelp(argv); // No command provided, show general help
+    }
+
+    let subject: string = "";
+    for (let arg of argv) {
+      if (arg.startsWith("-")) {
+        // If it's a flag, skip it
+        continue;
+      }
+      subject = arg; // The last non-flag argument is the subject
+    }
+
+    const command = this.config.findCommand(subject);
     if (!command) return super.showHelp(argv);
 
     // Get formatted output

--- a/src/types/cli.ts
+++ b/src/types/cli.ts
@@ -11,6 +11,9 @@ export interface BaseFlags {
   "control-host"?: string;
   env?: string;
   host?: string;
+  port?: number;
+  tls?: string;
+  tlsPort?: number;
   json?: boolean;
   "pretty-json"?: boolean;
   token?: string;


### PR DESCRIPTION
Update publishing messages so that we do not await the publisher. This means the delay between sending multiple messages works properly.

Also:
- Fix the help command only showing "channels" help when asking for "channels subscribe" help, etc.
- Add flags for tls, port, and tlsPort to make it easier to use the cli against a local instance of realtime in dev.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added new CLI flags to allow users to specify custom port, TLS port, and TLS usage for API calls.
- **Improvements**
  - Enhanced help command to more accurately determine and display help topics based on user input.
  - Improved message publishing to allow user-defined delays below 10ms when sending multiple messages.
- **Other Changes**
  - Updated CLI flag types to support the new network configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->