### PR TITLE
[DX-725] Add extras in the message for channel push notifications

### DIFF
--- a/src/commands/channels/publish.ts
+++ b/src/commands/channels/publish.ts
@@ -31,6 +31,7 @@ export default class ChannelsPublish extends AblyBaseCommand {
     '$ ably channels publish --transport realtime my-channel "Using realtime transport"',
     '$ ably channels publish my-channel "Hello World" --json',
     '$ ably channels publish my-channel "Hello World" --pretty-json',
+    '$ ably channels publish my-channel \'{"data":"Push notification","extras":{"push":{"notification":{"title":"Hello","body":"World"}}}}\'',
   ];
 
   static override flags = {
@@ -206,11 +207,22 @@ export default class ChannelsPublish extends AblyBaseCommand {
       delete messageData.name;
     }
 
+    // Add extras if provided in the message data (before processing data)
+    if (
+      messageData.extras &&
+      typeof messageData.extras === "object" &&
+      Object.keys(messageData.extras).length > 0
+    ) {
+      message.extras = messageData.extras;
+      // Remove extras from messageData to avoid duplication in data
+      delete messageData.extras;
+    }
+
     // If data is explicitly provided in the message, use it
     if ("data" in messageData) {
       message.data = messageData.data;
-    } else {
-      // Otherwise use the entire messageData as the data
+    } else if (Object.keys(messageData).length > 0) {
+      // Otherwise use the entire messageData object (not empty) as the data
       message.data = messageData;
     }
 

--- a/test/unit/commands/channels/publish.test.ts
+++ b/test/unit/commands/channels/publish.test.ts
@@ -399,4 +399,82 @@ describe("ChannelsPublish", function () {
       expect(stdout).toMatch(/error/i);
     });
   });
+
+  describe("should publish a message with data and extras", function () {
+    it("should include extras.push when provided in message data", async function () {
+      const restMock = getMockAblyRest();
+      const channel = restMock.channels._getChannel("test-channel");
+
+      await runCommand(
+        [
+          "channels:publish",
+          "test-channel",
+          '{"data":"hello","extras":{"push":{"notification":{"title":"Test","body":"Push notification"}}}}',
+          "--transport",
+          "rest",
+        ],
+        import.meta.url,
+      );
+
+      expect(channel.publish).toHaveBeenCalledOnce();
+      const publishArgs = channel.publish.mock.calls[0][0];
+      expect(publishArgs).toHaveProperty("data", "hello");
+      expect(publishArgs).toHaveProperty("extras");
+      expect(publishArgs.extras).toHaveProperty("push");
+      expect(publishArgs.extras.push).toEqual({
+        notification: { title: "Test", body: "Push notification" },
+      });
+    });
+
+    it("should publish a message when only extras is provided without data", async function () {
+      const restMock = getMockAblyRest();
+      const channel = restMock.channels._getChannel("test-channel");
+
+      await runCommand(
+        [
+          "channels:publish",
+          "test-channel",
+          '{"extras":{"push":{"notification":{"title":"Extras only","body":"No data field"}}}}',
+          "--transport",
+          "rest",
+        ],
+        import.meta.url,
+      );
+
+      expect(channel.publish).toHaveBeenCalledOnce();
+      const publishArgs = channel.publish.mock.calls[0][0];
+      expect(publishArgs).toHaveProperty("extras");
+      expect(publishArgs.extras).toHaveProperty("push");
+      expect(publishArgs.extras.push).toEqual({
+        notification: { title: "Extras only", body: "No data field" },
+      });
+      expect(publishArgs).not.toHaveProperty("data");
+    });
+
+    it("should preserve name when extras is provided without data", async function () {
+      const restMock = getMockAblyRest();
+      const channel = restMock.channels._getChannel("test-channel");
+
+      await runCommand(
+        [
+          "channels:publish",
+          "test-channel",
+          '{"name":"eventName","extras":{"push":{"notification":{"title":"With name","body":"No data field"}}}}',
+          "--transport",
+          "rest",
+        ],
+        import.meta.url,
+      );
+
+      expect(channel.publish).toHaveBeenCalledOnce();
+      const publishArgs = channel.publish.mock.calls[0][0];
+      expect(publishArgs).toHaveProperty("name", "eventName");
+      expect(publishArgs).toHaveProperty("extras");
+      expect(publishArgs.extras).toHaveProperty("push");
+      expect(publishArgs.extras.push).toEqual({
+        notification: { title: "With name", body: "No data field" },
+      });
+      expect(publishArgs).not.toHaveProperty("data");
+    });
+  });
 });


### PR DESCRIPTION
It is not support of push notifications with deviceId or clientId. Just have added `extras.push` support for channel pushes. Tried locally with

`./bin/run.js channels publish exampleChannel1 '{"data":"Test","extras":{"push":{"notification":{"title":"Hello","body":"World!"}}}}' --api-key "***"`

and it works.

Jira issue: https://ably.atlassian.net/browse/DX-725


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive change to CLI message shaping plus unit tests; low risk aside from potential edge cases in how JSON input is mapped into `data` vs `extras`.
> 
> **Overview**
> `ably channels publish` now supports publishing messages with `extras` (notably `extras.push` for push notification metadata) when provided in the JSON payload, and avoids duplicating `extras` inside `data`.
> 
> Message preparation also skips setting `data` when the JSON payload contains only `extras`/`name` (i.e., no `data` and nothing else), and the test suite adds coverage for `extras`+`data`, `extras`-only, and `name`+`extras` scenarios.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d3575be52cec1d8d1cb02352d7b8c6bcd2d983d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for including push notification metadata (extras.push) in Ably channel message publish payloads, enabling push notification data to be transmitted alongside messages.

* **Documentation**
  * Updated product requirements documentation to reflect the new push notification metadata publishing capability.

* **Tests**
  * Added test coverage to verify push notification metadata is correctly passed through the publish flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->