### PR TITLE
chore: bump react-web-cli version to cover release attempt

### DIFF
--- a/packages/react-web-cli/package.json
+++ b/packages/react-web-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ably/react-web-cli",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "React component for embedding the Ably CLI in a web terminal",
   "main": "dist/index.js",
   "module": "dist/index.mjs",


### PR DESCRIPTION
Had an unsuccessful push to npm, rendering 0.7.0 unusable - the underlying problem has been resolved. This PR bumps the package version to 0.7.1 to line up on that new version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the version number of the package to 0.7.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->