### PR TITLE
refactor: rename ABLY_RESTRICTED_MODE to ABLY_ANONYMOUS_USER_MODE

### DIFF
--- a/src/base-command.ts
+++ b/src/base-command.ts
@@ -160,8 +160,8 @@ export abstract class AblyBaseCommand extends Command {
   }
 
   protected isAnonymousWebMode(): boolean {
-    // In web CLI mode, the server sets ABLY_RESTRICTED_MODE when no access token is available
-    return this.isWebCliMode && process.env.ABLY_RESTRICTED_MODE === 'true';
+    // In web CLI mode, the server sets ABLY_ANONYMOUS_USER_MODE when no access token is available
+    return this.isWebCliMode && process.env.ABLY_ANONYMOUS_USER_MODE === 'true';
   }
 
   /**

--- a/src/help.ts
+++ b/src/help.ts
@@ -211,7 +211,7 @@ export default class CustomHelp extends Help {
     ];
     
     // Only show channels:logs for authenticated users
-    const isAnonymousMode = process.env.ABLY_RESTRICTED_MODE === "true";
+    const isAnonymousMode = process.env.ABLY_ANONYMOUS_USER_MODE === "true";
     if (!isAnonymousMode) {
       webCliCommands.push(`  ${chalk.cyan("View live channel events:")} ably channels logs`);
     }

--- a/test/unit/base/base-command.test.ts
+++ b/test/unit/base/base-command.test.ts
@@ -134,7 +134,7 @@ describe("AblyBaseCommand", function() {
 
     it("should throw error when in authenticated web CLI mode and command is restricted", function() {
       command.testIsWebCliMode = true;
-      process.env.ABLY_RESTRICTED_MODE = "false";
+      process.env.ABLY_ANONYMOUS_USER_MODE = "false";
       // Mock command ID to be a restricted command
       Object.defineProperty(command, "id", { value: "accounts:login", configurable: true });
 
@@ -143,7 +143,7 @@ describe("AblyBaseCommand", function() {
 
     it("should not throw error when in authenticated web CLI mode but command is allowed", function() {
       command.testIsWebCliMode = true;
-      process.env.ABLY_RESTRICTED_MODE = "false";
+      process.env.ABLY_ANONYMOUS_USER_MODE = "false";
       // Mock command ID to be an allowed command
       Object.defineProperty(command, "id", { value: "channels:publish", configurable: true });
 
@@ -152,7 +152,7 @@ describe("AblyBaseCommand", function() {
 
     it("should throw error for anonymous-restricted commands in anonymous mode", function() {
       command.testIsWebCliMode = true;
-      process.env.ABLY_RESTRICTED_MODE = "true";
+      process.env.ABLY_ANONYMOUS_USER_MODE = "true";
       
       // Test various anonymous-restricted commands
       const testCases = [
@@ -175,7 +175,7 @@ describe("AblyBaseCommand", function() {
 
     it("should allow non-restricted commands in anonymous mode", function() {
       command.testIsWebCliMode = true;
-      process.env.ABLY_RESTRICTED_MODE = "true";
+      process.env.ABLY_ANONYMOUS_USER_MODE = "true";
       
       // Test commands that should be allowed
       const allowedCommands = ["channels:publish", "rooms:get", "spaces:get", "help"];
@@ -188,7 +188,7 @@ describe("AblyBaseCommand", function() {
 
     it("should throw error for base restricted commands in anonymous mode", function() {
       command.testIsWebCliMode = true;
-      process.env.ABLY_RESTRICTED_MODE = "true";
+      process.env.ABLY_ANONYMOUS_USER_MODE = "true";
       
       // Test base restricted commands with their specific error messages
       // Note: accounts:login is caught by the anonymous restrictions first since it starts with "accounts"
@@ -213,7 +213,7 @@ describe("AblyBaseCommand", function() {
 
     it("should allow auth:keys commands when authenticated in web CLI mode", function() {
       command.testIsWebCliMode = true;
-      process.env.ABLY_RESTRICTED_MODE = "false"; // Authenticated
+      process.env.ABLY_ANONYMOUS_USER_MODE = "false"; // Authenticated
       
       // These should be allowed when authenticated
       const allowedCommands = ["auth:keys:list", "auth:keys:create", "auth:keys:revoke"];
@@ -302,11 +302,11 @@ describe("AblyBaseCommand", function() {
 
   describe("Anonymous Web Mode", function() {
     let originalWebCliMode: string | undefined;
-    let originalRestrictedMode: string | undefined;
+    let originalAnonymousMode: string | undefined;
 
     beforeEach(function() {
       originalWebCliMode = process.env.ABLY_WEB_CLI_MODE;
-      originalRestrictedMode = process.env.ABLY_RESTRICTED_MODE;
+      originalAnonymousMode = process.env.ABLY_ANONYMOUS_USER_MODE;
     });
 
     afterEach(function() {
@@ -316,34 +316,34 @@ describe("AblyBaseCommand", function() {
         process.env.ABLY_WEB_CLI_MODE = originalWebCliMode;
       }
       
-      if (originalRestrictedMode === undefined) {
-        delete process.env.ABLY_RESTRICTED_MODE;
+      if (originalAnonymousMode === undefined) {
+        delete process.env.ABLY_ANONYMOUS_USER_MODE;
       } else {
-        process.env.ABLY_RESTRICTED_MODE = originalRestrictedMode;
+        process.env.ABLY_ANONYMOUS_USER_MODE = originalAnonymousMode;
       }
     });
 
-    it("should detect anonymous mode when web CLI mode and ABLY_RESTRICTED_MODE is true", function() {
+    it("should detect anonymous mode when web CLI mode and ABLY_ANONYMOUS_USER_MODE is true", function() {
       process.env.ABLY_WEB_CLI_MODE = "true";
-      process.env.ABLY_RESTRICTED_MODE = "true";
+      process.env.ABLY_ANONYMOUS_USER_MODE = "true";
 
       const cmd = new TestCommand([], {} as Config);
       cmd.testConfigManager = configManagerStub;
       expect(cmd.testIsAnonymousWebMode()).to.be.true;
     });
 
-    it("should not detect anonymous mode when ABLY_RESTRICTED_MODE is not set", function() {
+    it("should not detect anonymous mode when ABLY_ANONYMOUS_USER_MODE is not set", function() {
       process.env.ABLY_WEB_CLI_MODE = "true";
-      delete process.env.ABLY_RESTRICTED_MODE;
+      delete process.env.ABLY_ANONYMOUS_USER_MODE;
 
       const cmd = new TestCommand([], {} as Config);
       cmd.testConfigManager = configManagerStub;
       expect(cmd.testIsAnonymousWebMode()).to.be.false;
     });
 
-    it("should not detect anonymous mode when ABLY_RESTRICTED_MODE is false", function() {
+    it("should not detect anonymous mode when ABLY_ANONYMOUS_USER_MODE is false", function() {
       process.env.ABLY_WEB_CLI_MODE = "true";
-      process.env.ABLY_RESTRICTED_MODE = "false";
+      process.env.ABLY_ANONYMOUS_USER_MODE = "false";
 
       const cmd = new TestCommand([], {} as Config);
       cmd.testConfigManager = configManagerStub;
@@ -352,7 +352,7 @@ describe("AblyBaseCommand", function() {
 
     it("should not detect anonymous mode when not in web CLI mode", function() {
       delete process.env.ABLY_WEB_CLI_MODE;
-      process.env.ABLY_RESTRICTED_MODE = "true";
+      process.env.ABLY_ANONYMOUS_USER_MODE = "true";
 
       const cmd = new TestCommand([], {} as Config);
       cmd.testConfigManager = configManagerStub;

--- a/test/unit/help/web-cli-help.test.ts
+++ b/test/unit/help/web-cli-help.test.ts
@@ -209,7 +209,7 @@ describe("CLI Help", function() {
         (help as any).configManager = configManagerStub;
 
         // Enable anonymous/restricted mode
-        process.env.ABLY_RESTRICTED_MODE = "true";
+        process.env.ABLY_ANONYMOUS_USER_MODE = "true";
 
         // Simulate no --help flag in argv
         process.argv = ["node", "ably"];
@@ -228,7 +228,7 @@ describe("CLI Help", function() {
         expect(output).to.not.include("View live channel events: ably channels logs");
 
         // Clean up
-        delete process.env.ABLY_RESTRICTED_MODE;
+        delete process.env.ABLY_ANONYMOUS_USER_MODE;
       });
 
       it("should show login prompt in simplified view when not authenticated", async function() {


### PR DESCRIPTION
  Updates the CLI to use the new ABLY_ANONYMOUS_USER_MODE environment variable
  instead of ABLY_RESTRICTED_MODE for better clarity. This aligns with the
  terminal server's naming convention where:
  - ABLY_ANONYMOUS_USER_MODE=true when no ABLY_ACCESS_TOKEN is provided
  - ABLY_ANONYMOUS_USER_MODE=false when ABLY_ACCESS_TOKEN exists

  Changes:
  - Update isAnonymousWebMode() method in base-command.ts
  - Update anonymous mode check in help.ts for web CLI help display
  - Update all related unit tests to use the new variable name