### PR TITLE
chore: Prepare release 0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.0] - 2025-09-10
+
+### Fixed
+
+- Setting the `--endpoint` flag or `ABLY_ENDPOINT` environment variable correctly sets the endpoint SDK client option
+- Setting the `ABLY_CONTROL_HOST` environment variable correctly sets the Control API client hostname
+
+### Added
+
+- Add `ablyEndpoint` and `ablyControlHost` props to the AblyCliTerminal react component
+
 ## [0.12.0] - 2025-08-31
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ $ npm install -g @ably/cli
 $ ably COMMAND
 running command...
 $ ably (--version)
-@ably/cli/0.12.0 darwin-arm64 node-v22.14.0
+@ably/cli/0.13.0 darwin-arm64 node-v22.14.0
 $ ably --help [COMMAND]
 USAGE
   $ ably COMMAND
@@ -252,7 +252,7 @@ COMMANDS
   ably accounts switch          Switch to a different Ably account
 ```
 
-_See code: [src/commands/accounts/index.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/accounts/index.ts)_
+_See code: [src/commands/accounts/index.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/accounts/index.ts)_
 
 ## `ably accounts current`
 
@@ -287,7 +287,7 @@ EXAMPLES
   $ ably accounts current --pretty-json
 ```
 
-_See code: [src/commands/accounts/current.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/accounts/current.ts)_
+_See code: [src/commands/accounts/current.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/accounts/current.ts)_
 
 ## `ably accounts list`
 
@@ -322,7 +322,7 @@ EXAMPLES
   $ ably accounts list --pretty-json
 ```
 
-_See code: [src/commands/accounts/list.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/accounts/list.ts)_
+_See code: [src/commands/accounts/list.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/accounts/list.ts)_
 
 ## `ably accounts login [TOKEN]`
 
@@ -364,7 +364,7 @@ EXAMPLES
   $ ably accounts login --pretty-json
 ```
 
-_See code: [src/commands/accounts/login.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/accounts/login.ts)_
+_See code: [src/commands/accounts/login.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/accounts/login.ts)_
 
 ## `ably accounts logout [ALIAS]`
 
@@ -405,7 +405,7 @@ EXAMPLES
   $ ably accounts logout --pretty-json
 ```
 
-_See code: [src/commands/accounts/logout.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/accounts/logout.ts)_
+_See code: [src/commands/accounts/logout.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/accounts/logout.ts)_
 
 ## `ably accounts stats`
 
@@ -459,7 +459,7 @@ EXAMPLES
   $ ably accounts stats --live --interval 15
 ```
 
-_See code: [src/commands/accounts/stats/index.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/accounts/stats/index.ts)_
+_See code: [src/commands/accounts/stats/index.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/accounts/stats/index.ts)_
 
 ## `ably accounts switch [ALIAS]`
 
@@ -499,7 +499,7 @@ EXAMPLES
   $ ably accounts switch --pretty-json
 ```
 
-_See code: [src/commands/accounts/switch.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/accounts/switch.ts)_
+_See code: [src/commands/accounts/switch.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/accounts/switch.ts)_
 
 ## `ably apps`
 
@@ -542,7 +542,7 @@ COMMANDS
   ably apps update              Update an app
 ```
 
-_See code: [src/commands/apps/index.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/apps/index.ts)_
+_See code: [src/commands/apps/index.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/apps/index.ts)_
 
 ## `ably apps channel-rules`
 
@@ -565,7 +565,7 @@ EXAMPLES
   $ ably apps channel-rules delete chat
 ```
 
-_See code: [src/commands/apps/channel-rules/index.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/apps/channel-rules/index.ts)_
+_See code: [src/commands/apps/channel-rules/index.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/apps/channel-rules/index.ts)_
 
 ## `ably apps channel-rules create`
 
@@ -617,7 +617,7 @@ EXAMPLES
   $ ably apps channel-rules create --name "notifications" --persisted --push-enabled --app "My App"
 ```
 
-_See code: [src/commands/apps/channel-rules/create.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/apps/channel-rules/create.ts)_
+_See code: [src/commands/apps/channel-rules/create.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/apps/channel-rules/create.ts)_
 
 ## `ably apps channel-rules delete NAMEORID`
 
@@ -661,7 +661,7 @@ EXAMPLES
   $ ably apps channel-rules delete chat --pretty-json
 ```
 
-_See code: [src/commands/apps/channel-rules/delete.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/apps/channel-rules/delete.ts)_
+_See code: [src/commands/apps/channel-rules/delete.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/apps/channel-rules/delete.ts)_
 
 ## `ably apps channel-rules list`
 
@@ -684,7 +684,7 @@ EXAMPLES
   $ ably apps:channel-rules:list --pretty-json
 ```
 
-_See code: [src/commands/apps/channel-rules/list.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/apps/channel-rules/list.ts)_
+_See code: [src/commands/apps/channel-rules/list.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/apps/channel-rules/list.ts)_
 
 ## `ably apps channel-rules update NAMEORID`
 
@@ -738,7 +738,7 @@ EXAMPLES
   $ ably apps channel-rules update notifications --persisted --push-enabled --app "My App"
 ```
 
-_See code: [src/commands/apps/channel-rules/update.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/apps/channel-rules/update.ts)_
+_See code: [src/commands/apps/channel-rules/update.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/apps/channel-rules/update.ts)_
 
 ## `ably apps create`
 
@@ -775,7 +775,7 @@ EXAMPLES
   $ ably apps create --name "My New App" --access-token "YOUR_ACCESS_TOKEN"
 ```
 
-_See code: [src/commands/apps/create.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/apps/create.ts)_
+_See code: [src/commands/apps/create.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/apps/create.ts)_
 
 ## `ably apps current`
 
@@ -810,7 +810,7 @@ EXAMPLES
   $ ably apps current --pretty-json
 ```
 
-_See code: [src/commands/apps/current.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/apps/current.ts)_
+_See code: [src/commands/apps/current.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/apps/current.ts)_
 
 ## `ably apps delete [ID]`
 
@@ -858,7 +858,7 @@ EXAMPLES
   $ ably apps delete app-id --pretty-json
 ```
 
-_See code: [src/commands/apps/delete.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/apps/delete.ts)_
+_See code: [src/commands/apps/delete.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/apps/delete.ts)_
 
 ## `ably apps list`
 
@@ -893,7 +893,7 @@ EXAMPLES
   $ ably apps list --pretty-json
 ```
 
-_See code: [src/commands/apps/list.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/apps/list.ts)_
+_See code: [src/commands/apps/list.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/apps/list.ts)_
 
 ## `ably apps logs`
 
@@ -914,7 +914,7 @@ EXAMPLES
   $ ably apps logs history
 ```
 
-_See code: [src/commands/apps/logs/index.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/apps/logs/index.ts)_
+_See code: [src/commands/apps/logs/index.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/apps/logs/index.ts)_
 
 ## `ably apps logs history`
 
@@ -957,7 +957,7 @@ EXAMPLES
   $ ably apps logs history --pretty-json
 ```
 
-_See code: [src/commands/apps/logs/history.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/apps/logs/history.ts)_
+_See code: [src/commands/apps/logs/history.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/apps/logs/history.ts)_
 
 ## `ably apps logs subscribe`
 
@@ -991,7 +991,7 @@ EXAMPLES
   $ ably apps logs subscribe --rewind 10
 ```
 
-_See code: [src/commands/apps/logs/subscribe.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/apps/logs/subscribe.ts)_
+_See code: [src/commands/apps/logs/subscribe.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/apps/logs/subscribe.ts)_
 
 ## `ably apps set-apns-p12 ID`
 
@@ -1033,7 +1033,7 @@ EXAMPLES
   $ ably apps set-apns-p12 app-id --certificate /path/to/certificate.p12 --use-for-sandbox
 ```
 
-_See code: [src/commands/apps/set-apns-p12.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/apps/set-apns-p12.ts)_
+_See code: [src/commands/apps/set-apns-p12.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/apps/set-apns-p12.ts)_
 
 ## `ably apps stats [ID]`
 
@@ -1096,7 +1096,7 @@ EXAMPLES
   $ ably apps stats --live --interval 15
 ```
 
-_See code: [src/commands/apps/stats/index.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/apps/stats/index.ts)_
+_See code: [src/commands/apps/stats/index.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/apps/stats/index.ts)_
 
 ## `ably apps switch [APPID]`
 
@@ -1132,7 +1132,7 @@ EXAMPLES
   $ ably apps switch
 ```
 
-_See code: [src/commands/apps/switch.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/apps/switch.ts)_
+_See code: [src/commands/apps/switch.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/apps/switch.ts)_
 
 ## `ably apps update ID`
 
@@ -1174,7 +1174,7 @@ EXAMPLES
   $ ably apps update app-id --name "Updated App Name" --access-token "YOUR_ACCESS_TOKEN"
 ```
 
-_See code: [src/commands/apps/update.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/apps/update.ts)_
+_See code: [src/commands/apps/update.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/apps/update.ts)_
 
 ## `ably auth`
 
@@ -1201,7 +1201,7 @@ COMMANDS
   ably auth revoke-token        Revokes the token provided
 ```
 
-_See code: [src/commands/auth/index.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/auth/index.ts)_
+_See code: [src/commands/auth/index.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/auth/index.ts)_
 
 ## `ably auth issue-ably-token`
 
@@ -1253,7 +1253,7 @@ EXAMPLES
   $ ably channels publish --token "$(ably auth issue-ably-token --token-only)" my-channel "Hello"
 ```
 
-_See code: [src/commands/auth/issue-ably-token.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/auth/issue-ably-token.ts)_
+_See code: [src/commands/auth/issue-ably-token.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/auth/issue-ably-token.ts)_
 
 ## `ably auth issue-jwt-token`
 
@@ -1303,7 +1303,7 @@ EXAMPLES
   $ ably channels publish --token "$(ably auth issue-jwt-token --token-only)" my-channel "Hello"
 ```
 
-_See code: [src/commands/auth/issue-jwt-token.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/auth/issue-jwt-token.ts)_
+_See code: [src/commands/auth/issue-jwt-token.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/auth/issue-jwt-token.ts)_
 
 ## `ably auth keys`
 
@@ -1330,7 +1330,7 @@ EXAMPLES
   $ ably auth keys switch KEY_ID
 ```
 
-_See code: [src/commands/auth/keys/index.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/auth/keys/index.ts)_
+_See code: [src/commands/auth/keys/index.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/auth/keys/index.ts)_
 
 ## `ably auth keys create`
 
@@ -1382,7 +1382,7 @@ EXAMPLES
   $ ably auth keys create --name "My New Key" --capabilities '{"channel1":["publish","subscribe"],"channel2":["history"]}'
 ```
 
-_See code: [src/commands/auth/keys/create.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/auth/keys/create.ts)_
+_See code: [src/commands/auth/keys/create.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/auth/keys/create.ts)_
 
 ## `ably auth keys current`
 
@@ -1420,7 +1420,7 @@ EXAMPLES
   $ ably auth keys current --pretty-json
 ```
 
-_See code: [src/commands/auth/keys/current.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/auth/keys/current.ts)_
+_See code: [src/commands/auth/keys/current.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/auth/keys/current.ts)_
 
 ## `ably auth keys get KEYNAMEORVALUE`
 
@@ -1461,7 +1461,7 @@ EXAMPLES
   $ ably auth keys get APP_ID.KEY_ID --pretty-json
 ```
 
-_See code: [src/commands/auth/keys/get.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/auth/keys/get.ts)_
+_See code: [src/commands/auth/keys/get.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/auth/keys/get.ts)_
 
 ## `ably auth keys list`
 
@@ -1499,7 +1499,7 @@ EXAMPLES
   $ ably auth keys list --pretty-json
 ```
 
-_See code: [src/commands/auth/keys/list.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/auth/keys/list.ts)_
+_See code: [src/commands/auth/keys/list.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/auth/keys/list.ts)_
 
 ## `ably auth keys revoke KEYNAME`
 
@@ -1543,7 +1543,7 @@ EXAMPLES
   $ ably auth keys revoke APP_ID.KEY_ID --pretty-json
 ```
 
-_See code: [src/commands/auth/keys/revoke.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/auth/keys/revoke.ts)_
+_See code: [src/commands/auth/keys/revoke.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/auth/keys/revoke.ts)_
 
 ## `ably auth keys switch [KEYNAMEORVALUE]`
 
@@ -1582,7 +1582,7 @@ EXAMPLES
   $ ably auth keys switch KEY_ID --app APP_ID
 ```
 
-_See code: [src/commands/auth/keys/switch.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/auth/keys/switch.ts)_
+_See code: [src/commands/auth/keys/switch.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/auth/keys/switch.ts)_
 
 ## `ably auth keys update KEYNAME`
 
@@ -1624,7 +1624,7 @@ EXAMPLES
   $ ably auth keys update APP_ID.KEY_ID --name "New Name" --capabilities "publish,subscribe"
 ```
 
-_See code: [src/commands/auth/keys/update.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/auth/keys/update.ts)_
+_See code: [src/commands/auth/keys/update.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/auth/keys/update.ts)_
 
 ## `ably auth revoke-token TOKEN`
 
@@ -1665,7 +1665,7 @@ EXAMPLES
   $ ably auth revoke-token TOKEN --pretty-json
 ```
 
-_See code: [src/commands/auth/revoke-token.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/auth/revoke-token.ts)_
+_See code: [src/commands/auth/revoke-token.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/auth/revoke-token.ts)_
 
 ## `ably autocomplete [SHELL]`
 
@@ -1719,7 +1719,7 @@ COMMANDS
   ably bench subscriber         Run a subscriber benchmark test
 ```
 
-_See code: [src/commands/bench/index.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/bench/index.ts)_
+_See code: [src/commands/bench/index.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/bench/index.ts)_
 
 ## `ably bench publisher CHANNEL`
 
@@ -1764,7 +1764,7 @@ EXAMPLES
   $ ably bench publisher --transport realtime my-channel
 ```
 
-_See code: [src/commands/bench/publisher.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/bench/publisher.ts)_
+_See code: [src/commands/bench/publisher.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/bench/publisher.ts)_
 
 ## `ably bench subscriber CHANNEL`
 
@@ -1798,7 +1798,7 @@ EXAMPLES
   $ ably bench subscriber my-channel
 ```
 
-_See code: [src/commands/bench/subscriber.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/bench/subscriber.ts)_
+_See code: [src/commands/bench/subscriber.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/bench/subscriber.ts)_
 
 ## `ably channels`
 
@@ -1829,7 +1829,7 @@ COMMANDS
   ably channels subscribe       Subscribe to messages published on one or more Ably channels
 ```
 
-_See code: [src/commands/channels/index.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/channels/index.ts)_
+_See code: [src/commands/channels/index.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/channels/index.ts)_
 
 ## `ably channels batch-publish [MESSAGE]`
 
@@ -1882,7 +1882,7 @@ EXAMPLES
   $ ably channels batch-publish --channels channel1,channel2 '{"data":"Message"}' --pretty-json
 ```
 
-_See code: [src/commands/channels/batch-publish.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/channels/batch-publish.ts)_
+_See code: [src/commands/channels/batch-publish.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/channels/batch-publish.ts)_
 
 ## `ably channels history CHANNEL`
 
@@ -1933,7 +1933,7 @@ EXAMPLES
   $ ably channels history my-channel --direction forward
 ```
 
-_See code: [src/commands/channels/history.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/channels/history.ts)_
+_See code: [src/commands/channels/history.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/channels/history.ts)_
 
 ## `ably channels list`
 
@@ -1974,7 +1974,7 @@ EXAMPLES
   $ ably channels list --pretty-json
 ```
 
-_See code: [src/commands/channels/list.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/channels/list.ts)_
+_See code: [src/commands/channels/list.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/channels/list.ts)_
 
 ## `ably channels logs [TOPIC]`
 
@@ -2011,7 +2011,7 @@ EXAMPLES
   $ ably channels logs channel-lifecycle --rewind 10
 ```
 
-_See code: [src/commands/channels/logs.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/channels/logs.ts)_
+_See code: [src/commands/channels/logs.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/channels/logs.ts)_
 
 ## `ably channels occupancy`
 
@@ -2030,7 +2030,7 @@ EXAMPLES
   $ ably channels occupancy subscribe my-channel
 ```
 
-_See code: [src/commands/channels/occupancy.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/channels/occupancy.ts)_
+_See code: [src/commands/channels/occupancy.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/channels/occupancy.ts)_
 
 ## `ably channels occupancy get CHANNEL`
 
@@ -2070,7 +2070,7 @@ EXAMPLES
   $ ably channels occupancy get my-channel --pretty-json
 ```
 
-_See code: [src/commands/channels/occupancy/get.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/channels/occupancy/get.ts)_
+_See code: [src/commands/channels/occupancy/get.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/channels/occupancy/get.ts)_
 
 ## `ably channels occupancy subscribe CHANNEL`
 
@@ -2115,7 +2115,7 @@ EXAMPLES
   $ ably channels occupancy subscribe my-channel --duration 30
 ```
 
-_See code: [src/commands/channels/occupancy/subscribe.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/channels/occupancy/subscribe.ts)_
+_See code: [src/commands/channels/occupancy/subscribe.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/channels/occupancy/subscribe.ts)_
 
 ## `ably channels presence`
 
@@ -2134,7 +2134,7 @@ EXAMPLES
   $ ably channels presence subscribe my-channel
 ```
 
-_See code: [src/commands/channels/presence.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/channels/presence.ts)_
+_See code: [src/commands/channels/presence.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/channels/presence.ts)_
 
 ## `ably channels presence enter CHANNELNAME`
 
@@ -2183,7 +2183,7 @@ EXAMPLES
   $ ably channels presence enter my-channel --duration 30
 ```
 
-_See code: [src/commands/channels/presence/enter.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/channels/presence/enter.ts)_
+_See code: [src/commands/channels/presence/enter.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/channels/presence/enter.ts)_
 
 ## `ably channels presence subscribe CHANNEL`
 
@@ -2230,7 +2230,7 @@ EXAMPLES
   $ ably channels presence subscribe my-channel --duration 30
 ```
 
-_See code: [src/commands/channels/presence/subscribe.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/channels/presence/subscribe.ts)_
+_See code: [src/commands/channels/presence/subscribe.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/channels/presence/subscribe.ts)_
 
 ## `ably channels publish CHANNEL MESSAGE`
 
@@ -2292,7 +2292,7 @@ EXAMPLES
   $ ably channels publish my-channel "Hello World" --pretty-json
 ```
 
-_See code: [src/commands/channels/publish.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/channels/publish.ts)_
+_See code: [src/commands/channels/publish.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/channels/publish.ts)_
 
 ## `ably channels subscribe CHANNELS`
 
@@ -2353,7 +2353,7 @@ EXAMPLES
   $ ably channels subscribe my-channel --duration 30
 ```
 
-_See code: [src/commands/channels/subscribe.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/channels/subscribe.ts)_
+_See code: [src/commands/channels/subscribe.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/channels/subscribe.ts)_
 
 ## `ably config`
 
@@ -2385,7 +2385,7 @@ EXAMPLES
   $ ably config edit
 ```
 
-_See code: [src/commands/config.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/config.ts)_
+_See code: [src/commands/config.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/config.ts)_
 
 ## `ably connections`
 
@@ -2411,7 +2411,7 @@ COMMANDS
   ably connections test         Test connection to Ably
 ```
 
-_See code: [src/commands/connections/index.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/connections/index.ts)_
+_See code: [src/commands/connections/index.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/connections/index.ts)_
 
 ## `ably connections logs [TOPIC]`
 
@@ -2448,7 +2448,7 @@ EXAMPLES
   $ ably connections logs connections-lifecycle --rewind 10
 ```
 
-_See code: [src/commands/connections/logs.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/connections/logs.ts)_
+_See code: [src/commands/connections/logs.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/connections/logs.ts)_
 
 ## `ably connections stats`
 
@@ -2500,7 +2500,7 @@ EXAMPLES
   $ ably connections stats --live
 ```
 
-_See code: [src/commands/connections/stats.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/connections/stats.ts)_
+_See code: [src/commands/connections/stats.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/connections/stats.ts)_
 
 ## `ably connections test`
 
@@ -2537,7 +2537,7 @@ EXAMPLES
   $ ably connections test --transport xhr
 ```
 
-_See code: [src/commands/connections/test.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/connections/test.ts)_
+_See code: [src/commands/connections/test.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/connections/test.ts)_
 
 ## `ably help [COMMANDS]`
 
@@ -2561,7 +2561,7 @@ EXAMPLES
   $ ably help channels publish
 ```
 
-_See code: [src/commands/help.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/help.ts)_
+_See code: [src/commands/help.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/help.ts)_
 
 ## `ably integrations`
 
@@ -2589,7 +2589,7 @@ COMMANDS
   ably integrations update      Update an integration rule
 ```
 
-_See code: [src/commands/integrations/index.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/integrations/index.ts)_
+_See code: [src/commands/integrations/index.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/integrations/index.ts)_
 
 ## `ably integrations create`
 
@@ -2636,7 +2636,7 @@ EXAMPLES
   $ ably integrations create --rule-type "amqp" --source-type "channel.message" --channel-filter "chat:*"
 ```
 
-_See code: [src/commands/integrations/create.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/integrations/create.ts)_
+_See code: [src/commands/integrations/create.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/integrations/create.ts)_
 
 ## `ably integrations delete RULEID`
 
@@ -2676,7 +2676,7 @@ EXAMPLES
   $ ably integrations delete rule123 --force
 ```
 
-_See code: [src/commands/integrations/delete.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/integrations/delete.ts)_
+_See code: [src/commands/integrations/delete.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/integrations/delete.ts)_
 
 ## `ably integrations get RULEID`
 
@@ -2715,7 +2715,7 @@ EXAMPLES
   $ ably integrations get rule123 --app "My App" --pretty-json
 ```
 
-_See code: [src/commands/integrations/get.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/integrations/get.ts)_
+_See code: [src/commands/integrations/get.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/integrations/get.ts)_
 
 ## `ably integrations list`
 
@@ -2751,7 +2751,7 @@ EXAMPLES
   $ ably integrations list --app "My App" --pretty-json
 ```
 
-_See code: [src/commands/integrations/list.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/integrations/list.ts)_
+_See code: [src/commands/integrations/list.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/integrations/list.ts)_
 
 ## `ably integrations update RULEID`
 
@@ -2799,7 +2799,7 @@ EXAMPLES
   $ ably integrations update rule123 --target-url "https://new-example.com/webhook"
 ```
 
-_See code: [src/commands/integrations/update.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/integrations/update.ts)_
+_See code: [src/commands/integrations/update.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/integrations/update.ts)_
 
 ## `ably login [TOKEN]`
 
@@ -2837,7 +2837,7 @@ EXAMPLES
   $ ably login --alias mycompany
 ```
 
-_See code: [src/commands/login.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/login.ts)_
+_See code: [src/commands/login.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/login.ts)_
 
 ## `ably logs`
 
@@ -2864,7 +2864,7 @@ COMMANDS
   ably logs push                Stream or retrieve push notification logs from [meta]log:push
 ```
 
-_See code: [src/commands/logs/index.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/logs/index.ts)_
+_See code: [src/commands/logs/index.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/logs/index.ts)_
 
 ## `ably logs app`
 
@@ -2885,7 +2885,7 @@ EXAMPLES
   $ ably logs app history
 ```
 
-_See code: [src/commands/logs/app/index.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/logs/app/index.ts)_
+_See code: [src/commands/logs/app/index.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/logs/app/index.ts)_
 
 ## `ably logs app history`
 
@@ -2928,7 +2928,7 @@ EXAMPLES
   $ ably logs app history --pretty-json
 ```
 
-_See code: [src/commands/logs/app/history.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/logs/app/history.ts)_
+_See code: [src/commands/logs/app/history.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/logs/app/history.ts)_
 
 ## `ably logs app subscribe`
 
@@ -2972,7 +2972,7 @@ EXAMPLES
   $ ably logs app subscribe --duration 30
 ```
 
-_See code: [src/commands/logs/app/subscribe.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/logs/app/subscribe.ts)_
+_See code: [src/commands/logs/app/subscribe.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/logs/app/subscribe.ts)_
 
 ## `ably logs channel-lifecycle`
 
@@ -3006,7 +3006,7 @@ EXAMPLES
   $ ably logs channel-lifecycle subscribe --rewind 10
 ```
 
-_See code: [src/commands/logs/channel-lifecycle/index.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/logs/channel-lifecycle/index.ts)_
+_See code: [src/commands/logs/channel-lifecycle/index.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/logs/channel-lifecycle/index.ts)_
 
 ## `ably logs channel-lifecycle subscribe`
 
@@ -3040,7 +3040,7 @@ EXAMPLES
   $ ably logs channel-lifecycle subscribe --rewind 10
 ```
 
-_See code: [src/commands/logs/channel-lifecycle/subscribe.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/logs/channel-lifecycle/subscribe.ts)_
+_See code: [src/commands/logs/channel-lifecycle/subscribe.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/logs/channel-lifecycle/subscribe.ts)_
 
 ## `ably logs connection-lifecycle`
 
@@ -3059,7 +3059,7 @@ EXAMPLES
   $ ably logs connection-lifecycle subscribe --rewind 10
 ```
 
-_See code: [src/commands/logs/connection-lifecycle/index.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/logs/connection-lifecycle/index.ts)_
+_See code: [src/commands/logs/connection-lifecycle/index.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/logs/connection-lifecycle/index.ts)_
 
 ## `ably logs connection-lifecycle history`
 
@@ -3102,7 +3102,7 @@ EXAMPLES
   $ ably logs connection-lifecycle history --pretty-json
 ```
 
-_See code: [src/commands/logs/connection-lifecycle/history.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/logs/connection-lifecycle/history.ts)_
+_See code: [src/commands/logs/connection-lifecycle/history.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/logs/connection-lifecycle/history.ts)_
 
 ## `ably logs connection-lifecycle subscribe`
 
@@ -3142,7 +3142,7 @@ EXAMPLES
   $ ably logs connection-lifecycle subscribe --duration 30
 ```
 
-_See code: [src/commands/logs/connection-lifecycle/subscribe.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/logs/connection-lifecycle/subscribe.ts)_
+_See code: [src/commands/logs/connection-lifecycle/subscribe.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/logs/connection-lifecycle/subscribe.ts)_
 
 ## `ably logs connection subscribe`
 
@@ -3180,7 +3180,7 @@ EXAMPLES
   $ ably logs connection subscribe --duration 30
 ```
 
-_See code: [src/commands/logs/connection/subscribe.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/logs/connection/subscribe.ts)_
+_See code: [src/commands/logs/connection/subscribe.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/logs/connection/subscribe.ts)_
 
 ## `ably logs push`
 
@@ -3201,7 +3201,7 @@ EXAMPLES
   $ ably logs push history
 ```
 
-_See code: [src/commands/logs/push/index.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/logs/push/index.ts)_
+_See code: [src/commands/logs/push/index.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/logs/push/index.ts)_
 
 ## `ably logs push history`
 
@@ -3244,7 +3244,7 @@ EXAMPLES
   $ ably logs push history --pretty-json
 ```
 
-_See code: [src/commands/logs/push/history.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/logs/push/history.ts)_
+_See code: [src/commands/logs/push/history.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/logs/push/history.ts)_
 
 ## `ably logs push subscribe`
 
@@ -3278,7 +3278,7 @@ EXAMPLES
   $ ably logs push subscribe --rewind 10
 ```
 
-_See code: [src/commands/logs/push/subscribe.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/logs/push/subscribe.ts)_
+_See code: [src/commands/logs/push/subscribe.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/logs/push/subscribe.ts)_
 
 ## `ably mcp`
 
@@ -3298,7 +3298,7 @@ COMMANDS
   ably mcp start-server         Start an MCP server for AI tools to interact with Ably (currently experimental)
 ```
 
-_See code: [src/commands/mcp/index.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/mcp/index.ts)_
+_See code: [src/commands/mcp/index.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/mcp/index.ts)_
 
 ## `ably mcp start-server`
 
@@ -3315,7 +3315,7 @@ EXAMPLES
   $ ably mcp start-server
 ```
 
-_See code: [src/commands/mcp/start-server.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/mcp/start-server.ts)_
+_See code: [src/commands/mcp/start-server.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/mcp/start-server.ts)_
 
 ## `ably queues`
 
@@ -3341,7 +3341,7 @@ COMMANDS
   ably queues list              List all queues
 ```
 
-_See code: [src/commands/queues/index.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/queues/index.ts)_
+_See code: [src/commands/queues/index.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/queues/index.ts)_
 
 ## `ably queues create`
 
@@ -3382,7 +3382,7 @@ EXAMPLES
   $ ably queues create --name "my-queue" --region "eu-west-1-a" --app "My App"
 ```
 
-_See code: [src/commands/queues/create.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/queues/create.ts)_
+_See code: [src/commands/queues/create.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/queues/create.ts)_
 
 ## `ably queues delete QUEUENAME`
 
@@ -3422,7 +3422,7 @@ EXAMPLES
   $ ably queues delete my-queue --force
 ```
 
-_See code: [src/commands/queues/delete.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/queues/delete.ts)_
+_See code: [src/commands/queues/delete.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/queues/delete.ts)_
 
 ## `ably queues list`
 
@@ -3458,7 +3458,7 @@ EXAMPLES
   $ ably queues list --app "My App" --pretty-json
 ```
 
-_See code: [src/commands/queues/list.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/queues/list.ts)_
+_See code: [src/commands/queues/list.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/queues/list.ts)_
 
 ## `ably rooms`
 
@@ -3487,7 +3487,7 @@ COMMANDS
   ably rooms typing             Commands for working with typing indicators in chat rooms
 ```
 
-_See code: [src/commands/rooms/index.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/rooms/index.ts)_
+_See code: [src/commands/rooms/index.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/rooms/index.ts)_
 
 ## `ably rooms list`
 
@@ -3528,7 +3528,7 @@ EXAMPLES
   $ ably rooms list --pretty-json
 ```
 
-_See code: [src/commands/rooms/list.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/rooms/list.ts)_
+_See code: [src/commands/rooms/list.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/rooms/list.ts)_
 
 ## `ably rooms messages`
 
@@ -3551,7 +3551,7 @@ EXAMPLES
   $ ably rooms messages reactions add my-room "message-id" "👍"
 ```
 
-_See code: [src/commands/rooms/messages/index.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/rooms/messages/index.ts)_
+_See code: [src/commands/rooms/messages/index.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/rooms/messages/index.ts)_
 
 ## `ably rooms messages history ROOMID`
 
@@ -3597,7 +3597,7 @@ EXAMPLES
   $ ably rooms messages history my-room --pretty-json
 ```
 
-_See code: [src/commands/rooms/messages/history.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/rooms/messages/history.ts)_
+_See code: [src/commands/rooms/messages/history.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/rooms/messages/history.ts)_
 
 ## `ably rooms messages reactions`
 
@@ -3618,7 +3618,7 @@ EXAMPLES
   $ ably rooms messages reactions remove my-room "message-id" "👍"
 ```
 
-_See code: [src/commands/rooms/messages/reactions/index.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/rooms/messages/reactions/index.ts)_
+_See code: [src/commands/rooms/messages/reactions/index.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/rooms/messages/reactions/index.ts)_
 
 ## `ably rooms messages reactions remove ROOMID MESSAGESERIAL REACTION`
 
@@ -3663,7 +3663,7 @@ EXAMPLES
   $ ably rooms messages reactions remove my-room message-serial 👍 --json
 ```
 
-_See code: [src/commands/rooms/messages/reactions/remove.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/rooms/messages/reactions/remove.ts)_
+_See code: [src/commands/rooms/messages/reactions/remove.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/rooms/messages/reactions/remove.ts)_
 
 ## `ably rooms messages reactions send ROOMID MESSAGESERIAL REACTION`
 
@@ -3711,7 +3711,7 @@ EXAMPLES
   $ ably rooms messages reactions send my-room message-serial 👍 --json
 ```
 
-_See code: [src/commands/rooms/messages/reactions/send.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/rooms/messages/reactions/send.ts)_
+_See code: [src/commands/rooms/messages/reactions/send.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/rooms/messages/reactions/send.ts)_
 
 ## `ably rooms messages reactions subscribe ROOMID`
 
@@ -3752,7 +3752,7 @@ EXAMPLES
   $ ably rooms messages reactions subscribe my-room --pretty-json
 ```
 
-_See code: [src/commands/rooms/messages/reactions/subscribe.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/rooms/messages/reactions/subscribe.ts)_
+_See code: [src/commands/rooms/messages/reactions/subscribe.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/rooms/messages/reactions/subscribe.ts)_
 
 ## `ably rooms messages send ROOMID TEXT`
 
@@ -3803,7 +3803,7 @@ EXAMPLES
   $ ably rooms messages send my-room "Hello World!" --pretty-json
 ```
 
-_See code: [src/commands/rooms/messages/send.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/rooms/messages/send.ts)_
+_See code: [src/commands/rooms/messages/send.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/rooms/messages/send.ts)_
 
 ## `ably rooms messages subscribe ROOMID`
 
@@ -3849,7 +3849,7 @@ EXAMPLES
   $ ably rooms messages subscribe my-room --pretty-json
 ```
 
-_See code: [src/commands/rooms/messages/subscribe.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/rooms/messages/subscribe.ts)_
+_See code: [src/commands/rooms/messages/subscribe.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/rooms/messages/subscribe.ts)_
 
 ## `ably rooms occupancy`
 
@@ -3868,7 +3868,7 @@ EXAMPLES
   $ ably rooms occupancy subscribe my-room
 ```
 
-_See code: [src/commands/rooms/occupancy/index.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/rooms/occupancy/index.ts)_
+_See code: [src/commands/rooms/occupancy/index.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/rooms/occupancy/index.ts)_
 
 ## `ably rooms occupancy get ROOMID`
 
@@ -3908,7 +3908,7 @@ EXAMPLES
   $ ably rooms occupancy get my-room --pretty-json
 ```
 
-_See code: [src/commands/rooms/occupancy/get.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/rooms/occupancy/get.ts)_
+_See code: [src/commands/rooms/occupancy/get.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/rooms/occupancy/get.ts)_
 
 ## `ably rooms occupancy subscribe ROOMID`
 
@@ -3946,7 +3946,7 @@ EXAMPLES
   $ ably rooms occupancy subscribe --pretty-json my-room
 ```
 
-_See code: [src/commands/rooms/occupancy/subscribe.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/rooms/occupancy/subscribe.ts)_
+_See code: [src/commands/rooms/occupancy/subscribe.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/rooms/occupancy/subscribe.ts)_
 
 ## `ably rooms presence`
 
@@ -3965,7 +3965,7 @@ EXAMPLES
   $ ably rooms presence subscribe my-room
 ```
 
-_See code: [src/commands/rooms/presence/index.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/rooms/presence/index.ts)_
+_See code: [src/commands/rooms/presence/index.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/rooms/presence/index.ts)_
 
 ## `ably rooms presence enter ROOMID`
 
@@ -4007,7 +4007,7 @@ EXAMPLES
   $ ably rooms presence enter my-room --duration 30
 ```
 
-_See code: [src/commands/rooms/presence/enter.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/rooms/presence/enter.ts)_
+_See code: [src/commands/rooms/presence/enter.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/rooms/presence/enter.ts)_
 
 ## `ably rooms presence subscribe ROOMID`
 
@@ -4046,7 +4046,7 @@ EXAMPLES
   $ ably rooms presence subscribe my-room --pretty-json
 ```
 
-_See code: [src/commands/rooms/presence/subscribe.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/rooms/presence/subscribe.ts)_
+_See code: [src/commands/rooms/presence/subscribe.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/rooms/presence/subscribe.ts)_
 
 ## `ably rooms reactions`
 
@@ -4065,7 +4065,7 @@ EXAMPLES
   $ ably rooms reactions subscribe my-room
 ```
 
-_See code: [src/commands/rooms/reactions/index.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/rooms/reactions/index.ts)_
+_See code: [src/commands/rooms/reactions/index.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/rooms/reactions/index.ts)_
 
 ## `ably rooms reactions send ROOMID EMOJI`
 
@@ -4107,7 +4107,7 @@ EXAMPLES
   $ ably rooms reactions send my-room 😂 --pretty-json
 ```
 
-_See code: [src/commands/rooms/reactions/send.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/rooms/reactions/send.ts)_
+_See code: [src/commands/rooms/reactions/send.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/rooms/reactions/send.ts)_
 
 ## `ably rooms reactions subscribe ROOMID`
 
@@ -4145,7 +4145,7 @@ EXAMPLES
   $ ably rooms reactions subscribe my-room --pretty-json
 ```
 
-_See code: [src/commands/rooms/reactions/subscribe.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/rooms/reactions/subscribe.ts)_
+_See code: [src/commands/rooms/reactions/subscribe.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/rooms/reactions/subscribe.ts)_
 
 ## `ably rooms typing`
 
@@ -4164,7 +4164,7 @@ EXAMPLES
   $ ably rooms typing keystroke my-room
 ```
 
-_See code: [src/commands/rooms/typing/index.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/rooms/typing/index.ts)_
+_See code: [src/commands/rooms/typing/index.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/rooms/typing/index.ts)_
 
 ## `ably rooms typing keystroke ROOMID`
 
@@ -4207,7 +4207,7 @@ EXAMPLES
   $ ably rooms typing keystroke my-room --pretty-json
 ```
 
-_See code: [src/commands/rooms/typing/keystroke.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/rooms/typing/keystroke.ts)_
+_See code: [src/commands/rooms/typing/keystroke.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/rooms/typing/keystroke.ts)_
 
 ## `ably rooms typing subscribe ROOMID`
 
@@ -4247,7 +4247,7 @@ EXAMPLES
   $ ably rooms typing subscribe my-room --pretty-json
 ```
 
-_See code: [src/commands/rooms/typing/subscribe.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/rooms/typing/subscribe.ts)_
+_See code: [src/commands/rooms/typing/subscribe.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/rooms/typing/subscribe.ts)_
 
 ## `ably spaces`
 
@@ -4275,7 +4275,7 @@ COMMANDS
   ably spaces members           Commands for managing members in Ably Spaces
 ```
 
-_See code: [src/commands/spaces/index.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/spaces/index.ts)_
+_See code: [src/commands/spaces/index.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/spaces/index.ts)_
 
 ## `ably spaces cursors`
 
@@ -4299,7 +4299,7 @@ EXAMPLES
   $ ably spaces cursors get-all my-space
 ```
 
-_See code: [src/commands/spaces/cursors/index.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/spaces/cursors/index.ts)_
+_See code: [src/commands/spaces/cursors/index.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/spaces/cursors/index.ts)_
 
 ## `ably spaces cursors get-all SPACEID`
 
@@ -4337,7 +4337,7 @@ EXAMPLES
   $ ably spaces cursors get-all my-space --pretty-json
 ```
 
-_See code: [src/commands/spaces/cursors/get-all.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/spaces/cursors/get-all.ts)_
+_See code: [src/commands/spaces/cursors/get-all.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/spaces/cursors/get-all.ts)_
 
 ## `ably spaces cursors set SPACEID`
 
@@ -4394,7 +4394,7 @@ EXAMPLES
   $ ably spaces cursors set my-space --x 100 --y 200 --pretty-json
 ```
 
-_See code: [src/commands/spaces/cursors/set.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/spaces/cursors/set.ts)_
+_See code: [src/commands/spaces/cursors/set.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/spaces/cursors/set.ts)_
 
 ## `ably spaces cursors subscribe SPACEID`
 
@@ -4435,7 +4435,7 @@ EXAMPLES
   $ ably spaces cursors subscribe my-space --duration 30
 ```
 
-_See code: [src/commands/spaces/cursors/subscribe.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/spaces/cursors/subscribe.ts)_
+_See code: [src/commands/spaces/cursors/subscribe.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/spaces/cursors/subscribe.ts)_
 
 ## `ably spaces list`
 
@@ -4476,7 +4476,7 @@ EXAMPLES
   $ ably spaces list --pretty-json
 ```
 
-_See code: [src/commands/spaces/list.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/spaces/list.ts)_
+_See code: [src/commands/spaces/list.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/spaces/list.ts)_
 
 ## `ably spaces locations`
 
@@ -4504,7 +4504,7 @@ DESCRIPTION
   Spaces Locations API commands (Ably Spaces client-to-client location sharing)
 ```
 
-_See code: [src/commands/spaces/locations/index.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/spaces/locations/index.ts)_
+_See code: [src/commands/spaces/locations/index.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/spaces/locations/index.ts)_
 
 ## `ably spaces locations get-all SPACEID`
 
@@ -4544,7 +4544,7 @@ EXAMPLES
   $ ably spaces locations get-all my-space --pretty-json
 ```
 
-_See code: [src/commands/spaces/locations/get-all.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/spaces/locations/get-all.ts)_
+_See code: [src/commands/spaces/locations/get-all.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/spaces/locations/get-all.ts)_
 
 ## `ably spaces locations set SPACEID`
 
@@ -4584,7 +4584,7 @@ EXAMPLES
   $ ably spaces locations set my-space --location '{"sectionId":"section1"}'
 ```
 
-_See code: [src/commands/spaces/locations/set.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/spaces/locations/set.ts)_
+_See code: [src/commands/spaces/locations/set.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/spaces/locations/set.ts)_
 
 ## `ably spaces locations subscribe SPACEID`
 
@@ -4625,7 +4625,7 @@ EXAMPLES
   $ ably spaces locations subscribe my-space --duration 30
 ```
 
-_See code: [src/commands/spaces/locations/subscribe.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/spaces/locations/subscribe.ts)_
+_See code: [src/commands/spaces/locations/subscribe.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/spaces/locations/subscribe.ts)_
 
 ## `ably spaces locks`
 
@@ -4648,7 +4648,7 @@ EXAMPLES
   $ ably spaces locks get-all my-space
 ```
 
-_See code: [src/commands/spaces/locks/index.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/spaces/locks/index.ts)_
+_See code: [src/commands/spaces/locks/index.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/spaces/locks/index.ts)_
 
 ## `ably spaces locks acquire SPACEID LOCKID`
 
@@ -4686,7 +4686,7 @@ EXAMPLES
   $ ably spaces locks acquire my-space my-lock-id --data '{"type":"editor"}'
 ```
 
-_See code: [src/commands/spaces/locks/acquire.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/spaces/locks/acquire.ts)_
+_See code: [src/commands/spaces/locks/acquire.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/spaces/locks/acquire.ts)_
 
 ## `ably spaces locks get SPACEID LOCKID`
 
@@ -4725,7 +4725,7 @@ EXAMPLES
   $ ably spaces locks get my-space my-lock --pretty-json
 ```
 
-_See code: [src/commands/spaces/locks/get.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/spaces/locks/get.ts)_
+_See code: [src/commands/spaces/locks/get.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/spaces/locks/get.ts)_
 
 ## `ably spaces locks get-all SPACEID`
 
@@ -4763,7 +4763,7 @@ EXAMPLES
   $ ably spaces locks get-all my-space --pretty-json
 ```
 
-_See code: [src/commands/spaces/locks/get-all.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/spaces/locks/get-all.ts)_
+_See code: [src/commands/spaces/locks/get-all.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/spaces/locks/get-all.ts)_
 
 ## `ably spaces locks subscribe SPACEID`
 
@@ -4804,7 +4804,7 @@ EXAMPLES
   $ ably spaces locks subscribe my-space --duration 30
 ```
 
-_See code: [src/commands/spaces/locks/subscribe.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/spaces/locks/subscribe.ts)_
+_See code: [src/commands/spaces/locks/subscribe.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/spaces/locks/subscribe.ts)_
 
 ## `ably spaces members`
 
@@ -4823,7 +4823,7 @@ EXAMPLES
   $ ably spaces members enter my-space
 ```
 
-_See code: [src/commands/spaces/members/index.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/spaces/members/index.ts)_
+_See code: [src/commands/spaces/members/index.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/spaces/members/index.ts)_
 
 ## `ably spaces members enter SPACEID`
 
@@ -4864,7 +4864,7 @@ EXAMPLES
   $ ably spaces members enter my-space --duration 30
 ```
 
-_See code: [src/commands/spaces/members/enter.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/spaces/members/enter.ts)_
+_See code: [src/commands/spaces/members/enter.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/spaces/members/enter.ts)_
 
 ## `ably spaces members subscribe SPACEID`
 
@@ -4905,7 +4905,7 @@ EXAMPLES
   $ ably spaces members subscribe my-space --duration 30
 ```
 
-_See code: [src/commands/spaces/members/subscribe.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/spaces/members/subscribe.ts)_
+_See code: [src/commands/spaces/members/subscribe.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/spaces/members/subscribe.ts)_
 
 ## `ably status`
 
@@ -4926,7 +4926,7 @@ EXAMPLES
   $ ably status
 ```
 
-_See code: [src/commands/status.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/status.ts)_
+_See code: [src/commands/status.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/status.ts)_
 
 ## `ably support`
 
@@ -4952,7 +4952,7 @@ COMMANDS
   ably support info             General support resources and documentation links
 ```
 
-_See code: [src/commands/support/index.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/support/index.ts)_
+_See code: [src/commands/support/index.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/support/index.ts)_
 
 ## `ably support ask QUESTION`
 
@@ -4992,7 +4992,7 @@ EXAMPLES
   $ ably support ask --continue "Can you explain more about token capabilities?"
 ```
 
-_See code: [src/commands/support/ask.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/support/ask.ts)_
+_See code: [src/commands/support/ask.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/support/ask.ts)_
 
 ## `ably support contact`
 
@@ -5012,7 +5012,7 @@ EXAMPLES
   $ ably support contact
 ```
 
-_See code: [src/commands/support/contact.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/support/contact.ts)_
+_See code: [src/commands/support/contact.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/support/contact.ts)_
 
 ## `ably support info`
 
@@ -5032,7 +5032,7 @@ EXAMPLES
   $ ably support info
 ```
 
-_See code: [src/commands/support/info.ts](https://github.com/ably/ably-cli/blob/v0.12.0/src/commands/support/info.ts)_
+_See code: [src/commands/support/info.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/support/info.ts)_
 <!-- commandsstop -->
 
 # MCP Server

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ably/cli",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Ably CLI for Pub/Sub, Chat and Spaces",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/react-web-cli/README.md
+++ b/packages/react-web-cli/README.md
@@ -89,6 +89,8 @@ export default function MyTerminal() {
 | `maxReconnectAttempts` | number | No | 15 | Maximum reconnection attempts before giving up |
 | `resumeOnReload` | boolean | No | false | Whether to attempt to resume an existing session after page reload |
 | `enableSplitScreen` | boolean | No | false | Enable split-screen mode with a second independent terminal |
+| `ablyEndpoint` | string | No | - | Optional SDK endpoint client option |
+| `ablyControlHost` | string | No | - | Optional Control API hostname |
 
 *\* `ablyApiKey` is mandatory.  `ablyAccessToken` is optional and only needed for Control-API commands (e.g. accounts, apps, keys).
 

--- a/packages/react-web-cli/package.json
+++ b/packages/react-web-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ably/react-web-cli",
-  "version": "0.8.1",
+  "version": "0.13.0",
   "description": "React component for embedding the Ably CLI in a web terminal",
   "main": "dist/index.js",
   "module": "dist/index.mjs",


### PR DESCRIPTION
The prepares release 0.13.0 for supporting running the Web CLI in staging (https://github.com/ably/ably-cli/pull/87).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added optional props to the React terminal component to configure SDK endpoint and Control API host.

* Bug Fixes
  * CLI now correctly applies the endpoint when set via flag or environment variable.
  * Control API host is correctly configured when provided via environment variable.

* Documentation
  * Updated usage examples, version references, and documented the new props.

* Chores
  * Bumped version to 0.13.0 and updated changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->