### PR TITLE
chat: replace --profile-data with --data

### DIFF
--- a/README.md
+++ b/README.md
@@ -3974,8 +3974,8 @@ Enter presence in a chat room and remain present until terminated
 ```
 USAGE
   $ ably rooms presence enter ROOMID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
-    [--endpoint <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--profile-data <value>]
-    [--show-others] [-D <value>]
+    [--endpoint <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--show-others] [-D <value>]
+    [--data <value>]
 
 ARGUMENTS
   ROOMID  Room ID to enter presence on
@@ -3987,12 +3987,12 @@ FLAGS
       --api-key=<value>       Overrides any configured API key used for the product APIs
       --client-id=<value>     Overrides any default client ID when using API authentication. Use "none" to explicitly
                               set no client ID. Not applicable when using token authentication.
+      --data=<value>          Data to include with the member (JSON format)
       --endpoint=<value>      Override the endpoint for all product API calls
       --env=<value>           Override the environment for all product API calls
       --host=<value>          Override the host endpoint for all product API calls
       --json                  Output in JSON format
       --pretty-json           Output in colorized JSON format
-      --profile-data=<value>  Profile data to include with the member (JSON format)
       --show-others           Show other presence events while present
       --token=<value>         Authenticate using an Ably Token or JWT Token instead of an API key
 
@@ -4002,7 +4002,7 @@ DESCRIPTION
 EXAMPLES
   $ ably rooms presence enter my-room
 
-  $ ably rooms presence enter my-room --profile-data '{"name":"User","status":"active"}'
+  $ ably rooms presence enter my-room --data '{"name":"User","status":"active"}'
 
   $ ably rooms presence enter my-room --duration 30
 ```

--- a/src/commands/rooms/presence/subscribe.ts
+++ b/src/commands/rooms/presence/subscribe.ts
@@ -61,7 +61,7 @@ export default class RoomsPresenceSubscribe extends ChatBaseCommand {
     return new Promise<void>((resolve) => {
       const timeout = setTimeout(() => {
         this.logCliEvent(flagsForLog, "connection", "cleanupTimeout", "Ably client close timed out after 2s. Forcing cleanup.");
-        resolve(); 
+        resolve();
       }, 2000);
       const onClosedOrFailed = () => {
         clearTimeout(timeout);
@@ -96,7 +96,7 @@ export default class RoomsPresenceSubscribe extends ChatBaseCommand {
         if (!this.shouldOutputJson(flags)) {
           this.log(chalk.yellow("Warning: Failed to connect to Ably (authentication failed)"));
         }
-        
+
         // Wait for the duration even with auth failures
         const effectiveDuration =
           typeof flags.duration === "number" && flags.duration > 0
@@ -117,7 +117,7 @@ export default class RoomsPresenceSubscribe extends ChatBaseCommand {
         if (!this.shouldOutputJson(flags)) {
           this.log(chalk.yellow("Warning: Failed to connect to Ably (likely authentication issue)"));
         }
-        
+
         // Wait for the duration even with auth failures
         const effectiveDuration =
           typeof flags.duration === "number" && flags.duration > 0
@@ -137,7 +137,7 @@ export default class RoomsPresenceSubscribe extends ChatBaseCommand {
       this.setupConnectionStateLogging(this.ablyClient!, flags, {
         includeUserFriendlyMessages: true
       });
-      
+
       this.room = await this.chatClient.rooms.get(this.roomId!);
       const currentRoom = this.room!;
 
@@ -156,7 +156,7 @@ export default class RoomsPresenceSubscribe extends ChatBaseCommand {
       });
 
       await currentRoom.attach();
-      
+
       if (!this.shouldOutputJson(flags) && this.roomId) {
         this.log(`Fetching current presence members for room ${chalk.cyan(this.roomId)}...`);
         const members: PresenceMember[] = await currentRoom.presence.get();
@@ -192,7 +192,7 @@ export default class RoomsPresenceSubscribe extends ChatBaseCommand {
           if (member.data && typeof member.data === 'object' && Object.keys(member.data).length > 0) {
             const profile = member.data as { name?: string };
             if (profile.name) { this.log(`  ${chalk.dim("Name:")} ${profile.name}`); }
-            this.log(`  ${chalk.dim("Full Profile Data:")} ${this.formatJsonOutput({ data: member.data }, flags)}`);
+            this.log(`  ${chalk.dim("Full Data:")} ${this.formatJsonOutput({ data: member.data }, flags)}`);
           }
         }
       });
@@ -253,30 +253,30 @@ export default class RoomsPresenceSubscribe extends ChatBaseCommand {
   private async performCleanup(flags: BaseFlags): Promise<void> {
     // Unsubscribe from presence events with timeout
     if (this.presenceSubscription) {
-      try { 
+      try {
         await Promise.race([
           Promise.resolve(this.presenceSubscription.unsubscribe()),
           new Promise<void>((resolve) => setTimeout(resolve, 1000))
         ]);
-        this.logCliEvent(flags, "presence", "unsubscribedEventsFinally", "Unsubscribed presence listener."); 
-      } catch (error) { 
-        this.logCliEvent(flags, "presence", "unsubscribeErrorFinally", `Error unsubscribing presence subscription: ${error instanceof Error ? error.message : String(error)}`); 
+        this.logCliEvent(flags, "presence", "unsubscribedEventsFinally", "Unsubscribed presence listener.");
+      } catch (error) {
+        this.logCliEvent(flags, "presence", "unsubscribeErrorFinally", `Error unsubscribing presence subscription: ${error instanceof Error ? error.message : String(error)}`);
       }
     }
 
     // Unsubscribe from status events with timeout
     if (this.unsubscribeStatusFn) {
-      try { 
+      try {
         await Promise.race([
           Promise.resolve(this.unsubscribeStatusFn.off()),
           new Promise<void>((resolve) => setTimeout(resolve, 1000))
         ]);
-        this.logCliEvent(flags, "room", "unsubscribedStatusFinally", "Unsubscribed room status listener."); 
-      } catch (error) { 
-        this.logCliEvent(flags, "room", "unsubscribeStatusErrorFinally", `Error unsubscribing status listener: ${error instanceof Error ? error.message : String(error)}`); 
+        this.logCliEvent(flags, "room", "unsubscribedStatusFinally", "Unsubscribed room status listener.");
+      } catch (error) {
+        this.logCliEvent(flags, "room", "unsubscribeStatusErrorFinally", `Error unsubscribing status listener: ${error instanceof Error ? error.message : String(error)}`);
       }
     }
-    
+
     // Release room with timeout
     if (this.chatClient && this.roomId) {
       try {
@@ -286,8 +286,8 @@ export default class RoomsPresenceSubscribe extends ChatBaseCommand {
           new Promise<void>((resolve) => setTimeout(resolve, 2000))
         ]);
         this.logCliEvent(flags, "room", "releasedInFinally", `Room ${this.roomId} released.`);
-      } catch (error) { 
-        this.logCliEvent(flags, "room", "releaseErrorInFinally", `Error releasing room: ${error instanceof Error ? error.message : String(error)}`); 
+      } catch (error) {
+        this.logCliEvent(flags, "room", "releaseErrorInFinally", `Error releasing room: ${error instanceof Error ? error.message : String(error)}`);
       }
     }
 

--- a/test/e2e/rooms/rooms-e2e.test.ts
+++ b/test/e2e/rooms/rooms-e2e.test.ts
@@ -96,7 +96,7 @@ describe('Rooms E2E Tests', function() {
         try {
           // Start client1 entering presence (this is a long-running command)
           presenceRunner = await startPresenceCommand(
-            ['rooms', 'presence', 'enter', testRoomId, '--profile-data', '{"name":"TestUser1"}', '--client-id', client1Id, '--duration', '15'],
+            ['rooms', 'presence', 'enter', testRoomId, '--data', '{"name":"TestUser1"}', '--client-id', client1Id, '--duration', '15'],
             /Entered room/,
             { timeoutMs: process.env.CI ? 20000 : 15000 }
           );
@@ -166,7 +166,7 @@ describe('Rooms E2E Tests', function() {
 
             // Have client2 enter the room
             enterRunner = await startPresenceCommand(
-              ['rooms', 'presence', 'enter', testRoomId, '--profile-data', '{"name":"TestUser2","status":"active"}', '--client-id', client2Id, '--duration', '25'],
+              ['rooms', 'presence', 'enter', testRoomId, '--data', '{"name":"TestUser2","status":"active"}', '--client-id', client2Id, '--duration', '25'],
               /Entered room/,
               { timeoutMs: process.env.CI ? 30000 : 20000 }
             );


### PR DESCRIPTION
It appears profile-data was introduced unintentionally during an unrelated change. We don't use (and don't plan to AFAICT) this term in the Chat SDK or Pub/Sub - so this change is moving back to using --data to more closely align the CLI with how things are represented in the SDK and our getting started guides.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Replaced the --profile-data flag with --data for presence enter; deprecated flag removed.
  * Updated logs to label member payloads as “Full Data” instead of “Full Profile Data.”
  * Error messaging now reads “Invalid data JSON” for malformed input.

* **Documentation**
  * Updated usage, flags, and examples to reflect --data, with wording simplified to “Data” (JSON format).
  * Adjusted flag order in the usage block for consistency.

* **Tests**
  * End-to-end scenarios updated to use --data in presence enter commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->