### PR TITLE
Fix production WebSocket URL for web-cli

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,7 @@ on:
       - 'pnpm-lock.yaml'
       - 'tsconfig.json'
       - 'scripts/**'
+      - 'examples/**'
       - '.github/workflows/test.yml'
   pull_request:
     branches: [ main ]
@@ -20,6 +21,7 @@ on:
       - 'pnpm-lock.yaml'
       - 'tsconfig.json'
       - 'scripts/**'
+      - 'examples/**'
       - '.github/workflows/test.yml'
 
 jobs:

--- a/examples/web-cli/src/App.tsx
+++ b/examples/web-cli/src/App.tsx
@@ -15,7 +15,7 @@ interface CliWindow extends Window {
 }
 
 // Default WebSocket URL - use public endpoint for production, localhost for development
-const DEFAULT_PRODUCTION_WEBSOCKET_URL = "wss://web-cli.ably.com";
+const DEFAULT_PRODUCTION_WEBSOCKET_URL = "wss://web-cli-terminal.ably.com";
 const DEFAULT_DEVELOPMENT_WEBSOCKET_URL = "wss://web-cli-terminal.ably-dev.com";
 
 // Get WebSocket URL from query parameters only


### PR DESCRIPTION
Updated to the new production endpoint.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk config change: updates the default production WebSocket URL used by the `examples/web-cli` app and expands CI triggers to include `examples/**`. Main risk is misconfiguration causing the example web client to connect to the wrong production endpoint.
> 
> **Overview**
> Updates the `examples/web-cli` default production WebSocket URL to use the new `wss://web-cli-terminal.ably.com` endpoint.
> 
> Adjusts the `Run Tests` GitHub Actions workflow path filters so pushes/PRs that change `examples/**` also trigger the test job.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 64711741205fd3d3c6560ba47a4b25427a832ea1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the default production WebSocket endpoint for improved service connectivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->