### PR TITLE
Add push command group and move set-apns-p12 to it

### DIFF
--- a/src/base-command.ts
+++ b/src/base-command.ts
@@ -69,6 +69,8 @@ export const WEB_CLI_ANONYMOUS_RESTRICTED_COMMANDS = [
   // Integrations and queues are not available to anonymous users
   "integrations*",
   "queues*",
+
+  "push*", // push commands not available to anonymous users
 ];
 
 /* Commands not suitable for interactive mode */

--- a/src/commands/apps/index.ts
+++ b/src/commands/apps/index.ts
@@ -11,7 +11,6 @@ export default class AppsCommand extends BaseTopicCommand {
     "$ ably apps create",
     "$ ably apps update",
     "$ ably apps delete",
-    "$ ably apps set-apns-p12",
     "$ ably apps stats",
     "$ ably apps channel-rules list",
     "$ ably apps switch my-app",

--- a/src/commands/push/index.ts
+++ b/src/commands/push/index.ts
@@ -1,0 +1,12 @@
+import { BaseTopicCommand } from "../../base-topic-command.js";
+
+export default class PushIndexCommand extends BaseTopicCommand {
+  protected topicName = "push";
+  protected commandGroup = "push notifications";
+
+  static description = "Manage Ably Push Notifications";
+
+  static examples = [
+    "<%= config.bin %> <%= command.id %> set-apns-p12 APP_ID --certificate /path/to/cert.p12",
+  ];
+}

--- a/src/commands/push/set-apns-p12.ts
+++ b/src/commands/push/set-apns-p12.ts
@@ -4,7 +4,7 @@ import * as path from "node:path";
 
 import { ControlBaseCommand } from "../../control-base-command.js";
 
-export default class AppsSetApnsP12Command extends ControlBaseCommand {
+export default class PushSetApnsP12Command extends ControlBaseCommand {
   static args = {
     id: Args.string({
       description: "App ID to set the APNS certificate for",
@@ -16,9 +16,9 @@ export default class AppsSetApnsP12Command extends ControlBaseCommand {
     "Upload Apple Push Notification Service P12 certificate for an app";
 
   static examples = [
-    "$ ably apps set-apns-p12 app-id --certificate /path/to/certificate.p12",
-    '$ ably apps set-apns-p12 app-id --certificate /path/to/certificate.p12 --password "YOUR_CERTIFICATE_PASSWORD"',
-    "$ ably apps set-apns-p12 app-id --certificate /path/to/certificate.p12 --use-for-sandbox",
+    "$ ably push set-apns-p12 app-id --certificate /path/to/certificate.p12",
+    '$ ably push set-apns-p12 app-id --certificate /path/to/certificate.p12 --password "YOUR_CERTIFICATE_PASSWORD"',
+    "$ ably push set-apns-p12 app-id --certificate /path/to/certificate.p12 --use-for-sandbox",
   ];
 
   static flags = {
@@ -38,7 +38,7 @@ export default class AppsSetApnsP12Command extends ControlBaseCommand {
   };
 
   async run(): Promise<void> {
-    const { args, flags } = await this.parse(AppsSetApnsP12Command);
+    const { args, flags } = await this.parse(PushSetApnsP12Command);
 
     // Display authentication information
     this.showAuthInfoIfNeeded(flags);

--- a/test/unit/commands/push/set-apns-p12.test.ts
+++ b/test/unit/commands/push/set-apns-p12.test.ts
@@ -6,7 +6,7 @@ import { mkdirSync, writeFileSync, existsSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { getMockConfigManager } from "../../../helpers/mock-config-manager.js";
 
-describe("apps:set-apns-p12 command", () => {
+describe("push:set-apns-p12 command", () => {
   let testTempDir: string;
   let testCertFile: string;
 
@@ -39,7 +39,7 @@ describe("apps:set-apns-p12 command", () => {
         });
 
       const { stdout } = await runCommand(
-        ["apps:set-apns-p12", appId, "--certificate", testCertFile],
+        ["push:set-apns-p12", appId, "--certificate", testCertFile],
         import.meta.url,
       );
 
@@ -57,7 +57,7 @@ describe("apps:set-apns-p12 command", () => {
 
       const { stdout } = await runCommand(
         [
-          "apps:set-apns-p12",
+          "push:set-apns-p12",
           appId,
           "--certificate",
           testCertFile,
@@ -81,7 +81,7 @@ describe("apps:set-apns-p12 command", () => {
 
       const { stdout } = await runCommand(
         [
-          "apps:set-apns-p12",
+          "push:set-apns-p12",
           appId,
           "--certificate",
           testCertFile,
@@ -98,7 +98,7 @@ describe("apps:set-apns-p12 command", () => {
   describe("error handling", () => {
     it("should require app ID argument", async () => {
       const { error } = await runCommand(
-        ["apps:set-apns-p12", "--certificate", testCertFile],
+        ["push:set-apns-p12", "--certificate", testCertFile],
         import.meta.url,
       );
 
@@ -109,7 +109,7 @@ describe("apps:set-apns-p12 command", () => {
     it("should require certificate flag", async () => {
       const appId = getMockConfigManager().getCurrentAppId()!;
       const { error } = await runCommand(
-        ["apps:set-apns-p12", appId],
+        ["push:set-apns-p12", appId],
         import.meta.url,
       );
 
@@ -121,7 +121,7 @@ describe("apps:set-apns-p12 command", () => {
       const appId = getMockConfigManager().getCurrentAppId()!;
       const { error } = await runCommand(
         [
-          "apps:set-apns-p12",
+          "push:set-apns-p12",
           appId,
           "--certificate",
           "/nonexistent/path/cert.p12",
@@ -140,7 +140,7 @@ describe("apps:set-apns-p12 command", () => {
         .reply(400, { error: "Invalid certificate" });
 
       const { error } = await runCommand(
-        ["apps:set-apns-p12", appId, "--certificate", testCertFile],
+        ["push:set-apns-p12", appId, "--certificate", testCertFile],
         import.meta.url,
       );
 
@@ -155,7 +155,7 @@ describe("apps:set-apns-p12 command", () => {
         .reply(401, { error: "Unauthorized" });
 
       const { error } = await runCommand(
-        ["apps:set-apns-p12", appId, "--certificate", testCertFile],
+        ["push:set-apns-p12", appId, "--certificate", testCertFile],
         import.meta.url,
       );
 


### PR DESCRIPTION
https://ably.atlassian.net/browse/FTF-266

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Creates a dedicated push notifications command group and migrates APNS certificate management into it.
> 
> - New `push` topic with `push:set-apns-p12` command; examples and command class names/parse references updated
> - Removed `apps set-apns-p12` example from `apps` topic
> - Added anonymous web CLI restriction for `push*` commands in `src/base-command.ts`
> - New/updated unit tests under `test/unit/commands/push/set-apns-p12.test.ts` validating success and error paths
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb82c9604d9b47aacf4ccbc9202f44649a046500. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new push notifications command group to manage Ably Push Notifications settings and features.
  * Added the push:set-apns-p12 command to configure APNS P12 certificates within the new command group.

* **Chores**
  * Reorganized CLI structure by moving APNS certificate configuration command from the apps group to the new push notifications group.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->