### PR TITLE
dev: release process automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+name: npm release
+
+on:
+  push:
+    tags:
+        - "v*"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'write'
+      id-token: 'write'
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v3
+        with:
+            version: 10 # Use pnpm version 10
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22.x" # Use Node.js 22.x
+          cache: "pnpm"
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Install dependencies and publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm run build
+          pnpm publish --provenance --access public

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,22 +3,22 @@ name: npm release
 on:
   push:
     tags:
-        - "v*"
+      - "v*"
 
 jobs:
   release:
     runs-on: ubuntu-latest
     permissions:
-      contents: 'write'
-      id-token: 'write'
+      contents: "write"
+      id-token: "write"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
       - name: Set up pnpm
         uses: pnpm/action-setup@v3
         with:
-            version: 10 # Use pnpm version 10
+          version: 10 # Use pnpm version 10
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,3 +49,14 @@ For Ably engineers working on terminal server features:
 4. Run CLI tests: `pnpm test:e2e`
 
 This allows testing CLI changes against local server modifications before deployment.
+
+## Release Workflow
+
+1. Make sure all checks are passing on main
+2. Create a new release branch, in the format `release/<version>` where the version is the SemVer version of the release. In that branch:
+    - Update the `package.json` version to the new version.
+    - Update the `CHANGELOG.md` with any user-affecting changes since the last release.
+    - Update `README.md` if it references the old version.
+3. Once the release branch is approved, merge it into main.
+4. Create a new tag, which will run the release workflow.
+5. Verify that the new release has been published to NPM.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -111,7 +111,7 @@
 - [x] Ensure all changes meet the linting requirements, `pnpm exec eslint [file]`
 - [ ] Look for areas of unnecessary duplication as help.ts checking "commandId.includes('accounts login')" when the list of unsupported web CLI commands exists already in BaseCommand WEB_CLI_RESTRICTED_COMMANDS
 - [x] [feat/terminal-server-improvements] Add inactivity timeout to the terminal server
-- [ ] Release new versions automatically from Github for NPM
+- [x] Release new versions automatically from Github for NPM
 - [ ] Now that we have .editorconfig, ensure all files adhere in one commit
 - [ ] We are using a PNPM workspace, but I am not convinced that's a good thing. We should consider not letting the examples or React component dependencies affect the core CLI packaging.
 - [ ] Publish Docker image to Github registry and use a path such as `ghcr.io/ably/ably-cli-sandbox` for the published artefact. Building and publishing should use the locally built Ably CLI binary as opposed to the latest version so that local changes can be tested locally.


### PR DESCRIPTION
This change adds an automated workflow (copied from chat-js) to release to npm on tag creation.

To run it, we'll need to create an access token on NPM.