### PR TITLE
[FTF-198] Send close code on react-web-cli panel unmount

### DIFF
--- a/packages/react-web-cli/src/AblyCliTerminal.test.tsx
+++ b/packages/react-web-cli/src/AblyCliTerminal.test.tsx
@@ -2557,3 +2557,74 @@ describe("AblyCliTerminal - Initial Command Execution", () => {
     expect(hasTestCmd).toBe(true);
   }, 15_000);
 });
+
+describe("AblyCliTerminal - Unmount cleanup", () => {
+  test("closes socket normally on unmount (no special code for resume support)", async () => {
+    mockClose.mockClear();
+
+    const { unmount } = render(
+      <AblyCliTerminal
+        websocketUrl={TEST_WEBSOCKET_URL}
+        signedConfig={DEFAULT_SIGNED_CONFIG}
+        signature={DEFAULT_SIGNATURE}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mockSocketInstance).toBeTruthy();
+      expect(mockSocketInstance.readyState).toBe(WebSocket.OPEN);
+    });
+
+    unmount();
+
+    expect(mockClose).toHaveBeenCalledWith();
+  });
+
+  test("does not call close if socket already closing", async () => {
+    mockClose.mockClear();
+
+    const { unmount } = render(
+      <AblyCliTerminal
+        websocketUrl={TEST_WEBSOCKET_URL}
+        signedConfig={DEFAULT_SIGNED_CONFIG}
+        signature={DEFAULT_SIGNATURE}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mockSocketInstance).toBeTruthy();
+      expect(mockSocketInstance.readyState).toBe(WebSocket.OPEN);
+    });
+
+    mockSocketInstance.readyState = WebSocket.CLOSING;
+
+    unmount();
+
+    expect(mockClose).not.toHaveBeenCalled();
+  });
+
+  test("terminateSession() sends close code 4001 for immediate cleanup", async () => {
+    mockClose.mockClear();
+    const terminalRef = React.createRef<AblyCliTerminalHandle>();
+
+    render(
+      <AblyCliTerminal
+        ref={terminalRef}
+        websocketUrl={TEST_WEBSOCKET_URL}
+        signedConfig={DEFAULT_SIGNED_CONFIG}
+        signature={DEFAULT_SIGNATURE}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mockSocketInstance).toBeTruthy();
+      expect(mockSocketInstance.readyState).toBe(WebSocket.OPEN);
+    });
+
+    act(() => {
+      terminalRef.current?.terminateSession();
+    });
+
+    expect(mockClose).toHaveBeenCalledWith(4001, "user-closed-primary");
+  });
+});

--- a/packages/react-web-cli/src/AblyCliTerminal.tsx
+++ b/packages/react-web-cli/src/AblyCliTerminal.tsx
@@ -142,6 +142,8 @@ export interface AblyCliTerminalHandle {
   setSplitPosition: (percent: number) => void;
   /** Read current split state. */
   getSplitState: () => { isSplit: boolean; splitPosition: number };
+  /** Terminate the session immediately. Call this before unmounting when user explicitly closes the panel. */
+  terminateSession: () => void;
 }
 
 // Use shared debug logging
@@ -340,6 +342,23 @@ const AblyCliTerminalInner = (
         setSplitPosition(clamped);
       },
       getSplitState: () => ({ isSplit, splitPosition }),
+      terminateSession: () => {
+        debugLog(
+          "[AblyCLITerminal] terminateSession called - closing with code 4001",
+        );
+        if (
+          socketReference.current &&
+          socketReference.current.readyState < WebSocket.CLOSING
+        ) {
+          socketReference.current.close(4001, "user-closed-primary");
+        }
+        if (
+          secondarySocketReference.current &&
+          secondarySocketReference.current.readyState < WebSocket.CLOSING
+        ) {
+          secondarySocketReference.current.close(4001, "user-closed-secondary");
+        }
+      },
     }),
     [
       enableSplitScreen,
@@ -2378,16 +2397,15 @@ const AblyCliTerminalInner = (
         term.current.dispose();
         term.current = null;
       }
+      grCancelReconnect();
       if (
         socketReference.current &&
         socketReference.current.readyState < WebSocket.CLOSING
       ) {
-        // close websocket
         debugLog("[AblyCLITerminal] Closing WebSocket on unmount.");
         socketReference.current.close();
       }
-      grResetState(); // Ensure global state is clean
-      clearConnectionTimeout(); // Clear any pending connection timeout
+      clearConnectionTimeout();
     };
   }, []); // Empty deps - this effect only runs once on mount to initialize the terminal
 


### PR DESCRIPTION
See [FTF-198] This PR ensures the terminal component signals session closure correctly over WebSocket, while preserving session resume on navigation/reload.

Companion server PR: https://github.com/ably/cli-terminal-server/pull/105

---

### Problem

The original implementation sent close code `4001` on every component unmount. This told the server to immediately destroy the session — but unmount also fires on page navigation and reloads, which broke `resumeOnReload` behavior. Additionally, the close handler didn't recognize the custom close reason, causing error UI to flash before unmount.

### Solution

**Unmount** calls `grCancelReconnect()` then `close()` with no special code. This prevents post-unmount reconnect attempts while preserving the server grace period for session resume.

**`terminateSession()`** — a new method on the `AblyCliTerminalHandle` ref — sends `close(4001, "user-closed-primary")` / `close(4001, "user-closed-secondary")`. These use existing recognized close reasons so `handleWebSocketClose` returns early (no error UI, no sessionId clearing), while the server still receives the 4001 code for immediate cleanup.

### Changes

| File | What changed |
|---|---|
| `AblyCliTerminal.tsx` | Unmount calls `grCancelReconnect()` before `close()`; `terminateSession()` uses recognized close reasons |
| `AblyCliTerminal.test.tsx` | Tests use correct `signedConfig`/`signature` props and `waitFor` instead of `setTimeout` |

### Usage

```tsx
const terminalRef = useRef<AblyCliTerminalHandle>(null);

// When user clicks "close panel":
terminalRef.current?.terminateSession();
// Then unmount the component
```

[FTF-198]: https://ably.atlassian.net/browse/FTF-198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes WebSocket lifecycle/close semantics and introduces a new imperative API; mistakes could cause session leaks or break resume/reconnect behavior, but scope is limited to the terminal component and is covered by new unit tests.
> 
> **Overview**
> Adjusts `AblyCliTerminal` unmount behavior to **cancel pending reconnects** and then `close()` the WebSocket *without* the special `4001` code, preventing unmount/navigation from forcing server-side session destruction and improving `resumeOnReload` support.
> 
> Adds a new imperative handle method `terminateSession()` that explicitly closes the primary/secondary sockets with `close(4001, "user-closed-*")` for immediate server cleanup when the user intentionally closes the panel.
> 
> Updates tests to cover unmount cleanup semantics and validate the new `terminateSession()` close code/reason behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 22e6b6582fa071f397eef6a56f50068662974c88. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->