### PR TITLE
Chat: Rename get() command to history()

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ $ ably-interactive
 
 - **Command history**: Previous commands are saved and can be accessed with up/down arrows
 - **Tab completion**: Full support for command and flag completion
-- **Ctrl+C handling**: 
+- **Ctrl+C handling**:
   - Single Ctrl+C interrupts the current command and returns to prompt
   - Double Ctrl+C (within 500ms) force quits the shell
 - **No "ably" prefix needed**: Commands can be typed directly (e.g., just `channels list` instead of `ably channels list`)
@@ -176,7 +176,7 @@ See [MCP Server section](#mcp-server) for more details on how to use the MCP Ser
 * [`ably rooms`](#ably-rooms)
 * [`ably rooms list`](#ably-rooms-list)
 * [`ably rooms messages`](#ably-rooms-messages)
-* [`ably rooms messages get ROOMID`](#ably-rooms-messages-get-roomid)
+* [`ably rooms messages history ROOMID`](#ably-rooms-messages-history-roomid)
 * [`ably rooms messages reactions`](#ably-rooms-messages-reactions)
 * [`ably rooms messages reactions remove ROOMID MESSAGESERIAL REACTION`](#ably-rooms-messages-reactions-remove-roomid-messageserial-reaction)
 * [`ably rooms messages reactions send ROOMID MESSAGESERIAL REACTION`](#ably-rooms-messages-reactions-send-roomid-messageserial-reaction)
@@ -3546,24 +3546,24 @@ EXAMPLES
 
   $ ably rooms messages subscribe my-room
 
-  $ ably rooms messages get my-room
+  $ ably rooms messages history my-room
 
   $ ably rooms messages reactions add my-room "message-id" "👍"
 ```
 
 _See code: [src/commands/rooms/messages/index.ts](https://github.com/ably/cli/blob/v0.10.0/src/commands/rooms/messages/index.ts)_
 
-## `ably rooms messages get ROOMID`
+## `ably rooms messages history ROOMID`
 
 Get historical messages from an Ably Chat room
 
 ```
 USAGE
-  $ ably rooms messages get ROOMID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
+  $ ably rooms messages history ROOMID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
     [--endpoint <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [-l <value>] [--show-metadata]
 
 ARGUMENTS
-  ROOMID  The room ID to get messages from
+  ROOMID  The room ID to get message history from
 
 FLAGS
   -l, --limit=<value>         [default: 20] Maximum number of messages to retrieve
@@ -3584,20 +3584,20 @@ DESCRIPTION
   Get historical messages from an Ably Chat room
 
 EXAMPLES
-  $ ably rooms messages get my-room
+  $ ably rooms messages history my-room
 
-  $ ably rooms messages get --api-key "YOUR_API_KEY" my-room
+  $ ably rooms messages history --api-key "YOUR_API_KEY" my-room
 
-  $ ably rooms messages get --limit 50 my-room
+  $ ably rooms messages history --limit 50 my-room
 
-  $ ably rooms messages get --show-metadata my-room
+  $ ably rooms messages history --show-metadata my-room
 
-  $ ably rooms messages get my-room --json
+  $ ably rooms messages history my-room --json
 
-  $ ably rooms messages get my-room --pretty-json
+  $ ably rooms messages history my-room --pretty-json
 ```
 
-_See code: [src/commands/rooms/messages/get.ts](https://github.com/ably/cli/blob/v0.10.0/src/commands/rooms/messages/get.ts)_
+_See code: [src/commands/rooms/messages/history.ts](https://github.com/ably/cli/blob/v0.10.0/src/commands/rooms/messages/history.ts)_
 
 ## `ably rooms messages reactions`
 
@@ -5097,7 +5097,7 @@ Please see the documentation in [`.cursor/rules/Workflow.mdc`](.cursor/rules/Wor
 
 ## For AI Assistants
 
-**IMPORTANT**: See [`.claude/CLAUDE.md`](./.claude/CLAUDE.md) for mandatory instructions before making any changes.  
+**IMPORTANT**: See [`.claude/CLAUDE.md`](./.claude/CLAUDE.md) for mandatory instructions before making any changes.
 If you are an AI assistant, start with [`AI_START_HERE.md`](./AI_START_HERE.md) first.
 
 ## Quick Development Validation

--- a/docs/Product-Requirements.md
+++ b/docs/Product-Requirements.md
@@ -104,7 +104,7 @@ The CLI uses topics (space-separated) to group related commands logically.
 - `$ ably rooms list`: Lists chat rooms (filters channel enumeration).
 - `$ ably rooms messages send ROOMID TEXT`: Sends a chat message. Supports `--count`, `--delay`, interpolation.
 - `$ ably rooms messages subscribe ROOMID`: Subscribes to chat messages. Runs until terminated.
-- `$ ably rooms messages get ROOMID`: Gets historical chat messages.
+- `$ ably rooms messages history ROOMID`: Gets historical chat messages.
 - `$ ably rooms occupancy get ROOMID`: Gets current occupancy for a room.
 - `$ ably rooms occupancy subscribe ROOMID`: Subscribes to live room occupancy. Runs until terminated.
 - `$ ably rooms presence enter ROOMID`: Enters presence in a room and stays present. Runs until terminated.

--- a/src/commands/rooms/messages/history.ts
+++ b/src/commands/rooms/messages/history.ts
@@ -4,10 +4,10 @@ import chalk from "chalk";
 
 import { ChatBaseCommand } from "../../../chat-base-command.js";
 
-export default class MessagesGet extends ChatBaseCommand {
+export default class MessagesHistory extends ChatBaseCommand {
   static override args = {
     roomId: Args.string({
-      description: "The room ID to get messages from",
+      description: "The room ID to get message history from",
       required: true,
     }),
   };
@@ -16,12 +16,12 @@ export default class MessagesGet extends ChatBaseCommand {
     "Get historical messages from an Ably Chat room";
 
   static override examples = [
-    "$ ably rooms messages get my-room",
-    '$ ably rooms messages get --api-key "YOUR_API_KEY" my-room',
-    "$ ably rooms messages get --limit 50 my-room",
-    "$ ably rooms messages get --show-metadata my-room",
-    "$ ably rooms messages get my-room --json",
-    "$ ably rooms messages get my-room --pretty-json",
+    "$ ably rooms messages history my-room",
+    '$ ably rooms messages history --api-key "YOUR_API_KEY" my-room',
+    "$ ably rooms messages history --limit 50 my-room",
+    "$ ably rooms messages history --show-metadata my-room",
+    "$ ably rooms messages history my-room --json",
+    "$ ably rooms messages history my-room --pretty-json",
   ];
 
   static override flags = {
@@ -40,7 +40,7 @@ export default class MessagesGet extends ChatBaseCommand {
   private ablyClient: Ably.Realtime | null = null;
 
   async run(): Promise<void> {
-    const { args, flags } = await this.parse(MessagesGet);
+    const { args, flags } = await this.parse(MessagesHistory);
 
     try {
       // Create Chat client

--- a/src/commands/rooms/messages/index.ts
+++ b/src/commands/rooms/messages/index.ts
@@ -7,7 +7,7 @@ export default class MessagesIndex extends Command {
   static override examples = [
     '$ ably rooms messages send my-room "Hello world!"',
     "$ ably rooms messages subscribe my-room",
-    "$ ably rooms messages get my-room",
+    "$ ably rooms messages history my-room",
     '$ ably rooms messages reactions add my-room "message-id" "👍"',
   ];
 
@@ -21,7 +21,7 @@ export default class MessagesIndex extends Command {
       "  ably rooms messages subscribe  - Subscribe to messages in a chat room",
     );
     this.log(
-      "  ably rooms messages get        - Get historical messages from a chat room",
+      "  ably rooms messages history    - Get historical messages from a chat room",
     );
     this.log(
       "  ably rooms messages reactions  - Work with message reactions in a chat room",

--- a/test/unit/commands/rooms/messages.test.ts
+++ b/test/unit/commands/rooms/messages.test.ts
@@ -5,7 +5,7 @@ import * as Ably from "ably";
 
 import RoomsMessagesSend from "../../../../src/commands/rooms/messages/send.js";
 import RoomsMessagesSubscribe from "../../../../src/commands/rooms/messages/subscribe.js";
-import RoomsMessagesGet from "../../../../src/commands/rooms/messages/get.js";
+import RoomsMessagesHistory from "../../../../src/commands/rooms/messages/history.js";
 
 // Testable subclass for rooms messages send command
 class TestableRoomsMessagesSend extends RoomsMessagesSend {
@@ -75,8 +75,8 @@ class TestableRoomsMessagesSubscribe extends RoomsMessagesSubscribe {
   } as any;
 }
 
-// Testable subclass for rooms messages get command
-class TestableRoomsMessagesGet extends RoomsMessagesGet {
+// Testable subclass for rooms messages history command
+class TestableRoomsMessagesHistory extends RoomsMessagesHistory {
   private _parseResult: any;
   public mockChatClient: any;
   public mockRealtimeClient: any;
@@ -129,7 +129,7 @@ describe("rooms messages commands", function () {
 
     beforeEach(function () {
       command = new TestableRoomsMessagesSend([], mockConfig);
-      
+
       sendStub = sandbox.stub().resolves();
       mockMessages = {
         send: sendStub,
@@ -189,11 +189,11 @@ describe("rooms messages commands", function () {
 
       // Should eventually send 3 messages
       expect(sendStub.callCount).to.equal(3);
-      
+
       // Check first and last calls for interpolation
       const firstCall = sendStub.getCall(0);
       const lastCall = sendStub.getCall(2);
-      
+
       expect(firstCall.args[0].text).to.equal("Message 1");
       expect(lastCall.args[0].text).to.equal("Message 3");
     });
@@ -240,7 +240,7 @@ describe("rooms messages commands", function () {
 
     beforeEach(function () {
       command = new TestableRoomsMessagesSubscribe([], mockConfig);
-      
+
       subscribeStub = sandbox.stub();
       mockMessages = {
         subscribe: subscribeStub,
@@ -296,28 +296,28 @@ describe("rooms messages commands", function () {
 
       // Since subscribe runs indefinitely, we'll test the setup
       const runPromise = command.run();
-      
+
       // Give it a moment to set up
       await new Promise(resolve => setTimeout(resolve, 50));
-      
+
       expect(command.mockChatClient.rooms.get.calledWith("test-room")).to.be.true;
       expect(mockRoom.attach.calledOnce).to.be.true;
       expect(subscribeStub.calledOnce).to.be.true;
-      
+
       // Cleanup - this would normally be done by SIGINT
       command.mockRealtimeClient.close();
     });
   });
 
-  describe("rooms messages get (history)", function () {
-    let command: TestableRoomsMessagesGet;
+  describe("rooms messages history", function () {
+    let command: TestableRoomsMessagesHistory;
     let mockRoom: any;
     let mockMessages: any;
     let getStub: sinon.SinonStub;
 
     beforeEach(function () {
-      command = new TestableRoomsMessagesGet([], mockConfig);
-      
+      command = new TestableRoomsMessagesHistory([], mockConfig);
+
       getStub = sandbox.stub().resolves({
         items: [
           {
@@ -326,7 +326,7 @@ describe("rooms messages commands", function () {
             timestamp: new Date(Date.now() - 10000),
           },
           {
-            text: "Historical message 2", 
+            text: "Historical message 2",
             clientId: "client2",
             timestamp: new Date(Date.now() - 5000),
           },


### PR DESCRIPTION
This pull request renames the CLI command and related code for fetching historical messages from an Ably chat room from `get` to `history`. The update ensures consistency with the Chat SDK's current API.

[CHA-1086](https://ably.atlassian.net/browse/CHA-1086)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated all documentation to rename the command for retrieving chat room message history from ably rooms messages get ROOMID to ably rooms messages history ROOMID, including usage examples and descriptions.
  * Clarified command descriptions and fixed minor formatting issues.

* **Tests**
  * Updated test suite references to reflect the new command name for message history retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[CHA-1086]: https://ably.atlassian.net/browse/CHA-1086?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ