### PR TITLE
fix: update cursor set command examples to show correct usage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4145,7 +4145,7 @@ DESCRIPTION
   Commands for interacting with Cursors in Ably Spaces
 
 EXAMPLES
-  $ ably spaces cursors set my-space --position '{"x": 100, "y": 200}' --data '{"color": "red"}'
+  $ ably spaces cursors set my-space --x 100 --y 200 --data '{"color": "red"}'
 
   $ ably spaces cursors subscribe my-space
 

--- a/src/commands/spaces/cursors.ts
+++ b/src/commands/spaces/cursors.ts
@@ -5,7 +5,7 @@ export default class SpacesCursors extends Command {
     "Commands for interacting with Cursors in Ably Spaces";
 
   static override examples: Command.Example[] = [
-    `$ ably spaces cursors set my-space --position '{"x": 100, "y": 200}' --data '{"color": "red"}'`,
+    `$ ably spaces cursors set my-space --x 100 --y 200 --data '{"color": "red"}'`,
     `$ ably spaces cursors subscribe my-space`,
     `$ ably spaces cursors get-all my-space`,
   ];

--- a/src/commands/spaces/cursors/index.ts
+++ b/src/commands/spaces/cursors/index.ts
@@ -4,7 +4,7 @@ export default class SpacesCursorsIndex extends Command {
   static override description = "Commands for cursor management in Ably Spaces";
 
   static override examples = [
-    "$ ably spaces cursors set my-space",
+    "$ ably spaces cursors set my-space --x 100 --y 200",
     "$ ably spaces cursors subscribe my-space",
     "$ ably spaces cursors get-all my-space",
   ];


### PR DESCRIPTION
The spaces command examples were showing the usage of a `--position` flag which doesn't actually exist. Updated to show correct usage or `--x` and `--y` flags.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs/example-only changes with no functional code or API behavior modifications.
> 
> **Overview**
> Updates `ably spaces cursors set` examples in `README.md`, `src/commands/spaces/cursors.ts`, and `src/commands/spaces/cursors/index.ts` to show `--x`/`--y` coordinate flags (and `--data`) instead of the nonexistent `--position` flag, aligning the help output with actual CLI usage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7328bf7e90d4958cada8e9f545cf0b4e9e6e63b1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Spaces Cursors set command examples throughout the documentation, replacing the combined position payload format with separate --x and --y coordinate flags to provide clearer guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->