### PR TITLE
chat: bump to 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     }
   },
   "dependencies": {
-    "@ably/chat": "^0.14.0",
+    "@ably/chat": "^1.0.0",
     "@ably/spaces": "^0.4.0",
     "@inquirer/prompts": "^5.1.3",
     "@modelcontextprotocol/sdk": "^1.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,8 +14,8 @@ importers:
   .:
     dependencies:
       '@ably/chat':
-        specifier: ^0.14.0
-        version: 0.14.0(ably@2.10.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^1.0.0
+        version: 1.0.0(ably@2.10.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@ably/spaces':
         specifier: ^0.4.0
         version: 0.4.0(ably@2.10.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -367,11 +367,11 @@ importers:
 
 packages:
 
-  '@ably/chat@0.14.0':
-    resolution: {integrity: sha512-9QsJdHVcyYDP0cTHXh7towHI9tM+SbmEMMVK10+0y1N1epl6FBSEeBDMn1fH5i73nxbKleUxjBltWiXlQz4InA==}
-    engines: {node: '>=18.0.0'}
+  '@ably/chat@1.0.0':
+    resolution: {integrity: sha512-001+DfhCFWTAD6CAZSltdIR9TMaznWsHOMyDN23vhPoFVGmM1nlXl9uTh3OE695pHfOrTuD/AqGC5J4qWYrrmA==}
+    engines: {node: '>=20.0.0'}
     peerDependencies:
-      ably: ^2.13.0
+      ably: ^2.14.0
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
     peerDependenciesMeta:
@@ -6415,7 +6415,7 @@ packages:
 
 snapshots:
 
-  '@ably/chat@0.14.0(ably@2.10.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@ably/chat@1.0.0(ably@2.10.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       ably: 2.10.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       async-mutex: 0.5.0

--- a/src/commands/rooms/messages/reactions/remove.ts
+++ b/src/commands/rooms/messages/reactions/remove.ts
@@ -196,7 +196,7 @@ export default class MessagesReactionsRemove extends ChatBaseCommand {
 
       // Use delete method instead of remove
       await chatRoom.messages.reactions.delete(
-        { serial: messageSerial }, 
+        messageSerial, 
         { 
           name: reaction,
           ...(flags.type && { type: REACTION_TYPE_MAP[flags.type] }),

--- a/src/commands/rooms/messages/reactions/send.ts
+++ b/src/commands/rooms/messages/reactions/send.ts
@@ -247,7 +247,7 @@ export default class MessagesReactionsSend extends ChatBaseCommand {
       );
 
       await chatRoom.messages.reactions.send(
-        { serial: messageSerial },
+        messageSerial,
         reactionParams,
       );
 

--- a/src/commands/rooms/messages/reactions/subscribe.ts
+++ b/src/commands/rooms/messages/reactions/subscribe.ts
@@ -1,16 +1,9 @@
-import { ChatClient, RoomStatus, Subscription, MessageReactionRawEvent, MessageReactionSummaryEvent } from "@ably/chat";
+import { ChatClient, RoomStatus, Subscription, MessageReactionRawEvent, MessageReactionSummaryEvent, MessageReactionSummary } from "@ably/chat";
 import { Args, Flags } from "@oclif/core";
 import * as Ably from "ably";
 import chalk from "chalk";
 
 import { ChatBaseCommand } from "../../../../chat-base-command.js";
-
-interface ReactionSummary {
-  messageSerial: string;
-  unique?: Record<string, { total: number; clientIds: string[] }>;
-  distinct?: Record<string, { total: number; clientIds: string[] }>;
-  multiple?: Record<string, { total: number; clientIds: Record<string, number> }>;
-}
 
 export default class MessagesReactionsSubscribe extends ChatBaseCommand {
   static override args = {
@@ -258,7 +251,7 @@ export default class MessagesReactionsSubscribe extends ChatBaseCommand {
           const timestamp = new Date().toISOString();
           
           // Format the summary for display
-          const summaryData: ReactionSummary = event.summary;
+          const summaryData: MessageReactionSummary = event.reactions;
           
           this.logCliEvent(
             flags,
@@ -283,23 +276,23 @@ export default class MessagesReactionsSubscribe extends ChatBaseCommand {
             );
           } else {
             this.log(
-              `[${chalk.dim(timestamp)}] ${chalk.green("📊")} Reaction summary for message ${chalk.cyan(event.summary.messageSerial)}:`,
+              `[${chalk.dim(timestamp)}] ${chalk.green("📊")} Reaction summary for message ${chalk.cyan(event.messageSerial)}:`,
             );
 
             // Display the summaries by type if they exist
-            if (event.summary.unique && Object.keys(event.summary.unique).length > 0) {
+            if (event.reactions.unique && Object.keys(event.reactions.unique).length > 0) {
               this.log(`  ${chalk.blue("Unique reactions:")}`);
-              this.displayReactionSummary(event.summary.unique, flags);
+              this.displayReactionSummary(event.reactions.unique, flags);
             }
             
-            if (event.summary.distinct && Object.keys(event.summary.distinct).length > 0) {
+            if (event.reactions.distinct && Object.keys(event.reactions.distinct).length > 0) {
               this.log(`  ${chalk.blue("Distinct reactions:")}`);
-              this.displayReactionSummary(event.summary.distinct, flags);
+              this.displayReactionSummary(event.reactions.distinct, flags);
             }
             
-            if (event.summary.multiple && Object.keys(event.summary.multiple).length > 0) {
+            if (event.reactions.multiple && Object.keys(event.reactions.multiple).length > 0) {
               this.log(`  ${chalk.blue("Multiple reactions:")}`);
-              this.displayMultipleReactionSummary(event.summary.multiple, flags);
+              this.displayMultipleReactionSummary(event.reactions.multiple, flags);
             }
           }
         });

--- a/src/commands/rooms/messages/send.ts
+++ b/src/commands/rooms/messages/send.ts
@@ -1,13 +1,13 @@
 import { Args, Flags } from "@oclif/core";
 import * as Ably from "ably"; // Import Ably
-import { ChatClient } from "@ably/chat";
+import { ChatClient, JsonObject } from "@ably/chat";
 
 import { ChatBaseCommand } from "../../../chat-base-command.js";
 
 // Define interfaces for the message send command
 interface MessageToSend {
   text: string;
-  metadata?: Record<string, unknown>;
+  metadata?: JsonObject;
   [key: string]: unknown;
 }
 

--- a/src/commands/rooms/reactions/send.ts
+++ b/src/commands/rooms/reactions/send.ts
@@ -1,4 +1,4 @@
-import { RoomStatus, ChatClient, RoomStatusChange } from "@ably/chat";
+import { RoomStatus, ChatClient, RoomStatusChange, JsonObject } from "@ably/chat";
 import { Args, Flags } from "@oclif/core";
 import * as Ably from "ably";
 import chalk from "chalk";
@@ -38,7 +38,7 @@ export default class RoomsReactionsSend extends ChatBaseCommand {
   private ablyClient: Ably.Realtime | null = null;
   private chatClient: ChatClient | null = null;
   private unsubscribeStatusFn: (() => void) | null = null;
-  private metadataObj: Record<string, unknown> | null = null;
+  private metadataObj: JsonObject | null = null;
 
   async finally(err: Error | undefined): Promise<void> {
     if (this.unsubscribeStatusFn) {


### PR DESCRIPTION
This change bumps the `@ably/chat` package to version 1.0.

[CHA-1218]

[CHA-1218]: https://ably.atlassian.net/browse/CHA-1218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Dependency Updates**
  * Upgraded @ably/chat from version 0.14.0 to version 1.0.0

* **Updates**
  * Adjusted reaction sending and deletion integration with message operations
  * Enhanced metadata type validation for improved consistency across message and reaction features
  * Refined how reaction data is organized and accessed

<!-- end of auto-generated comment: release notes by coderabbit.ai -->