### PR TITLE
release: add web CLI auto releaser

### DIFF
--- a/.github/workflows/release-web-cli.yml
+++ b/.github/workflows/release-web-cli.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    concurrency:
+      group: web-cli-release-${{ github.ref }}
+      cancel-in-progress: true
     permissions:
       contents: "write"
       id-token: "write"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    concurrency:
+      group: cli-release-${{ github.ref }}
+      cancel-in-progress: true
     permissions:
       contents: "write"
       id-token: "write"


### PR DESCRIPTION
This was already approved in https://github.com/ably/ably-cli/pull/63, but got merged into a stale release branch that GitHub didn't re-point at main on merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced an automated npm release workflow for the React Web CLI triggered by version tags, including a version existence check to skip duplicates.
  * Added build and publish steps with provenance and public access, using Node.js 22 and pnpm 10 with caching and submodule support.
  * Implemented concurrency controls to ensure only one release per ref runs at a time and to cancel in-progress runs when superseded.
  * Overall, improves reliability and transparency of the release pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->