### PR TITLE
feat: Send ably-cli agent in data and control plane requests

### DIFF
--- a/src/base-command.ts
+++ b/src/base-command.ts
@@ -8,6 +8,7 @@ import { ConfigManager } from "./services/config-manager.js";
 import { ControlApi } from "./services/control-api.js";
 import { InteractiveHelper } from "./services/interactive-helper.js";
 import { BaseFlags, CommandConfig, ErrorDetails } from "./types/cli.js";
+import { getCliVersion } from "./utils/version.js";
 
 // Export BaseFlags for potential use in other modules like MCP
 
@@ -732,6 +733,9 @@ export abstract class AblyBaseCommand extends Command {
 
     // Set logLevel to highest ONLY when using custom handler to capture everything needed by it
     options.logLevel = 4;
+
+    // Add agent header to identify requests from the CLI
+    (options as any).agents = { 'ably-cli': getCliVersion() };
 
     return options;
   }

--- a/src/commands/help/status.ts
+++ b/src/commands/help/status.ts
@@ -3,6 +3,7 @@ import chalk from "chalk";
 import fetch from "node-fetch";
 import open from "open";
 import ora from "ora";
+import { getCliVersion } from "../../utils/version.js";
 
 interface StatusResponse {
   status: boolean;
@@ -28,7 +29,11 @@ export default class StatusCommand extends Command {
     const spinner = ora("Checking Ably service status...").start();
 
     try {
-      const response = await fetch("https://ably.com/status/up.json");
+      const response = await fetch("https://ably.com/status/up.json", {
+        headers: {
+          "Ably-Agent": `ably-cli/${getCliVersion()}`
+        }
+      });
       const data = (await response.json()) as StatusResponse;
       spinner.stop();
 

--- a/src/mcp/mcp-server.ts
+++ b/src/mcp/mcp-server.ts
@@ -14,6 +14,7 @@ import ChannelsPublish from "../commands/channels/publish.js";
 import ChannelsSubscribe from "../commands/channels/subscribe.js";
 import { ConfigManager } from "../services/config-manager.js";
 import Ably, { Connection } from "ably";
+import { getCliVersion } from "../utils/version.js";
 // Comment to explain why we're not using these directly but still need to import
 // We need these types from control-api but using them through a different interface
 import {
@@ -548,9 +549,10 @@ export class AblyMcpServer {
         );
       }
 
-      const clientOptions = {
+      const clientOptions: any = {
         clientId: process.env.ABLY_CLIENT_ID,
         key: apiKey,
+        agents: { 'ably-cli': getCliVersion() },
       };
 
       // Create Ably REST client (not Realtime, to avoid connections)

--- a/src/services/control-api.ts
+++ b/src/services/control-api.ts
@@ -1,4 +1,5 @@
 import fetch, { type RequestInit } from "node-fetch";
+import { getCliVersion } from "../utils/version.js";
 
 export interface ControlApiOptions {
   accessToken: string;
@@ -515,6 +516,7 @@ export class ControlApi {
         Accept: "application/json",
         Authorization: `Bearer ${this.accessToken}`,
         "Content-Type": "application/json",
+        "Ably-Agent": `ably-cli/${getCliVersion()}`,
       },
       method,
     };

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -2,6 +2,17 @@
  * Common utilities for version-related functionality
  */
 import colorJson from 'color-json';
+// Import package.json directly - TypeScript will resolve this at compile time
+// eslint-disable-next-line n/no-unpublished-import
+import packageJson from '../../package.json' with { type: 'json' };
+
+/**
+ * Get the CLI version from package.json
+ * @returns The CLI version string
+ */
+export function getCliVersion(): string {
+  return packageJson.version;
+}
 
 /**
  * Get standardized version information object

--- a/test/integration/core/agent-header.test.ts
+++ b/test/integration/core/agent-header.test.ts
@@ -1,0 +1,57 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { Config } from '@oclif/core';
+import { AblyBaseCommand } from '../../../src/base-command.js';
+import { getCliVersion } from '../../../src/utils/version.js';
+
+// Create a test command that extends AblyBaseCommand
+class TestCommand extends AblyBaseCommand {
+  async run(): Promise<void> {
+    // No-op for testing
+  }
+
+  // Expose protected methods for testing
+  public testGetClientOptions(flags: any): any {
+    return this.getClientOptions(flags);
+  }
+}
+
+describe('Agent Header Integration Tests', function() {
+  let sandbox: sinon.SinonSandbox;
+  
+  beforeEach(function() {
+    sandbox = sinon.createSandbox();
+  });
+
+  afterEach(function() {
+    sandbox.restore();
+  });
+
+  describe('Ably SDK Agent Header', function() {
+    it('should include agent header in client options', function() {
+      const mockConfig = { runHook: sandbox.stub() } as unknown as Config;
+      const command = new TestCommand([], mockConfig);
+      
+      const flags = {
+        'api-key': 'test-key:secret',
+      };
+      
+      const clientOptions = command.testGetClientOptions(flags);
+      
+      expect(clientOptions.agents).to.exist;
+      expect(clientOptions.agents).to.deep.equal({
+        'ably-cli': getCliVersion()
+      });
+    });
+  });
+
+  describe('Version Format', function() {
+    it('should format agent header correctly', function() {
+      const version = getCliVersion();
+      const expectedAgentHeader = `ably-cli/${version}`;
+      
+      // Should match the format: ably-cli/x.y.z
+      expect(expectedAgentHeader).to.match(/^ably-cli\/\d+\.\d+\.\d+$/);
+    });
+  });
+});

--- a/test/unit/utils/version.test.ts
+++ b/test/unit/utils/version.test.ts
@@ -1,0 +1,33 @@
+import { expect } from 'chai';
+import { getCliVersion } from '../../../src/utils/version.js';
+import packageJson from '../../../package.json' with { type: 'json' };
+
+describe('version utility', function() {
+  describe('getCliVersion', function() {
+    it('should return a valid semantic version string', function() {
+      const version = getCliVersion();
+      expect(version).to.be.a('string');
+      // Should match semantic versioning format (e.g., 1.2.3, 1.2.3-beta.1, etc.)
+      expect(version).to.match(/^\d+\.\d+\.\d+(-[\w.]+)?$/);
+    });
+
+    it('should return the same version from package.json', function() {
+      const version = getCliVersion();
+      expect(version).to.equal(packageJson.version);
+    });
+
+    it('should return consistent version on multiple calls', function() {
+      const version1 = getCliVersion();
+      const version2 = getCliVersion();
+      const version3 = getCliVersion();
+      
+      expect(version1).to.equal(version2);
+      expect(version2).to.equal(version3);
+    });
+
+    it('should return a non-empty version', function() {
+      const version = getCliVersion();
+      expect(version).to.have.length.greaterThan(0);
+    });
+  });
+});


### PR DESCRIPTION
Enables usage tracking / adoption of the CLI (with no personally identifiable info).