### PR TITLE
[DX-967] Adds more happy path E2E tests

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -18,7 +18,7 @@ jobs:
     env:
       NO_COLOR: 1
       E2E_ABLY_API_KEY: ${{ secrets.E2E_ABLY_API_KEY }}
-      E2E_ABLY_ACCESS_TOKEN: ${{ secrets.E2E_ABLY_ACCESS_TOKEN }}
+      E2E_ABLY_ACCESS_TOKEN: ${{ secrets.E2E_ABLY_ABLY_ACCESS_TOKEN }}
       TERMINAL_SERVER_SIGNING_SECRET: ${{ secrets.TERMINAL_SERVER_SIGNING_SECRET }}
       E2E_TESTS: true
 
@@ -69,7 +69,7 @@ jobs:
         run: |
           echo "ABLY_API_KEY=${{ secrets.E2E_ABLY_API_KEY }}" > .env.test
           echo "E2E_ABLY_API_KEY=${{ secrets.E2E_ABLY_API_KEY }}" >> .env.test
-          echo "E2E_ABLY_ACCESS_TOKEN=${{ secrets.E2E_ABLY_ACCESS_TOKEN }}" >> .env.test
+          echo "E2E_ABLY_ACCESS_TOKEN=${{ secrets.E2E_ABLY_ABLY_ACCESS_TOKEN }}" >> .env.test
           echo "TERMINAL_SERVER_SIGNING_SECRET=${{ secrets.TERMINAL_SERVER_SIGNING_SECRET }}" >> .env.test
 
       - name: Run All E2E CLI Tests

--- a/.github/workflows/e2e-web-cli-parallel.yml
+++ b/.github/workflows/e2e-web-cli-parallel.yml
@@ -85,7 +85,7 @@ jobs:
     env:
       NO_COLOR: 1
       E2E_ABLY_API_KEY: ${{ secrets.E2E_ABLY_API_KEY }}
-      E2E_ABLY_ACCESS_TOKEN: ${{ secrets.E2E_ABLY_ACCESS_TOKEN }}
+      E2E_ABLY_ACCESS_TOKEN: ${{ secrets.E2E_ABLY_ABLY_ACCESS_TOKEN }}
       TERMINAL_SERVER_SIGNING_SECRET: ${{ secrets.TERMINAL_SERVER_SIGNING_SECRET }}
       E2E_TESTS: true
       HEADLESS: true
@@ -150,7 +150,7 @@ jobs:
     env:
       NO_COLOR: 1
       E2E_ABLY_API_KEY: ${{ secrets.E2E_ABLY_API_KEY }}
-      E2E_ABLY_ACCESS_TOKEN: ${{ secrets.E2E_ABLY_ACCESS_TOKEN }}
+      E2E_ABLY_ACCESS_TOKEN: ${{ secrets.E2E_ABLY_ABLY_ACCESS_TOKEN }}
       TERMINAL_SERVER_SIGNING_SECRET: ${{ secrets.TERMINAL_SERVER_SIGNING_SECRET }}
       E2E_TESTS: true
       HEADLESS: true
@@ -216,7 +216,7 @@ jobs:
     env:
       NO_COLOR: 1
       E2E_ABLY_API_KEY: ${{ secrets.E2E_ABLY_API_KEY }}
-      E2E_ABLY_ACCESS_TOKEN: ${{ secrets.E2E_ABLY_ACCESS_TOKEN }}
+      E2E_ABLY_ACCESS_TOKEN: ${{ secrets.E2E_ABLY_ABLY_ACCESS_TOKEN }}
       TERMINAL_SERVER_SIGNING_SECRET: ${{ secrets.TERMINAL_SERVER_SIGNING_SECRET }}
       E2E_TESTS: true
       HEADLESS: true
@@ -282,7 +282,7 @@ jobs:
     env:
       NO_COLOR: 1
       E2E_ABLY_API_KEY: ${{ secrets.E2E_ABLY_API_KEY }}
-      E2E_ABLY_ACCESS_TOKEN: ${{ secrets.E2E_ABLY_ACCESS_TOKEN }}
+      E2E_ABLY_ACCESS_TOKEN: ${{ secrets.E2E_ABLY_ABLY_ACCESS_TOKEN }}
       # Terminal Server Signing Secret is intentionally not set
       # Rate limit test should NOT use terminal server signing secret.
       E2E_TESTS: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,16 +64,16 @@ jobs:
         run: pnpm test:unit
         env:
           E2E_ABLY_API_KEY: ${{ secrets.E2E_ABLY_API_KEY }}
-          E2E_ABLY_ACCESS_TOKEN: ${{ secrets.E2E_ABLY_ACCESS_TOKEN }}
+          E2E_ABLY_ACCESS_TOKEN: ${{ secrets.E2E_ABLY_ABLY_ACCESS_TOKEN }}
 
       - name: Run CLI Hooks Unit Tests
         run: pnpm test:hooks
         env:
           E2E_ABLY_API_KEY: ${{ secrets.E2E_ABLY_API_KEY }}
-          E2E_ABLY_ACCESS_TOKEN: ${{ secrets.E2E_ABLY_ACCESS_TOKEN }}
+          E2E_ABLY_ACCESS_TOKEN: ${{ secrets.E2E_ABLY_ABLY_ACCESS_TOKEN }}
 
       - name: Run CLI Integration Tests
         run: pnpm test:integration
         env:
           E2E_ABLY_API_KEY: ${{ secrets.E2E_ABLY_API_KEY }}
-          E2E_ABLY_ACCESS_TOKEN: ${{ secrets.E2E_ABLY_ACCESS_TOKEN }}
+          E2E_ABLY_ACCESS_TOKEN: ${{ secrets.E2E_ABLY_ABLY_ACCESS_TOKEN }}

--- a/src/base-command.ts
+++ b/src/base-command.ts
@@ -9,6 +9,10 @@ import {
   createConfigManager,
 } from "./services/config-manager.js";
 import { ControlApi } from "./services/control-api.js";
+import {
+  extractAppIdFromApiKey,
+  extractKeyNameFromApiKey,
+} from "./utils/api-key.js";
 import { CommandError } from "./errors/command-error.js";
 import { getFriendlyAblyErrorHint } from "./utils/errors.js";
 import { coreGlobalFlags } from "./flags.js";
@@ -665,7 +669,7 @@ export abstract class AblyBaseCommand extends InteractiveBaseCommand {
           const apiKey =
             flags["api-key"] || this.configManager.getApiKey(appId);
           if (apiKey) {
-            const keyId = apiKey.split(":")[0]!; // Extract key ID (part before colon)
+            const keyId = extractKeyNameFromApiKey(apiKey);
             const keyName =
               this.configManager.getKeyName(appId) || "Default Key";
             // Format the full key name (app_id.key_id)
@@ -731,12 +735,11 @@ export abstract class AblyBaseCommand extends InteractiveBaseCommand {
       }
 
       // Debug log the API key format (masking the secret part)
-      const keyParts = apiKey.split(":");
-      const maskedKey = keyParts.length > 1 ? `${keyParts[0]}:***` : apiKey;
+      const keyName = extractKeyNameFromApiKey(apiKey);
+      const maskedKey = keyName ? `${keyName}:***` : apiKey;
       this.debug(`Using API key format: ${maskedKey}`);
 
-      // The app ID is the part before the first period in the key
-      const appId = apiKey.split(".")[0] || "";
+      const appId = extractAppIdFromApiKey(apiKey);
       if (!appId) {
         this.log("Failed to extract app ID from API key");
         return null;
@@ -752,7 +755,7 @@ export abstract class AblyBaseCommand extends InteractiveBaseCommand {
 
     // When apiKey comes from ABLY_API_KEY env var but appId is missing, extract it from the key
     if (apiKey && !appId) {
-      appId = apiKey.split(".")[0] || "";
+      appId = extractAppIdFromApiKey(apiKey);
     }
 
     // If we have both, return them

--- a/src/base-command.ts
+++ b/src/base-command.ts
@@ -755,6 +755,15 @@ export abstract class AblyBaseCommand extends InteractiveBaseCommand {
       return { apiKey, appId };
     }
 
+    // Fall back to ABLY_API_KEY environment variable (for CI/scripting)
+    const envApiKey = process.env.ABLY_API_KEY;
+    if (envApiKey) {
+      const envAppId = envApiKey.split(".")[0] || "";
+      if (envAppId) {
+        return { apiKey: envApiKey, appId: envAppId };
+      }
+    }
+
     // Get access token for control API
     const accessToken =
       process.env.ABLY_ACCESS_TOKEN || this.configManager.getAccessToken();

--- a/src/base-command.ts
+++ b/src/base-command.ts
@@ -750,18 +750,14 @@ export abstract class AblyBaseCommand extends InteractiveBaseCommand {
     let appId = flags.app || this.configManager.getCurrentAppId();
     let apiKey = this.configManager.getApiKey(appId);
 
+    // When apiKey comes from ABLY_API_KEY env var but appId is missing, extract it from the key
+    if (apiKey && !appId) {
+      appId = apiKey.split(".")[0] || "";
+    }
+
     // If we have both, return them
     if (appId && apiKey) {
       return { apiKey, appId };
-    }
-
-    // Fall back to ABLY_API_KEY environment variable (for CI/scripting)
-    const envApiKey = process.env.ABLY_API_KEY;
-    if (envApiKey) {
-      const envAppId = envApiKey.split(".")[0] || "";
-      if (envAppId) {
-        return { apiKey: envApiKey, appId: envAppId };
-      }
     }
 
     // Get access token for control API

--- a/src/commands/accounts/current.ts
+++ b/src/commands/accounts/current.ts
@@ -1,6 +1,10 @@
 import chalk from "chalk";
 
 import { ControlBaseCommand } from "../../control-base-command.js";
+import {
+  extractAppIdFromApiKey,
+  extractKeyNameFromApiKey,
+} from "../../utils/api-key.js";
 import { errorMessage } from "../../utils/errors.js";
 import { ControlApi } from "../../services/control-api.js";
 import { formatLabel } from "../../utils/output.js";
@@ -68,7 +72,8 @@ export default class AccountsCurrent extends ControlBaseCommand {
         const apiKey = this.configManager.getApiKey(currentAppId);
         if (apiKey) {
           const keyId =
-            this.configManager.getKeyId(currentAppId) || apiKey.split(":")[0]!;
+            this.configManager.getKeyId(currentAppId) ||
+            extractKeyNameFromApiKey(apiKey);
           const keyName =
             this.configManager.getKeyName(currentAppId) || "Unnamed key";
           const formattedKeyName = keyId.includes(".")
@@ -198,8 +203,8 @@ export default class AccountsCurrent extends ControlBaseCommand {
         let keyId = "";
 
         if (apiKey) {
-          appId = apiKey.split(".")[0]!;
-          keyId = apiKey.split(":")[0]!; // This includes APP_ID.KEY_ID
+          appId = extractAppIdFromApiKey(apiKey);
+          keyId = extractKeyNameFromApiKey(apiKey);
         }
 
         this.log(

--- a/src/commands/apps/create.ts
+++ b/src/commands/apps/create.ts
@@ -73,14 +73,16 @@ export default class AppsCreateCommand extends ControlBaseCommand {
         this.log(`${formatLabel("Updated")} ${this.formatDate(app.modified)}`);
       }
 
-      // Automatically switch to the newly created app
-      this.configManager.setCurrentApp(app.id);
-      this.configManager.storeAppInfo(app.id, { appName: app.name });
+      // Automatically switch to the newly created app if a local account exists
+      if (this.configManager.getCurrentAccount()) {
+        this.configManager.setCurrentApp(app.id);
+        this.configManager.storeAppInfo(app.id, { appName: app.name });
 
-      this.logSuccessMessage(
-        `Automatically switched to app ${formatResource(app.name)} (${app.id}).`,
-        flags,
-      );
+        this.logSuccessMessage(
+          `Automatically switched to app ${formatResource(app.name)} (${app.id}).`,
+          flags,
+        );
+      }
     } catch (error) {
       this.fail(error, flags, "appCreate");
     }

--- a/src/commands/apps/current.ts
+++ b/src/commands/apps/current.ts
@@ -1,6 +1,10 @@
 import chalk from "chalk";
 
 import { ControlBaseCommand } from "../../control-base-command.js";
+import {
+  extractAppIdFromApiKey,
+  extractKeyNameFromApiKey,
+} from "../../utils/api-key.js";
 import { errorMessage } from "../../utils/errors.js";
 import { formatLabel } from "../../utils/output.js";
 
@@ -57,7 +61,8 @@ export default class AppsCurrent extends ControlBaseCommand {
 
         if (apiKey) {
           const keyId =
-            this.configManager.getKeyId(currentAppId) || apiKey.split(":")[0]!;
+            this.configManager.getKeyId(currentAppId) ||
+            extractKeyNameFromApiKey(apiKey);
           const keyLabel =
             this.configManager.getKeyName(currentAppId) || "Unnamed key";
           const keyName = keyId.includes(".")
@@ -94,7 +99,8 @@ export default class AppsCurrent extends ControlBaseCommand {
         if (apiKey) {
           // Extract the key ID and format the full key name (app_id.key_id)
           const keyId =
-            this.configManager.getKeyId(currentAppId) || apiKey.split(":")[0]!;
+            this.configManager.getKeyId(currentAppId) ||
+            extractKeyNameFromApiKey(apiKey);
           const keyLabel =
             this.configManager.getKeyName(currentAppId) || "Unnamed key";
 
@@ -137,9 +143,8 @@ export default class AppsCurrent extends ControlBaseCommand {
       );
     }
 
-    // API key format is [APP_ID].[KEY_ID]:[KEY_SECRET]
-    const appId = apiKey.split(".")[0]!;
-    const keyId = apiKey.split(":")[0]!; // This includes APP_ID.KEY_ID
+    const appId = extractAppIdFromApiKey(apiKey);
+    const keyId = extractKeyNameFromApiKey(apiKey);
 
     try {
       // Create a control API instance using the base class method

--- a/src/commands/auth/keys/current.ts
+++ b/src/commands/auth/keys/current.ts
@@ -2,6 +2,10 @@ import { Flags } from "@oclif/core";
 import chalk from "chalk";
 
 import { ControlBaseCommand } from "../../../control-base-command.js";
+import {
+  extractAppIdFromApiKey,
+  extractKeyNameFromApiKey,
+} from "../../../utils/api-key.js";
 import { resolveCurrentKeyName } from "../../../utils/key-parsing.js";
 import { formatLabel } from "../../../utils/output.js";
 
@@ -45,8 +49,8 @@ export default class KeysCurrentCommand extends ControlBaseCommand {
       );
     }
 
-    // Extract the key ID (part before the colon)
-    const keyId = this.configManager.getKeyId(appId) || apiKey.split(":")[0]!;
+    const keyId =
+      this.configManager.getKeyId(appId) || extractKeyNameFromApiKey(apiKey);
     const keyLabel = this.configManager.getKeyName(appId) || "Unnamed key";
     const appName = this.configManager.getAppName(appId) || appId;
 
@@ -98,8 +102,8 @@ export default class KeysCurrentCommand extends ControlBaseCommand {
     }
 
     // Parse components from the API key
-    const appId = apiKey.split(".")[0]!;
-    const keyComponents = apiKey.split(":")[0]!.split(".");
+    const appId = extractAppIdFromApiKey(apiKey);
+    const keyComponents = extractKeyNameFromApiKey(apiKey).split(".");
     const keyId = keyComponents.length > 1 ? keyComponents[1] : null;
     const keyName = `${appId}.${keyId || ""}`;
 

--- a/src/commands/logs/subscribe.ts
+++ b/src/commands/logs/subscribe.ts
@@ -60,15 +60,6 @@ export default class LogsSubscribe extends AblyBaseCommand {
         includeUserFriendlyMessages: true,
       });
 
-      // Get the logs channel
-      const appConfig = await this.ensureAppAndKey(flags);
-      if (!appConfig) {
-        this.fail(
-          "Unable to determine app configuration",
-          flags,
-          "logSubscribe",
-        );
-      }
       const logsChannelName = `[meta]log`;
 
       // Configure channel options for rewind if specified

--- a/src/commands/rooms/typing/keystroke.ts
+++ b/src/commands/rooms/typing/keystroke.ts
@@ -159,18 +159,24 @@ export default class TypingKeystroke extends ChatBaseCommand {
         }, KEYSTROKE_INTERVAL);
       }
 
-      this.logCliEvent(
-        flags,
-        "typing",
-        "listening",
-        "Maintaining typing status...",
-      );
+      // If auto-type is enabled, keep the command running to maintain typing state
+      if (flags["auto-type"]) {
+        this.logCliEvent(
+          flags,
+          "typing",
+          "listening",
+          "Maintaining typing status...",
+        );
 
-      // Wait until the user interrupts, duration elapses, or the room fails
-      await Promise.race([
-        this.waitAndTrackCleanup(flags, "typing", flags.duration),
-        failurePromise,
-      ]);
+        // Wait until the user interrupts, duration elapses, or the room fails
+        await Promise.race([
+          this.waitAndTrackCleanup(flags, "typing", flags.duration),
+          failurePromise,
+        ]);
+      } else {
+        // Suppress unhandled rejection if room fails during cleanup
+        failurePromise.catch(() => {});
+      }
     } catch (error) {
       this.fail(error, flags, "roomTypingKeystroke", { room: args.roomName });
     }

--- a/src/commands/rooms/typing/keystroke.ts
+++ b/src/commands/rooms/typing/keystroke.ts
@@ -157,10 +157,7 @@ export default class TypingKeystroke extends ChatBaseCommand {
             );
           });
         }, KEYSTROKE_INTERVAL);
-      }
 
-      // If auto-type is enabled, keep the command running to maintain typing state
-      if (flags["auto-type"]) {
         this.logCliEvent(
           flags,
           "typing",
@@ -174,7 +171,7 @@ export default class TypingKeystroke extends ChatBaseCommand {
           failurePromise,
         ]);
       } else {
-        // Suppress unhandled rejection if room fails during cleanup
+        // Suppress unhandled rejection — failurePromise exists from setupRoomStatusHandler
         failurePromise.catch(() => {});
       }
     } catch (error) {

--- a/src/commands/spaces/cursors/get.ts
+++ b/src/commands/spaces/cursors/get.ts
@@ -49,6 +49,7 @@ export default class SpacesCursorsGet extends SpacesBaseCommand {
         flags,
       );
 
+      await this.waitForCursorsChannelAttachment(flags);
       const allCursors = await this.space!.cursors.getAll();
 
       const cursors: CursorUpdate[] = Object.values(allCursors).filter(

--- a/src/services/config-manager.ts
+++ b/src/services/config-manager.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { parse, stringify } from "smol-toml";
+import { extractKeyNameFromApiKey } from "../utils/api-key.js";
 import isTestMode from "../utils/test-mode.js";
 
 // Updated to include key and app metadata
@@ -265,7 +266,7 @@ export class TomlConfigManager implements ConfigManager {
     }
 
     if (appConfig.apiKey) {
-      return appConfig.apiKey.split(":")[0];
+      return extractKeyNameFromApiKey(appConfig.apiKey);
     }
 
     return undefined;
@@ -444,7 +445,7 @@ export class TomlConfigManager implements ConfigManager {
       ...this.config.accounts[alias].apps[appId],
       apiKey,
       appName: metadata?.appName,
-      keyId: metadata?.keyId || apiKey.split(":")[0], // Extract key ID if not provided
+      keyId: metadata?.keyId || extractKeyNameFromApiKey(apiKey),
       keyName: metadata?.keyName,
     };
 

--- a/src/services/control-api.ts
+++ b/src/services/control-api.ts
@@ -384,7 +384,14 @@ export class ControlApi {
   }
 
   async getNamespace(appId: string, namespaceId: string): Promise<Namespace> {
-    return this.request<Namespace>(`/apps/${appId}/namespaces/${namespaceId}`);
+    // Individual namespace GET endpoint is no longer available;
+    // list all namespaces and filter by ID instead.
+    const namespaces = await this.listNamespaces(appId);
+    const namespace = namespaces.find((ns) => ns.id === namespaceId);
+    if (!namespace) {
+      throw new Error(`Namespace with ID "${namespaceId}" not found`);
+    }
+    return namespace;
   }
 
   async getRule(appId: string, ruleId: string): Promise<Rule> {

--- a/src/utils/api-key.ts
+++ b/src/utils/api-key.ts
@@ -1,0 +1,15 @@
+/**
+ * Ably API keys have the shape `APP_ID.KEY_ID:KEY_SECRET`.
+ */
+
+export function extractAppIdFromApiKey(apiKey: string): string {
+  return apiKey.split(".")[0] ?? "";
+}
+
+/**
+ * Returns the "key name" portion — everything before the `:` separator
+ * (i.e. `APP_ID.KEY_ID`). Empty string if the input is not a valid key.
+ */
+export function extractKeyNameFromApiKey(apiKey: string): string {
+  return apiKey.split(":")[0] ?? "";
+}

--- a/test/e2e/accounts/accounts-e2e.test.ts
+++ b/test/e2e/accounts/accounts-e2e.test.ts
@@ -1,16 +1,7 @@
-import {
-  describe,
-  it,
-  beforeEach,
-  afterEach,
-  beforeAll,
-  afterAll,
-  expect,
-} from "vitest";
+import { describe, it, beforeEach, afterEach, expect } from "vitest";
 import {
   E2E_ACCESS_TOKEN,
   SHOULD_SKIP_CONTROL_E2E,
-  forceExit,
   cleanupTrackedResources,
   setupTestFailureHandler,
   resetTestTracking,
@@ -18,14 +9,6 @@ import {
 import { runCommand } from "../../helpers/command-helpers.js";
 
 describe.skipIf(SHOULD_SKIP_CONTROL_E2E)("Accounts E2E Tests", () => {
-  beforeAll(() => {
-    process.on("SIGINT", forceExit);
-  });
-
-  afterAll(() => {
-    process.removeListener("SIGINT", forceExit);
-  });
-
   beforeEach(() => {
     resetTestTracking();
   });

--- a/test/e2e/accounts/accounts-e2e.test.ts
+++ b/test/e2e/accounts/accounts-e2e.test.ts
@@ -1,0 +1,68 @@
+import {
+  describe,
+  it,
+  beforeEach,
+  afterEach,
+  beforeAll,
+  afterAll,
+  expect,
+} from "vitest";
+import {
+  E2E_ACCESS_TOKEN,
+  SHOULD_SKIP_CONTROL_E2E,
+  forceExit,
+  cleanupTrackedResources,
+  setupTestFailureHandler,
+  resetTestTracking,
+} from "../../helpers/e2e-test-helper.js";
+import { runCommand } from "../../helpers/command-helpers.js";
+
+describe.skipIf(SHOULD_SKIP_CONTROL_E2E)("Accounts E2E Tests", () => {
+  beforeAll(() => {
+    process.on("SIGINT", forceExit);
+  });
+
+  afterAll(() => {
+    process.removeListener("SIGINT", forceExit);
+  });
+
+  beforeEach(() => {
+    resetTestTracking();
+  });
+
+  afterEach(async () => {
+    await cleanupTrackedResources();
+  });
+
+  it(
+    "should list locally configured accounts",
+    { timeout: 15000 },
+    async () => {
+      setupTestFailureHandler("should list locally configured accounts");
+
+      // accounts list reads from local config, not the API directly.
+      // In E2E environment, there may or may not be configured accounts.
+      // We just verify the command runs without crashing.
+      const listResult = await runCommand(["accounts", "list"], {
+        env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN || "" },
+      });
+
+      // The command may exit 0 (accounts found) or non-zero (no accounts configured).
+      // Either way, it should produce output and not crash.
+      const combinedOutput = listResult.stdout + listResult.stderr;
+      expect(combinedOutput.length).toBeGreaterThan(0);
+    },
+  );
+
+  it("should show help for accounts current", { timeout: 10000 }, async () => {
+    setupTestFailureHandler("should show help for accounts current");
+
+    const helpResult = await runCommand(["accounts", "current", "--help"], {
+      env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN || "" },
+    });
+
+    expect(helpResult.exitCode).toBe(0);
+    const output = helpResult.stdout + helpResult.stderr;
+    expect(output).toContain("USAGE");
+  });
+});

--- a/test/e2e/auth/auth-keys-e2e.test.ts
+++ b/test/e2e/auth/auth-keys-e2e.test.ts
@@ -1,0 +1,224 @@
+import {
+  describe,
+  it,
+  beforeEach,
+  afterEach,
+  beforeAll,
+  afterAll,
+  expect,
+} from "vitest";
+import {
+  E2E_ACCESS_TOKEN,
+  SHOULD_SKIP_CONTROL_E2E,
+  forceExit,
+  cleanupTrackedResources,
+  setupTestFailureHandler,
+  resetTestTracking,
+} from "../../helpers/e2e-test-helper.js";
+import { runCommand } from "../../helpers/command-helpers.js";
+import { parseNdjsonLines } from "../../helpers/ndjson.js";
+
+describe.skipIf(SHOULD_SKIP_CONTROL_E2E)("Auth Keys E2E Tests", () => {
+  let testAppId: string;
+
+  beforeAll(async () => {
+    process.on("SIGINT", forceExit);
+
+    // Create a test app for key operations
+    const createResult = await runCommand(
+      ["apps", "create", "--name", `e2e-keys-test-${Date.now()}`, "--json"],
+      {
+        env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN || "" },
+      },
+    );
+
+    if (createResult.exitCode !== 0) {
+      throw new Error(`Failed to create test app: ${createResult.stderr}`);
+    }
+    const result = parseNdjsonLines(createResult.stdout).find(
+      (r) => r.type === "result",
+    ) as Record<string, unknown>;
+    const app = result.app as Record<string, unknown>;
+    testAppId = (app.id ?? app.appId) as string;
+    if (!testAppId) {
+      throw new Error(`No app ID found in result: ${JSON.stringify(result)}`);
+    }
+  });
+
+  afterAll(async () => {
+    if (testAppId) {
+      try {
+        await runCommand(["apps", "delete", testAppId, "--force"], {
+          env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN || "" },
+        });
+      } catch {
+        // Ignore cleanup errors — the app may already be deleted
+      }
+    }
+    process.removeListener("SIGINT", forceExit);
+  });
+
+  beforeEach(() => {
+    resetTestTracking();
+  });
+
+  afterEach(async () => {
+    await cleanupTrackedResources();
+  });
+
+  it("should list API keys for an app", { timeout: 15000 }, async () => {
+    setupTestFailureHandler("should list API keys for an app");
+
+    const listResult = await runCommand(
+      ["auth", "keys", "list", "--app", testAppId, "--json"],
+      {
+        env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN || "" },
+      },
+    );
+
+    expect(listResult.exitCode).toBe(0);
+    const records = parseNdjsonLines(listResult.stdout);
+    const result = records.find((r) => r.type === "result");
+    expect(result).toBeDefined();
+    expect(result).toHaveProperty("success", true);
+    expect(Array.isArray(result!.keys)).toBe(true);
+    // Every app has at least one default key
+    expect((result!.keys as unknown[]).length).toBeGreaterThan(0);
+  });
+
+  it("should create a new API key", { timeout: 15000 }, async () => {
+    setupTestFailureHandler("should create a new API key");
+
+    const keyName = `e2e-test-key-${Date.now()}`;
+    const createResult = await runCommand(
+      [
+        "auth",
+        "keys",
+        "create",
+        "--app",
+        testAppId,
+        "--name",
+        keyName,
+        "--json",
+      ],
+      {
+        env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN || "" },
+      },
+    );
+
+    expect(createResult.exitCode).toBe(0);
+    const result = parseNdjsonLines(createResult.stdout).find(
+      (r) => r.type === "result",
+    ) as Record<string, unknown>;
+    expect(result).toBeDefined();
+    expect(result).toHaveProperty("success", true);
+    const key = result.key as Record<string, unknown>;
+    expect(key).toHaveProperty("name", keyName);
+    expect(key).toHaveProperty("key");
+    expect(key).toHaveProperty("keyName");
+  });
+
+  it("should get details for a specific key", { timeout: 20000 }, async () => {
+    setupTestFailureHandler("should get details for a specific key");
+
+    // First create a key to get
+    const keyName = `e2e-get-key-${Date.now()}`;
+    const createResult = await runCommand(
+      [
+        "auth",
+        "keys",
+        "create",
+        "--app",
+        testAppId,
+        "--name",
+        keyName,
+        "--json",
+      ],
+      {
+        env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN || "" },
+      },
+    );
+
+    const createRecord = parseNdjsonLines(createResult.stdout).find(
+      (r) => r.type === "result",
+    ) as Record<string, unknown>;
+    const createdKey = createRecord.key as Record<string, unknown>;
+    const keyFullName = createdKey.keyName as string;
+
+    // Now get that key by its name
+    const getResult = await runCommand(
+      ["auth", "keys", "get", keyFullName, "--app", testAppId, "--json"],
+      {
+        env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN || "" },
+      },
+    );
+
+    expect(getResult.exitCode).toBe(0);
+    const getRecord = parseNdjsonLines(getResult.stdout).find(
+      (r) => r.type === "result",
+    ) as Record<string, unknown>;
+    expect(getRecord).toBeDefined();
+    expect(getRecord).toHaveProperty("success", true);
+    const fetchedKey = getRecord.key as Record<string, unknown>;
+    expect(fetchedKey).toHaveProperty("name", keyName);
+    expect(fetchedKey).toHaveProperty("keyName", keyFullName);
+  });
+
+  it("should update a key name", { timeout: 20000 }, async () => {
+    setupTestFailureHandler("should update a key name");
+
+    // First create a key to update
+    const originalName = `e2e-update-key-${Date.now()}`;
+    const createResult = await runCommand(
+      [
+        "auth",
+        "keys",
+        "create",
+        "--app",
+        testAppId,
+        "--name",
+        originalName,
+        "--json",
+      ],
+      {
+        env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN || "" },
+      },
+    );
+
+    const createRecord = parseNdjsonLines(createResult.stdout).find(
+      (r) => r.type === "result",
+    ) as Record<string, unknown>;
+    const createdKey = createRecord.key as Record<string, unknown>;
+    const keyFullName = createdKey.keyName as string;
+
+    // Update the key name
+    const updatedName = `updated-key-${Date.now()}`;
+    const updateResult = await runCommand(
+      [
+        "auth",
+        "keys",
+        "update",
+        keyFullName,
+        "--app",
+        testAppId,
+        "--name",
+        updatedName,
+        "--json",
+      ],
+      {
+        env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN || "" },
+      },
+    );
+
+    expect(updateResult.exitCode).toBe(0);
+    const updateRecord = parseNdjsonLines(updateResult.stdout).find(
+      (r) => r.type === "result",
+    ) as Record<string, unknown>;
+    expect(updateRecord).toBeDefined();
+    expect(updateRecord).toHaveProperty("success", true);
+    const updatedKey = updateRecord.key as Record<string, unknown>;
+    const nameChange = updatedKey.name as Record<string, unknown>;
+    expect(nameChange).toHaveProperty("before", originalName);
+    expect(nameChange).toHaveProperty("after", updatedName);
+  });
+});

--- a/test/e2e/auth/auth-keys-e2e.test.ts
+++ b/test/e2e/auth/auth-keys-e2e.test.ts
@@ -26,7 +26,7 @@ describe.skipIf(SHOULD_SKIP_CONTROL_E2E)("Auth Keys E2E Tests", () => {
 
     // Create a test app for key operations
     const createResult = await runCommand(
-      ["apps", "create", "--name", `e2e-keys-test-${Date.now()}`, "--json"],
+      ["apps", "create", `e2e-keys-test-${Date.now()}`, "--json"],
       {
         env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN || "" },
       },
@@ -91,16 +91,7 @@ describe.skipIf(SHOULD_SKIP_CONTROL_E2E)("Auth Keys E2E Tests", () => {
 
     const keyName = `e2e-test-key-${Date.now()}`;
     const createResult = await runCommand(
-      [
-        "auth",
-        "keys",
-        "create",
-        "--app",
-        testAppId,
-        "--name",
-        keyName,
-        "--json",
-      ],
+      ["auth", "keys", "create", keyName, "--app", testAppId, "--json"],
       {
         env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN || "" },
       },
@@ -124,16 +115,7 @@ describe.skipIf(SHOULD_SKIP_CONTROL_E2E)("Auth Keys E2E Tests", () => {
     // First create a key to get
     const keyName = `e2e-get-key-${Date.now()}`;
     const createResult = await runCommand(
-      [
-        "auth",
-        "keys",
-        "create",
-        "--app",
-        testAppId,
-        "--name",
-        keyName,
-        "--json",
-      ],
+      ["auth", "keys", "create", keyName, "--app", testAppId, "--json"],
       {
         env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN || "" },
       },
@@ -170,16 +152,7 @@ describe.skipIf(SHOULD_SKIP_CONTROL_E2E)("Auth Keys E2E Tests", () => {
     // First create a key to update
     const originalName = `e2e-update-key-${Date.now()}`;
     const createResult = await runCommand(
-      [
-        "auth",
-        "keys",
-        "create",
-        "--app",
-        testAppId,
-        "--name",
-        originalName,
-        "--json",
-      ],
+      ["auth", "keys", "create", originalName, "--app", testAppId, "--json"],
       {
         env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN || "" },
       },

--- a/test/e2e/auth/auth-keys-e2e.test.ts
+++ b/test/e2e/auth/auth-keys-e2e.test.ts
@@ -10,52 +10,25 @@ import {
 import {
   E2E_ACCESS_TOKEN,
   SHOULD_SKIP_CONTROL_E2E,
-  forceExit,
   cleanupTrackedResources,
   setupTestFailureHandler,
   resetTestTracking,
 } from "../../helpers/e2e-test-helper.js";
 import { runCommand } from "../../helpers/command-helpers.js";
+import { createTestApp } from "../../helpers/e2e-test-app.js";
 import { parseNdjsonLines } from "../../helpers/ndjson.js";
 
 describe.skipIf(SHOULD_SKIP_CONTROL_E2E)("Auth Keys E2E Tests", () => {
   let testAppId: string;
+  let teardownApp: (() => Promise<void>) | undefined;
 
   beforeAll(async () => {
-    process.on("SIGINT", forceExit);
-
-    // Create a test app for key operations
-    const createResult = await runCommand(
-      ["apps", "create", `e2e-keys-test-${Date.now()}`, "--json"],
-      {
-        env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN || "" },
-      },
-    );
-
-    if (createResult.exitCode !== 0) {
-      throw new Error(`Failed to create test app: ${createResult.stderr}`);
-    }
-    const result = parseNdjsonLines(createResult.stdout).find(
-      (r) => r.type === "result",
-    ) as Record<string, unknown>;
-    const app = result.app as Record<string, unknown>;
-    testAppId = (app.id ?? app.appId) as string;
-    if (!testAppId) {
-      throw new Error(`No app ID found in result: ${JSON.stringify(result)}`);
-    }
+    ({ appId: testAppId, teardown: teardownApp } =
+      await createTestApp("e2e-keys-test"));
   });
 
   afterAll(async () => {
-    if (testAppId) {
-      try {
-        await runCommand(["apps", "delete", testAppId, "--force"], {
-          env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN || "" },
-        });
-      } catch {
-        // Ignore cleanup errors — the app may already be deleted
-      }
-    }
-    process.removeListener("SIGINT", forceExit);
+    await teardownApp?.();
   });
 
   beforeEach(() => {

--- a/test/e2e/auth/auth-tokens-e2e.test.ts
+++ b/test/e2e/auth/auth-tokens-e2e.test.ts
@@ -1,16 +1,7 @@
-import {
-  describe,
-  it,
-  beforeEach,
-  afterEach,
-  beforeAll,
-  afterAll,
-  expect,
-} from "vitest";
+import { describe, it, beforeEach, afterEach, expect } from "vitest";
 import {
   E2E_API_KEY,
   SHOULD_SKIP_E2E,
-  forceExit,
   cleanupTrackedResources,
   setupTestFailureHandler,
   resetTestTracking,
@@ -19,14 +10,6 @@ import { runCommand } from "../../helpers/command-helpers.js";
 import { parseNdjsonLines } from "../../helpers/ndjson.js";
 
 describe.skipIf(SHOULD_SKIP_E2E)("Auth Tokens E2E Tests", () => {
-  beforeAll(() => {
-    process.on("SIGINT", forceExit);
-  });
-
-  afterAll(() => {
-    process.removeListener("SIGINT", forceExit);
-  });
-
   beforeEach(() => {
     resetTestTracking();
   });

--- a/test/e2e/auth/auth-tokens-e2e.test.ts
+++ b/test/e2e/auth/auth-tokens-e2e.test.ts
@@ -1,0 +1,154 @@
+import {
+  describe,
+  it,
+  beforeEach,
+  afterEach,
+  beforeAll,
+  afterAll,
+  expect,
+} from "vitest";
+import {
+  E2E_API_KEY,
+  SHOULD_SKIP_E2E,
+  forceExit,
+  cleanupTrackedResources,
+  setupTestFailureHandler,
+  resetTestTracking,
+} from "../../helpers/e2e-test-helper.js";
+import { runCommand } from "../../helpers/command-helpers.js";
+import { parseNdjsonLines } from "../../helpers/ndjson.js";
+
+describe.skipIf(SHOULD_SKIP_E2E)("Auth Tokens E2E Tests", () => {
+  beforeAll(() => {
+    process.on("SIGINT", forceExit);
+  });
+
+  afterAll(() => {
+    process.removeListener("SIGINT", forceExit);
+  });
+
+  beforeEach(() => {
+    resetTestTracking();
+  });
+
+  afterEach(async () => {
+    await cleanupTrackedResources();
+  });
+
+  describe("auth issue-ably-token", () => {
+    it("should issue an Ably token with --json", async () => {
+      setupTestFailureHandler("should issue an Ably token with --json");
+
+      const result = await runCommand(["auth", "issue-ably-token", "--json"], {
+        env: { ABLY_API_KEY: E2E_API_KEY || "" },
+        timeoutMs: 30000,
+      });
+
+      expect(result.exitCode).toBe(0);
+
+      const records = parseNdjsonLines(result.stdout);
+      const resultRecord = records.find((r) => r.type === "result");
+
+      expect(resultRecord).toBeDefined();
+      expect(resultRecord!.success).toBe(true);
+
+      const token = resultRecord!.token as Record<string, unknown>;
+      expect(token).toBeDefined();
+      expect(token.value).toBeDefined();
+      expect(typeof token.value).toBe("string");
+      expect((token.value as string).length).toBeGreaterThan(0);
+      expect(token.issuedAt).toBeDefined();
+      expect(token.expiresAt).toBeDefined();
+      expect(token.capability).toBeDefined();
+    });
+  });
+
+  describe("auth issue-jwt-token", () => {
+    it("should issue a JWT token with --json", async () => {
+      setupTestFailureHandler("should issue a JWT token with --json");
+
+      const result = await runCommand(["auth", "issue-jwt-token", "--json"], {
+        env: { ABLY_API_KEY: E2E_API_KEY || "" },
+        timeoutMs: 30000,
+      });
+
+      expect(result.exitCode).toBe(0);
+
+      const records = parseNdjsonLines(result.stdout);
+      const resultRecord = records.find((r) => r.type === "result");
+
+      expect(resultRecord).toBeDefined();
+      expect(resultRecord!.success).toBe(true);
+
+      const token = resultRecord!.token as Record<string, unknown>;
+      expect(token).toBeDefined();
+      expect(token.value).toBeDefined();
+      expect(typeof token.value).toBe("string");
+
+      // JWT tokens have three dot-separated parts (header.payload.signature)
+      const jwtValue = token.value as string;
+      const parts = jwtValue.split(".");
+      expect(parts).toHaveLength(3);
+
+      expect(token.tokenType).toBe("jwt");
+      expect(token.appId).toBeDefined();
+      expect(token.keyId).toBeDefined();
+    });
+  });
+
+  describe("auth revoke-token", () => {
+    it("should issue a token and then revoke it", async () => {
+      setupTestFailureHandler("should issue a token and then revoke it");
+
+      // Step 1: Issue an Ably token with a known client ID
+      const issueResult = await runCommand(
+        [
+          "auth",
+          "issue-ably-token",
+          "--json",
+          "--client-id",
+          "e2e-revoke-test",
+        ],
+        {
+          env: { ABLY_API_KEY: E2E_API_KEY || "" },
+          timeoutMs: 30000,
+        },
+      );
+
+      expect(issueResult.exitCode).toBe(0);
+
+      const issueRecords = parseNdjsonLines(issueResult.stdout);
+      const issueResultRecord = issueRecords.find((r) => r.type === "result");
+
+      expect(issueResultRecord).toBeDefined();
+      const issuedToken = issueResultRecord!.token as Record<string, unknown>;
+      expect(issuedToken.value).toBeDefined();
+
+      const tokenValue = issuedToken.value as string;
+
+      // Step 2: Revoke the token using its client ID
+      const revokeResult = await runCommand(
+        [
+          "auth",
+          "revoke-token",
+          tokenValue,
+          "--client-id",
+          "e2e-revoke-test",
+          "--json",
+        ],
+        {
+          env: { ABLY_API_KEY: E2E_API_KEY || "" },
+          timeoutMs: 30000,
+        },
+      );
+
+      expect(revokeResult.exitCode).toBe(0);
+
+      const revokeRecords = parseNdjsonLines(revokeResult.stdout);
+      const revokeResultRecord = revokeRecords.find((r) => r.type === "result");
+
+      expect(revokeResultRecord).toBeDefined();
+      expect(revokeResultRecord!.success).toBe(true);
+    });
+  });
+});

--- a/test/e2e/auth/basic-auth.test.ts
+++ b/test/e2e/auth/basic-auth.test.ts
@@ -1,17 +1,8 @@
-import {
-  describe,
-  it,
-  beforeEach,
-  afterEach,
-  beforeAll,
-  afterAll,
-  expect,
-} from "vitest";
+import { describe, it, beforeEach, afterEach, expect } from "vitest";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import {
-  forceExit,
   cleanupTrackedResources,
   setupTestFailureHandler,
   resetTestTracking,
@@ -20,14 +11,6 @@ import {
 describe("Authentication E2E", () => {
   let tempConfigDir: string;
   let originalEnv: NodeJS.ProcessEnv;
-
-  beforeAll(async () => {
-    process.on("SIGINT", forceExit);
-  });
-
-  afterAll(() => {
-    process.removeListener("SIGINT", forceExit);
-  });
 
   beforeEach(() => {
     resetTestTracking();

--- a/test/e2e/auth/capability-scoping-e2e.test.ts
+++ b/test/e2e/auth/capability-scoping-e2e.test.ts
@@ -2,10 +2,10 @@ import { describe, it, beforeAll, afterAll, expect } from "vitest";
 import {
   E2E_ACCESS_TOKEN,
   SHOULD_SKIP_CONTROL_E2E,
-  forceExit,
   setupTestFailureHandler,
 } from "../../helpers/e2e-test-helper.js";
 import { runCommand } from "../../helpers/command-helpers.js";
+import { createTestApp } from "../../helpers/e2e-test-app.js";
 import { parseAllJsonRecords } from "../../helpers/ndjson.js";
 import stripAnsi from "strip-ansi";
 
@@ -13,23 +13,13 @@ describe.skipIf(SHOULD_SKIP_CONTROL_E2E)(
   "Auth Capability Scoping E2E Tests",
   () => {
     let testAppId: string;
+    let teardownApp: (() => Promise<void>) | undefined;
     let publishOnlyKey: string;
 
     beforeAll(async () => {
-      process.on("SIGINT", forceExit);
-
-      // Create a dedicated app so scoped keys have no interference
-      const createApp = await runCommand(
-        ["apps", "create", `e2e-capability-scoping-${Date.now()}`, "--json"],
-        {
-          env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN || "" },
-        },
-      );
-      const appResult = parseAllJsonRecords(stripAnsi(createApp.stdout)).find(
-        (r) => r.type === "result",
-      ) as Record<string, unknown>;
-      const app = appResult.app as Record<string, unknown>;
-      testAppId = app.id as string;
+      ({ appId: testAppId, teardown: teardownApp } = await createTestApp(
+        "e2e-capability-scoping",
+      ));
 
       // Create a key with publish-only capability scoped to "allowed-*"
       const createKey = await runCommand(
@@ -61,16 +51,7 @@ describe.skipIf(SHOULD_SKIP_CONTROL_E2E)(
     }, 30000);
 
     afterAll(async () => {
-      if (testAppId) {
-        try {
-          await runCommand(["apps", "delete", testAppId, "--force"], {
-            env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN || "" },
-          });
-        } catch {
-          // Ignore cleanup errors
-        }
-      }
-      process.removeListener("SIGINT", forceExit);
+      await teardownApp?.();
     });
 
     it(

--- a/test/e2e/auth/capability-scoping-e2e.test.ts
+++ b/test/e2e/auth/capability-scoping-e2e.test.ts
@@ -20,13 +20,7 @@ describe.skipIf(SHOULD_SKIP_CONTROL_E2E)(
 
       // Create a dedicated app so scoped keys have no interference
       const createApp = await runCommand(
-        [
-          "apps",
-          "create",
-          "--name",
-          `e2e-capability-scoping-${Date.now()}`,
-          "--json",
-        ],
+        ["apps", "create", `e2e-capability-scoping-${Date.now()}`, "--json"],
         {
           env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN || "" },
         },
@@ -43,10 +37,9 @@ describe.skipIf(SHOULD_SKIP_CONTROL_E2E)(
           "auth",
           "keys",
           "create",
+          "publish-only-allowed-prefix",
           "--app",
           testAppId,
-          "--name",
-          "publish-only-allowed-prefix",
           "--capabilities",
           '{"allowed-*":["publish"]}',
           "--json",

--- a/test/e2e/auth/capability-scoping-e2e.test.ts
+++ b/test/e2e/auth/capability-scoping-e2e.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, beforeAll, afterAll, expect } from "vitest";
+import {
+  E2E_ACCESS_TOKEN,
+  SHOULD_SKIP_CONTROL_E2E,
+  forceExit,
+  setupTestFailureHandler,
+} from "../../helpers/e2e-test-helper.js";
+import { runCommand } from "../../helpers/command-helpers.js";
+import { parseAllJsonRecords } from "../../helpers/ndjson.js";
+import stripAnsi from "strip-ansi";
+
+describe.skipIf(SHOULD_SKIP_CONTROL_E2E)(
+  "Auth Capability Scoping E2E Tests",
+  () => {
+    let testAppId: string;
+    let publishOnlyKey: string;
+
+    beforeAll(async () => {
+      process.on("SIGINT", forceExit);
+
+      // Create a dedicated app so scoped keys have no interference
+      const createApp = await runCommand(
+        [
+          "apps",
+          "create",
+          "--name",
+          `e2e-capability-scoping-${Date.now()}`,
+          "--json",
+        ],
+        {
+          env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN || "" },
+        },
+      );
+      const appResult = parseAllJsonRecords(stripAnsi(createApp.stdout)).find(
+        (r) => r.type === "result",
+      ) as Record<string, unknown>;
+      const app = appResult.app as Record<string, unknown>;
+      testAppId = app.id as string;
+
+      // Create a key with publish-only capability scoped to "allowed-*"
+      const createKey = await runCommand(
+        [
+          "auth",
+          "keys",
+          "create",
+          "--app",
+          testAppId,
+          "--name",
+          "publish-only-allowed-prefix",
+          "--capabilities",
+          '{"allowed-*":["publish"]}',
+          "--json",
+        ],
+        {
+          env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN || "" },
+        },
+      );
+      const keyResult = parseAllJsonRecords(stripAnsi(createKey.stdout)).find(
+        (r) => r.type === "result",
+      ) as Record<string, unknown>;
+      const key = keyResult.key as Record<string, unknown>;
+      publishOnlyKey = key.key as string;
+      if (!publishOnlyKey) {
+        throw new Error(
+          `Failed to create scoped key: ${JSON.stringify(keyResult)}`,
+        );
+      }
+    }, 30000);
+
+    afterAll(async () => {
+      if (testAppId) {
+        try {
+          await runCommand(["apps", "delete", testAppId, "--force"], {
+            env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN || "" },
+          });
+        } catch {
+          // Ignore cleanup errors
+        }
+      }
+      process.removeListener("SIGINT", forceExit);
+    });
+
+    it(
+      "should allow publish on a channel matching the key's resource scope",
+      { timeout: 30000 },
+      async () => {
+        setupTestFailureHandler(
+          "should allow publish on a channel matching the key's resource scope",
+        );
+
+        const publishResult = await runCommand(
+          [
+            "channels",
+            "publish",
+            "allowed-scope-test",
+            "hello-scoped",
+            "--json",
+          ],
+          { env: { ABLY_API_KEY: publishOnlyKey } },
+        );
+
+        expect(publishResult.exitCode).toBe(0);
+        const result = parseAllJsonRecords(
+          stripAnsi(publishResult.stdout),
+        ).find((r) => r.type === "result") as Record<string, unknown>;
+        expect(result).toHaveProperty("success", true);
+      },
+    );
+
+    it(
+      "should reject publish on a channel outside the key's resource scope",
+      { timeout: 30000 },
+      async () => {
+        setupTestFailureHandler(
+          "should reject publish on a channel outside the key's resource scope",
+        );
+
+        const publishResult = await runCommand(
+          [
+            "channels",
+            "publish",
+            "forbidden-channel",
+            "hello-scoped",
+            "--json",
+          ],
+          { env: { ABLY_API_KEY: publishOnlyKey } },
+        );
+
+        // `channels publish` reports per-message errors inline, not via fail().
+        const result = parseAllJsonRecords(
+          stripAnsi(publishResult.stdout),
+        ).find((r) => r.type === "result") as Record<string, unknown>;
+        expect(result).toBeDefined();
+        const publish = result.publish as {
+          errors: number;
+          published: number;
+          allSucceeded: boolean;
+          results: Array<{ success: boolean; error?: { message: string } }>;
+        };
+        expect(publish.errors).toBeGreaterThanOrEqual(1);
+        expect(publish.published).toBe(0);
+        expect(publish.allSucceeded).toBe(false);
+        expect(publish.results[0].success).toBe(false);
+        expect(publish.results[0].error?.message).toBeTruthy();
+      },
+    );
+
+    it(
+      "should reject history on a channel when the key lacks the history op",
+      { timeout: 30000 },
+      async () => {
+        setupTestFailureHandler(
+          "should reject history on a channel when the key lacks the history op",
+        );
+
+        const historyResult = await runCommand(
+          ["channels", "history", "allowed-scope-test", "--json"],
+          { env: { ABLY_API_KEY: publishOnlyKey } },
+        );
+
+        expect(historyResult.exitCode).not.toBe(0);
+        const errorEvent = parseAllJsonRecords(
+          stripAnsi(historyResult.stdout),
+        ).find((r) => r.type === "error");
+        expect(errorEvent).toBeDefined();
+        expect(errorEvent).toHaveProperty("success", false);
+      },
+    );
+  },
+);

--- a/test/e2e/bench/bench.test.ts
+++ b/test/e2e/bench/bench.test.ts
@@ -1,14 +1,5 @@
+import { describe, it, beforeEach, afterEach, beforeAll, expect } from "vitest";
 import {
-  describe,
-  it,
-  beforeEach,
-  afterEach,
-  beforeAll,
-  afterAll,
-  expect,
-} from "vitest";
-import {
-  forceExit,
   cleanupTrackedResources,
   testOutputFiles,
   testCommands,
@@ -33,7 +24,6 @@ describe("E2E: ably bench publisher and subscriber", () => {
   let shouldSkip = false;
 
   beforeAll(async () => {
-    process.on("SIGINT", forceExit);
     const envApiKey = process.env.E2E_ABLY_API_KEY;
     if (!envApiKey) {
       console.log(
@@ -44,10 +34,6 @@ describe("E2E: ably bench publisher and subscriber", () => {
     }
     apiKey = envApiKey;
     testChannel = `cli-e2e-bench-${Date.now()}`;
-  });
-
-  afterAll(() => {
-    process.removeListener("SIGINT", forceExit);
   });
 
   beforeEach(() => {

--- a/test/e2e/channels/channel-annotations-e2e.test.ts
+++ b/test/e2e/channels/channel-annotations-e2e.test.ts
@@ -1,0 +1,272 @@
+import {
+  describe,
+  it,
+  beforeEach,
+  afterEach,
+  beforeAll,
+  afterAll,
+  expect,
+} from "vitest";
+import {
+  E2E_API_KEY,
+  SHOULD_SKIP_E2E,
+  getUniqueChannelName,
+  forceExit,
+  cleanupTrackedResources,
+  setupTestFailureHandler,
+  resetTestTracking,
+} from "../../helpers/e2e-test-helper.js";
+import {
+  runCommand,
+  startSubscribeCommand,
+  waitForOutput,
+  cleanupRunners,
+} from "../../helpers/command-helpers.js";
+import type { CliRunner } from "../../helpers/cli-runner.js";
+import { parseNdjsonLines } from "../../helpers/ndjson.js";
+import {
+  checkMutableMessagesSupport,
+  publishAndGetSerial,
+} from "../../helpers/e2e-mutable-messages.js";
+
+function findResult(stdout: string): Record<string, unknown> {
+  const records = parseNdjsonLines(stdout);
+  return records.find((r) => r.type === "result") ?? records.at(-1) ?? {};
+}
+
+// Check if the E2E test app supports mutable messages (required for annotations)
+const mutableMessagesSupported = SHOULD_SKIP_E2E
+  ? false
+  : await checkMutableMessagesSupport();
+
+describe.skipIf(SHOULD_SKIP_E2E || !mutableMessagesSupported)(
+  "Channel Annotations E2E Tests",
+  () => {
+    let channelName: string;
+    let messageSerial: string;
+
+    beforeAll(async () => {
+      process.on("SIGINT", forceExit);
+
+      // Publish a test message and get its serial for use in all tests
+      channelName = getUniqueChannelName("annotations");
+      messageSerial = await publishAndGetSerial(channelName, "annotate-me");
+    });
+
+    afterAll(() => {
+      process.removeListener("SIGINT", forceExit);
+    });
+
+    beforeEach(() => {
+      resetTestTracking();
+    });
+
+    afterEach(async () => {
+      await cleanupTrackedResources();
+    });
+
+    it(
+      "should publish an annotation on a message",
+      { timeout: 60000 },
+      async () => {
+        setupTestFailureHandler("should publish an annotation on a message");
+
+        const result = await runCommand(
+          [
+            "channels",
+            "annotations",
+            "publish",
+            channelName,
+            messageSerial,
+            "reactions:like.v1",
+            "--json",
+          ],
+          {
+            env: { ABLY_API_KEY: E2E_API_KEY || "" },
+            timeoutMs: 30000,
+          },
+        );
+
+        expect(result.exitCode).toBe(0);
+
+        const parsed = findResult(result.stdout);
+        expect(parsed.success).toBe(true);
+        expect(parsed.annotation).toBeDefined();
+
+        const annotation = parsed.annotation as {
+          channel: string;
+          serial: string;
+          type: string;
+        };
+        expect(annotation.channel).toBe(channelName);
+        expect(annotation.serial).toBe(messageSerial);
+        expect(annotation.type).toBe("reactions:like.v1");
+      },
+    );
+
+    it("should get annotations for a message", { timeout: 60000 }, async () => {
+      setupTestFailureHandler("should get annotations for a message");
+
+      // First publish an annotation to ensure there is one
+      const publishResult = await runCommand(
+        [
+          "channels",
+          "annotations",
+          "publish",
+          channelName,
+          messageSerial,
+          "metrics:total.v1",
+          "--json",
+        ],
+        {
+          env: { ABLY_API_KEY: E2E_API_KEY || "" },
+          timeoutMs: 30000,
+        },
+      );
+      expect(publishResult.exitCode).toBe(0);
+
+      // Wait for annotation to be indexed
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+
+      const result = await runCommand(
+        [
+          "channels",
+          "annotations",
+          "get",
+          channelName,
+          messageSerial,
+          "--json",
+        ],
+        {
+          env: { ABLY_API_KEY: E2E_API_KEY || "" },
+          timeoutMs: 30000,
+        },
+      );
+
+      expect(result.exitCode).toBe(0);
+
+      const parsed = findResult(result.stdout);
+      expect(parsed.success).toBe(true);
+      expect(parsed.annotations).toBeDefined();
+      expect(Array.isArray(parsed.annotations)).toBe(true);
+    });
+
+    it(
+      "should delete an annotation on a message",
+      { timeout: 60000 },
+      async () => {
+        setupTestFailureHandler("should delete an annotation on a message");
+
+        // First publish an annotation to delete
+        const annotationType = "receipts:flag.v1";
+        const publishResult = await runCommand(
+          [
+            "channels",
+            "annotations",
+            "publish",
+            channelName,
+            messageSerial,
+            annotationType,
+            "--json",
+          ],
+          {
+            env: { ABLY_API_KEY: E2E_API_KEY || "" },
+            timeoutMs: 30000,
+          },
+        );
+        expect(publishResult.exitCode).toBe(0);
+
+        // Wait for annotation to be indexed
+        await new Promise((resolve) => setTimeout(resolve, 2000));
+
+        // Now delete it
+        const result = await runCommand(
+          [
+            "channels",
+            "annotations",
+            "delete",
+            channelName,
+            messageSerial,
+            annotationType,
+            "--json",
+          ],
+          {
+            env: { ABLY_API_KEY: E2E_API_KEY || "" },
+            timeoutMs: 30000,
+          },
+        );
+
+        expect(result.exitCode).toBe(0);
+
+        const parsed = findResult(result.stdout);
+        expect(parsed.success).toBe(true);
+        expect(parsed.annotation).toBeDefined();
+
+        const annotation = parsed.annotation as {
+          channel: string;
+          serial: string;
+          type: string;
+        };
+        expect(annotation.channel).toBe(channelName);
+        expect(annotation.serial).toBe(messageSerial);
+        expect(annotation.type).toBe(annotationType);
+      },
+    );
+
+    it(
+      "should subscribe to annotation events on a channel",
+      { timeout: 60000 },
+      async () => {
+        setupTestFailureHandler(
+          "should subscribe to annotation events on a channel",
+        );
+
+        let subscriber: CliRunner | null = null;
+
+        try {
+          // Start subscribing to annotations
+          subscriber = await startSubscribeCommand(
+            [
+              "channels",
+              "annotations",
+              "subscribe",
+              channelName,
+              "--duration",
+              "30",
+            ],
+            /Listening for annotations/,
+            {
+              env: { ABLY_API_KEY: E2E_API_KEY || "" },
+              timeoutMs: 30000,
+            },
+          );
+
+          // Publish an annotation to trigger the subscriber
+          const publishResult = await runCommand(
+            [
+              "channels",
+              "annotations",
+              "publish",
+              channelName,
+              messageSerial,
+              "reactions:subscribe-test.v1",
+              "--json",
+            ],
+            {
+              env: { ABLY_API_KEY: E2E_API_KEY || "" },
+              timeoutMs: 30000,
+            },
+          );
+          expect(publishResult.exitCode).toBe(0);
+
+          // Wait for the annotation event to appear in subscriber output
+          await waitForOutput(subscriber, "subscribe-test", 15000);
+        } finally {
+          if (subscriber) {
+            await cleanupRunners([subscriber]);
+          }
+        }
+      },
+    );
+  },
+);

--- a/test/e2e/channels/channel-annotations-e2e.test.ts
+++ b/test/e2e/channels/channel-annotations-e2e.test.ts
@@ -10,7 +10,6 @@ import {
 import {
   E2E_API_KEY,
   SHOULD_SKIP_E2E,
-  getUniqueChannelName,
   forceExit,
   cleanupTrackedResources,
   setupTestFailureHandler,
@@ -25,7 +24,10 @@ import {
 import type { CliRunner } from "../../helpers/cli-runner.js";
 import { parseNdjsonLines } from "../../helpers/ndjson.js";
 import {
-  checkMutableMessagesSupport,
+  SHOULD_SKIP_MUTABLE_TESTS,
+  setupMutableMessagesRule,
+  teardownMutableMessagesRule,
+  getMutableChannelName,
   publishAndGetSerial,
 } from "../../helpers/e2e-mutable-messages.js";
 
@@ -34,12 +36,7 @@ function findResult(stdout: string): Record<string, unknown> {
   return records.find((r) => r.type === "result") ?? records.at(-1) ?? {};
 }
 
-// Check if the E2E test app supports mutable messages (required for annotations)
-const mutableMessagesSupported = SHOULD_SKIP_E2E
-  ? false
-  : await checkMutableMessagesSupport();
-
-describe.skipIf(SHOULD_SKIP_E2E || !mutableMessagesSupported)(
+describe.skipIf(SHOULD_SKIP_E2E || SHOULD_SKIP_MUTABLE_TESTS)(
   "Channel Annotations E2E Tests",
   () => {
     let channelName: string;
@@ -48,12 +45,16 @@ describe.skipIf(SHOULD_SKIP_E2E || !mutableMessagesSupported)(
     beforeAll(async () => {
       process.on("SIGINT", forceExit);
 
+      // Create channel rule with mutableMessages enabled
+      await setupMutableMessagesRule();
+
       // Publish a test message and get its serial for use in all tests
-      channelName = getUniqueChannelName("annotations");
+      channelName = getMutableChannelName("annotations");
       messageSerial = await publishAndGetSerial(channelName, "annotate-me");
     });
 
-    afterAll(() => {
+    afterAll(async () => {
+      await teardownMutableMessagesRule();
       process.removeListener("SIGINT", forceExit);
     });
 

--- a/test/e2e/channels/channel-annotations-e2e.test.ts
+++ b/test/e2e/channels/channel-annotations-e2e.test.ts
@@ -10,7 +10,6 @@ import {
 import {
   E2E_API_KEY,
   SHOULD_SKIP_E2E,
-  forceExit,
   cleanupTrackedResources,
   setupTestFailureHandler,
   resetTestTracking,
@@ -43,8 +42,6 @@ describe.skipIf(SHOULD_SKIP_E2E || SHOULD_SKIP_MUTABLE_TESTS)(
     let messageSerial: string;
 
     beforeAll(async () => {
-      process.on("SIGINT", forceExit);
-
       // Create channel rule with mutableMessages enabled
       await setupMutableMessagesRule();
 
@@ -55,7 +52,6 @@ describe.skipIf(SHOULD_SKIP_E2E || SHOULD_SKIP_MUTABLE_TESTS)(
 
     afterAll(async () => {
       await teardownMutableMessagesRule();
-      process.removeListener("SIGINT", forceExit);
     });
 
     beforeEach(() => {
@@ -262,6 +258,61 @@ describe.skipIf(SHOULD_SKIP_E2E || SHOULD_SKIP_MUTABLE_TESTS)(
 
           // Wait for the annotation event to appear in subscriber output
           await waitForOutput(subscriber, "total.v1", 15000);
+        } finally {
+          if (subscriber) {
+            await cleanupRunners([subscriber]);
+          }
+        }
+      },
+    );
+
+    it(
+      "should receive a message.summary event when an annotation is published",
+      { timeout: 60000 },
+      async () => {
+        setupTestFailureHandler(
+          "should receive a message.summary event when an annotation is published",
+        );
+
+        // Use a fresh channel + message so we get the summary in isolation,
+        // not mixed with summaries caused by earlier tests in this suite.
+        const summaryChannel = getMutableChannelName("summary");
+        const summarySerial = await publishAndGetSerial(
+          summaryChannel,
+          "summarise-me",
+        );
+
+        let subscriber: CliRunner | null = null;
+        try {
+          subscriber = await startSubscribeCommand(
+            ["channels", "subscribe", summaryChannel, "--duration", "30"],
+            /Subscribed to channel/,
+            {
+              env: { ABLY_API_KEY: E2E_API_KEY || "" },
+              timeoutMs: 30000,
+            },
+          );
+
+          const publishResult = await runCommand(
+            [
+              "channels",
+              "annotations",
+              "publish",
+              summaryChannel,
+              summarySerial,
+              "reactions:flag.v1",
+              "--json",
+            ],
+            {
+              env: { ABLY_API_KEY: E2E_API_KEY || "" },
+              timeoutMs: 30000,
+            },
+          );
+          expect(publishResult.exitCode).toBe(0);
+
+          // The server rolls the annotation up into a message.summary event
+          // and delivers it on the regular channel (no annotation_subscribe mode needed).
+          await waitForOutput(subscriber, "message.summary", 15000);
         } finally {
           if (subscriber) {
             await cleanupRunners([subscriber]);

--- a/test/e2e/channels/channel-annotations-e2e.test.ts
+++ b/test/e2e/channels/channel-annotations-e2e.test.ts
@@ -79,7 +79,7 @@ describe.skipIf(SHOULD_SKIP_E2E || SHOULD_SKIP_MUTABLE_TESTS)(
             "publish",
             channelName,
             messageSerial,
-            "reactions:like.v1",
+            "reactions:flag.v1",
             "--json",
           ],
           {
@@ -101,7 +101,7 @@ describe.skipIf(SHOULD_SKIP_E2E || SHOULD_SKIP_MUTABLE_TESTS)(
         };
         expect(annotation.channel).toBe(channelName);
         expect(annotation.serial).toBe(messageSerial);
-        expect(annotation.type).toBe("reactions:like.v1");
+        expect(annotation.type).toBe("reactions:flag.v1");
       },
     );
 
@@ -250,7 +250,7 @@ describe.skipIf(SHOULD_SKIP_E2E || SHOULD_SKIP_MUTABLE_TESTS)(
               "publish",
               channelName,
               messageSerial,
-              "reactions:subscribe-test.v1",
+              "reactions:total.v1",
               "--json",
             ],
             {
@@ -261,7 +261,7 @@ describe.skipIf(SHOULD_SKIP_E2E || SHOULD_SKIP_MUTABLE_TESTS)(
           expect(publishResult.exitCode).toBe(0);
 
           // Wait for the annotation event to appear in subscriber output
-          await waitForOutput(subscriber, "subscribe-test", 15000);
+          await waitForOutput(subscriber, "total.v1", 15000);
         } finally {
           if (subscriber) {
             await cleanupRunners([subscriber]);

--- a/test/e2e/channels/channel-batch-publish-e2e.test.ts
+++ b/test/e2e/channels/channel-batch-publish-e2e.test.ts
@@ -1,0 +1,96 @@
+import {
+  describe,
+  it,
+  beforeEach,
+  afterEach,
+  beforeAll,
+  afterAll,
+  expect,
+} from "vitest";
+import {
+  E2E_API_KEY,
+  SHOULD_SKIP_E2E,
+  getUniqueChannelName,
+  createAblyClient,
+  forceExit,
+  cleanupTrackedResources,
+  setupTestFailureHandler,
+  resetTestTracking,
+} from "../../helpers/e2e-test-helper.js";
+import { runCommand } from "../../helpers/command-helpers.js";
+import { parseNdjsonLines } from "../../helpers/ndjson.js";
+
+describe.skipIf(SHOULD_SKIP_E2E)("Channel Batch Publish E2E Tests", () => {
+  beforeAll(() => {
+    process.on("SIGINT", forceExit);
+  });
+
+  afterAll(() => {
+    process.removeListener("SIGINT", forceExit);
+  });
+
+  beforeEach(() => {
+    resetTestTracking();
+  });
+
+  afterEach(async () => {
+    await cleanupTrackedResources();
+  });
+
+  it(
+    "should batch publish a message to multiple channels and verify via SDK history",
+    { timeout: 60000 },
+    async () => {
+      setupTestFailureHandler(
+        "should batch publish a message to multiple channels and verify via SDK history",
+      );
+
+      const ch1 = getUniqueChannelName("batch1");
+      const ch2 = getUniqueChannelName("batch2");
+
+      const result = await runCommand(
+        [
+          "channels",
+          "batch-publish",
+          "hello",
+          "--channels",
+          `${ch1},${ch2}`,
+          "--json",
+        ],
+        {
+          env: { ABLY_API_KEY: E2E_API_KEY || "" },
+          timeoutMs: 30000,
+        },
+      );
+
+      expect(result.exitCode).toBe(0);
+
+      const records = parseNdjsonLines(result.stdout);
+      const resultLine = records.find((r) => r.type === "result");
+      expect(resultLine).toBeDefined();
+      expect(resultLine!.success).toBe(true);
+
+      // Verify via SDK that at least one channel received the message
+      const client = createAblyClient();
+      const channel = client.channels.get(ch1);
+
+      // Retry until history is available (eventually consistent)
+      let found = false;
+      for (let i = 0; i < 10; i++) {
+        const historyPage = await channel.history();
+        const messages = historyPage.items;
+        if (
+          messages.some(
+            (msg) =>
+              msg.data === "hello" || JSON.stringify(msg.data) === '"hello"',
+          )
+        ) {
+          found = true;
+          break;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+      }
+      expect(found).toBe(true);
+    },
+  );
+});

--- a/test/e2e/channels/channel-batch-publish-e2e.test.ts
+++ b/test/e2e/channels/channel-batch-publish-e2e.test.ts
@@ -1,18 +1,9 @@
-import {
-  describe,
-  it,
-  beforeEach,
-  afterEach,
-  beforeAll,
-  afterAll,
-  expect,
-} from "vitest";
+import { describe, it, beforeEach, afterEach, expect } from "vitest";
 import {
   E2E_API_KEY,
   SHOULD_SKIP_E2E,
   getUniqueChannelName,
   createAblyClient,
-  forceExit,
   cleanupTrackedResources,
   setupTestFailureHandler,
   resetTestTracking,
@@ -21,14 +12,6 @@ import { runCommand } from "../../helpers/command-helpers.js";
 import { parseNdjsonLines } from "../../helpers/ndjson.js";
 
 describe.skipIf(SHOULD_SKIP_E2E)("Channel Batch Publish E2E Tests", () => {
-  beforeAll(() => {
-    process.on("SIGINT", forceExit);
-  });
-
-  afterAll(() => {
-    process.removeListener("SIGINT", forceExit);
-  });
-
   beforeEach(() => {
     resetTestTracking();
   });

--- a/test/e2e/channels/channel-history-e2e.test.ts
+++ b/test/e2e/channels/channel-history-e2e.test.ts
@@ -1,17 +1,8 @@
-import {
-  describe,
-  it,
-  beforeEach,
-  afterEach,
-  beforeAll,
-  afterAll,
-  expect,
-} from "vitest";
+import { describe, it, beforeEach, afterEach, beforeAll, expect } from "vitest";
 import {
   E2E_API_KEY,
   SHOULD_SKIP_E2E,
   getUniqueChannelName,
-  forceExit,
   cleanupTrackedResources,
   testOutputFiles,
   testCommands,
@@ -26,11 +17,6 @@ describe("Channel History E2E Tests", () => {
     if (SHOULD_SKIP_E2E) {
       return;
     }
-    process.on("SIGINT", forceExit);
-  });
-
-  afterAll(() => {
-    process.removeListener("SIGINT", forceExit);
   });
 
   beforeEach(() => {

--- a/test/e2e/channels/channel-message-ops-e2e.test.ts
+++ b/test/e2e/channels/channel-message-ops-e2e.test.ts
@@ -1,0 +1,146 @@
+import {
+  describe,
+  it,
+  beforeEach,
+  afterEach,
+  beforeAll,
+  afterAll,
+  expect,
+} from "vitest";
+import {
+  E2E_API_KEY,
+  SHOULD_SKIP_E2E,
+  getUniqueChannelName,
+  forceExit,
+  cleanupTrackedResources,
+  setupTestFailureHandler,
+  resetTestTracking,
+} from "../../helpers/e2e-test-helper.js";
+import { runCommand } from "../../helpers/command-helpers.js";
+import { parseNdjsonLines } from "../../helpers/ndjson.js";
+import {
+  checkMutableMessagesSupport,
+  publishAndGetSerial,
+} from "../../helpers/e2e-mutable-messages.js";
+
+// Check if the E2E test app supports mutable messages (required for update/append/delete)
+const mutableMessagesSupported = SHOULD_SKIP_E2E
+  ? false
+  : await checkMutableMessagesSupport();
+
+describe.skipIf(SHOULD_SKIP_E2E || !mutableMessagesSupported)(
+  "Channel Message Operations E2E Tests",
+  () => {
+    let channelName: string;
+    let messageSerial: string;
+
+    beforeAll(async () => {
+      process.on("SIGINT", forceExit);
+
+      // Publish a test message and get its serial for use in all tests
+      channelName = getUniqueChannelName("msg-ops");
+      messageSerial = await publishAndGetSerial(channelName, "test-msg");
+    });
+
+    afterAll(() => {
+      process.removeListener("SIGINT", forceExit);
+    });
+
+    beforeEach(() => {
+      resetTestTracking();
+    });
+
+    afterEach(async () => {
+      await cleanupTrackedResources();
+    });
+
+    it(
+      "should update a message via channels update",
+      { timeout: 60000 },
+      async () => {
+        setupTestFailureHandler("should update a message via channels update");
+
+        const result = await runCommand(
+          [
+            "channels",
+            "update",
+            channelName,
+            messageSerial,
+            "updated-text",
+            "--json",
+          ],
+          {
+            env: { ABLY_API_KEY: E2E_API_KEY || "" },
+            timeoutMs: 30000,
+          },
+        );
+
+        expect(result.exitCode).toBe(0);
+
+        const records = parseNdjsonLines(result.stdout);
+        const parsed = records.find((r) => r.type === "result") ?? records[0];
+        expect(parsed.success).toBe(true);
+        expect(parsed.message).toBeDefined();
+      },
+    );
+
+    it(
+      "should append to a message via channels append",
+      { timeout: 60000 },
+      async () => {
+        setupTestFailureHandler(
+          "should append to a message via channels append",
+        );
+
+        const result = await runCommand(
+          [
+            "channels",
+            "append",
+            channelName,
+            messageSerial,
+            "appended-text",
+            "--json",
+          ],
+          {
+            env: { ABLY_API_KEY: E2E_API_KEY || "" },
+            timeoutMs: 30000,
+          },
+        );
+
+        expect(result.exitCode).toBe(0);
+
+        const records = parseNdjsonLines(result.stdout);
+        const parsed = records.find((r) => r.type === "result") ?? records[0];
+        expect(parsed.success).toBe(true);
+        expect(parsed.message).toBeDefined();
+      },
+    );
+
+    it(
+      "should delete a message via channels delete",
+      { timeout: 60000 },
+      async () => {
+        setupTestFailureHandler("should delete a message via channels delete");
+
+        // Publish a fresh message to delete (so we don't conflict with update/append tests)
+        const deleteChannel = getUniqueChannelName("msg-delete");
+        const serial = await publishAndGetSerial(deleteChannel, "to-delete");
+
+        const result = await runCommand(
+          ["channels", "delete", deleteChannel, serial, "--json"],
+          {
+            env: { ABLY_API_KEY: E2E_API_KEY || "" },
+            timeoutMs: 30000,
+          },
+        );
+
+        expect(result.exitCode).toBe(0);
+
+        const records = parseNdjsonLines(result.stdout);
+        const parsed = records.find((r) => r.type === "result") ?? records[0];
+        expect(parsed.success).toBe(true);
+        expect(parsed.message).toBeDefined();
+      },
+    );
+  },
+);

--- a/test/e2e/channels/channel-message-ops-e2e.test.ts
+++ b/test/e2e/channels/channel-message-ops-e2e.test.ts
@@ -10,7 +10,6 @@ import {
 import {
   E2E_API_KEY,
   SHOULD_SKIP_E2E,
-  getUniqueChannelName,
   forceExit,
   cleanupTrackedResources,
   setupTestFailureHandler,
@@ -19,16 +18,14 @@ import {
 import { runCommand } from "../../helpers/command-helpers.js";
 import { parseNdjsonLines } from "../../helpers/ndjson.js";
 import {
-  checkMutableMessagesSupport,
+  SHOULD_SKIP_MUTABLE_TESTS,
+  setupMutableMessagesRule,
+  teardownMutableMessagesRule,
+  getMutableChannelName,
   publishAndGetSerial,
 } from "../../helpers/e2e-mutable-messages.js";
 
-// Check if the E2E test app supports mutable messages (required for update/append/delete)
-const mutableMessagesSupported = SHOULD_SKIP_E2E
-  ? false
-  : await checkMutableMessagesSupport();
-
-describe.skipIf(SHOULD_SKIP_E2E || !mutableMessagesSupported)(
+describe.skipIf(SHOULD_SKIP_E2E || SHOULD_SKIP_MUTABLE_TESTS)(
   "Channel Message Operations E2E Tests",
   () => {
     let channelName: string;
@@ -37,12 +34,16 @@ describe.skipIf(SHOULD_SKIP_E2E || !mutableMessagesSupported)(
     beforeAll(async () => {
       process.on("SIGINT", forceExit);
 
+      // Create channel rule with mutableMessages enabled
+      await setupMutableMessagesRule();
+
       // Publish a test message and get its serial for use in all tests
-      channelName = getUniqueChannelName("msg-ops");
+      channelName = getMutableChannelName("msg-ops");
       messageSerial = await publishAndGetSerial(channelName, "test-msg");
     });
 
-    afterAll(() => {
+    afterAll(async () => {
+      await teardownMutableMessagesRule();
       process.removeListener("SIGINT", forceExit);
     });
 
@@ -123,7 +124,7 @@ describe.skipIf(SHOULD_SKIP_E2E || !mutableMessagesSupported)(
         setupTestFailureHandler("should delete a message via channels delete");
 
         // Publish a fresh message to delete (so we don't conflict with update/append tests)
-        const deleteChannel = getUniqueChannelName("msg-delete");
+        const deleteChannel = getMutableChannelName("msg-delete");
         const serial = await publishAndGetSerial(deleteChannel, "to-delete");
 
         const result = await runCommand(

--- a/test/e2e/channels/channel-message-ops-e2e.test.ts
+++ b/test/e2e/channels/channel-message-ops-e2e.test.ts
@@ -10,7 +10,6 @@ import {
 import {
   E2E_API_KEY,
   SHOULD_SKIP_E2E,
-  forceExit,
   cleanupTrackedResources,
   setupTestFailureHandler,
   resetTestTracking,
@@ -32,8 +31,6 @@ describe.skipIf(SHOULD_SKIP_E2E || SHOULD_SKIP_MUTABLE_TESTS)(
     let messageSerial: string;
 
     beforeAll(async () => {
-      process.on("SIGINT", forceExit);
-
       // Create channel rule with mutableMessages enabled
       await setupMutableMessagesRule();
 
@@ -44,7 +41,6 @@ describe.skipIf(SHOULD_SKIP_E2E || SHOULD_SKIP_MUTABLE_TESTS)(
 
     afterAll(async () => {
       await teardownMutableMessagesRule();
-      process.removeListener("SIGINT", forceExit);
     });
 
     beforeEach(() => {

--- a/test/e2e/channels/channel-occupancy-e2e.test.ts
+++ b/test/e2e/channels/channel-occupancy-e2e.test.ts
@@ -1,12 +1,4 @@
-import {
-  describe,
-  it,
-  beforeEach,
-  afterEach,
-  beforeAll,
-  afterAll,
-  expect,
-} from "vitest";
+import { describe, it, beforeEach, afterEach, beforeAll, expect } from "vitest";
 import {
   SHOULD_SKIP_E2E,
   getUniqueChannelName,
@@ -14,7 +6,6 @@ import {
   runLongRunningBackgroundProcess,
   runBackgroundProcessAndGetOutput,
   killProcess,
-  forceExit,
   cleanupTrackedResources,
   testOutputFiles,
   testCommands,
@@ -29,11 +20,6 @@ describe("Channel Occupancy E2E Tests", () => {
     if (SHOULD_SKIP_E2E) {
       return;
     }
-    process.on("SIGINT", forceExit);
-  });
-
-  afterAll(() => {
-    process.removeListener("SIGINT", forceExit);
   });
 
   let occupancyChannel: string;

--- a/test/e2e/channels/channel-occupancy-get-e2e.test.ts
+++ b/test/e2e/channels/channel-occupancy-get-e2e.test.ts
@@ -1,17 +1,8 @@
-import {
-  describe,
-  it,
-  beforeEach,
-  afterEach,
-  beforeAll,
-  afterAll,
-  expect,
-} from "vitest";
+import { describe, it, beforeEach, afterEach, expect } from "vitest";
 import {
   E2E_API_KEY,
   SHOULD_SKIP_E2E,
   getUniqueChannelName,
-  forceExit,
   cleanupTrackedResources,
   setupTestFailureHandler,
   resetTestTracking,
@@ -26,14 +17,6 @@ import { parseNdjsonLines } from "../../helpers/ndjson.js";
 
 describe.skipIf(SHOULD_SKIP_E2E)("Channel Occupancy Get E2E Tests", () => {
   const runners: CliRunner[] = [];
-
-  beforeAll(() => {
-    process.on("SIGINT", forceExit);
-  });
-
-  afterAll(() => {
-    process.removeListener("SIGINT", forceExit);
-  });
 
   beforeEach(() => {
     resetTestTracking();

--- a/test/e2e/channels/channel-occupancy-get-e2e.test.ts
+++ b/test/e2e/channels/channel-occupancy-get-e2e.test.ts
@@ -1,0 +1,96 @@
+import {
+  describe,
+  it,
+  beforeEach,
+  afterEach,
+  beforeAll,
+  afterAll,
+  expect,
+} from "vitest";
+import {
+  E2E_API_KEY,
+  SHOULD_SKIP_E2E,
+  getUniqueChannelName,
+  forceExit,
+  cleanupTrackedResources,
+  setupTestFailureHandler,
+  resetTestTracking,
+} from "../../helpers/e2e-test-helper.js";
+import {
+  runCommand,
+  startSubscribeCommand,
+  cleanupRunners,
+} from "../../helpers/command-helpers.js";
+import type { CliRunner } from "../../helpers/cli-runner.js";
+import { parseNdjsonLines } from "../../helpers/ndjson.js";
+
+describe.skipIf(SHOULD_SKIP_E2E)("Channel Occupancy Get E2E Tests", () => {
+  const runners: CliRunner[] = [];
+
+  beforeAll(() => {
+    process.on("SIGINT", forceExit);
+  });
+
+  afterAll(() => {
+    process.removeListener("SIGINT", forceExit);
+  });
+
+  beforeEach(() => {
+    resetTestTracking();
+  });
+
+  afterEach(async () => {
+    await cleanupRunners(runners);
+    runners.length = 0;
+    await cleanupTrackedResources();
+  });
+
+  it(
+    "should get occupancy data for a channel with an active subscriber",
+    { timeout: 60000 },
+    async () => {
+      setupTestFailureHandler(
+        "should get occupancy data for a channel with an active subscriber",
+      );
+
+      const channel = getUniqueChannelName("occupancy");
+
+      // Start a subscriber to create some occupancy
+      const subscriber = await startSubscribeCommand(
+        ["channels", "subscribe", channel, "--duration", "30"],
+        /Listening for messages/,
+        { env: { ABLY_API_KEY: E2E_API_KEY || "" } },
+      );
+      runners.push(subscriber);
+
+      // Give some time for the subscriber to be fully registered
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+
+      // Get occupancy via CLI
+      const result = await runCommand(
+        ["channels", "occupancy", "get", channel, "--json"],
+        {
+          env: { ABLY_API_KEY: E2E_API_KEY || "" },
+          timeoutMs: 30000,
+        },
+      );
+
+      expect(result.exitCode).toBe(0);
+
+      // Parse JSON output
+      const records = parseNdjsonLines(result.stdout);
+      const resultObj = records.find((r) => r.type === "result" || r.occupancy);
+
+      expect(resultObj).toBeDefined();
+      expect(resultObj!.occupancy).toBeDefined();
+
+      const occupancy = resultObj!.occupancy as {
+        channel: string;
+        metrics: Record<string, number>;
+      };
+      expect(occupancy.channel).toBe(channel);
+      expect(occupancy.metrics).toBeDefined();
+      expect(typeof occupancy.metrics.subscribers).toBe("number");
+    },
+  );
+});

--- a/test/e2e/channels/channel-presence-e2e.test.ts
+++ b/test/e2e/channels/channel-presence-e2e.test.ts
@@ -1,18 +1,9 @@
-import {
-  describe,
-  it,
-  beforeEach,
-  afterEach,
-  beforeAll,
-  afterAll,
-  expect,
-} from "vitest";
+import { describe, it, beforeEach, afterEach, beforeAll, expect } from "vitest";
 import { randomUUID } from "node:crypto";
 import {
   E2E_API_KEY,
   SHOULD_SKIP_E2E,
   getUniqueChannelName,
-  forceExit,
   cleanupTrackedResources,
   testOutputFiles,
   testCommands,
@@ -27,11 +18,6 @@ describe("Channel Presence E2E Tests", () => {
     if (SHOULD_SKIP_E2E) {
       return;
     }
-    process.on("SIGINT", forceExit);
-  });
-
-  afterAll(() => {
-    process.removeListener("SIGINT", forceExit);
   });
 
   beforeEach(() => {

--- a/test/e2e/channels/channel-presence-subscribe-e2e.test.ts
+++ b/test/e2e/channels/channel-presence-subscribe-e2e.test.ts
@@ -1,0 +1,104 @@
+import {
+  describe,
+  it,
+  beforeEach,
+  afterEach,
+  beforeAll,
+  afterAll,
+  expect,
+} from "vitest";
+import {
+  E2E_API_KEY,
+  SHOULD_SKIP_E2E,
+  getUniqueChannelName,
+  getUniqueClientId,
+  forceExit,
+  cleanupTrackedResources,
+  setupTestFailureHandler,
+  resetTestTracking,
+} from "../../helpers/e2e-test-helper.js";
+import {
+  startSubscribeCommand,
+  startPresenceCommand,
+  waitForOutput,
+  cleanupRunners,
+} from "../../helpers/command-helpers.js";
+import type { CliRunner } from "../../helpers/cli-runner.js";
+
+describe.skipIf(SHOULD_SKIP_E2E)("Channel Presence Subscribe E2E Tests", () => {
+  const runners: CliRunner[] = [];
+
+  beforeAll(() => {
+    process.on("SIGINT", forceExit);
+  });
+
+  afterAll(() => {
+    process.removeListener("SIGINT", forceExit);
+  });
+
+  beforeEach(() => {
+    resetTestTracking();
+  });
+
+  afterEach(async () => {
+    await cleanupRunners(runners);
+    runners.length = 0;
+    await cleanupTrackedResources();
+  });
+
+  it(
+    "should receive presence enter events on a subscribed channel",
+    { timeout: 60000 },
+    async () => {
+      setupTestFailureHandler(
+        "should receive presence enter events on a subscribed channel",
+      );
+
+      const channel = getUniqueChannelName("pres-sub");
+      const subClientId = getUniqueClientId("sub-client");
+      const enterClientId = getUniqueClientId("enter-client");
+
+      // Start presence subscriber
+      const subscriber = await startSubscribeCommand(
+        [
+          "channels",
+          "presence",
+          "subscribe",
+          channel,
+          "--client-id",
+          subClientId,
+          "--duration",
+          "30",
+        ],
+        /Listening for presence events/,
+        { env: { ABLY_API_KEY: E2E_API_KEY || "" } },
+      );
+      runners.push(subscriber);
+
+      // Start presence enter on the same channel with a different client
+      const enterer = await startPresenceCommand(
+        [
+          "channels",
+          "presence",
+          "enter",
+          channel,
+          "--client-id",
+          enterClientId,
+          "--data",
+          '{"status":"online"}',
+          "--duration",
+          "30",
+        ],
+        /Entered presence/,
+        { env: { ABLY_API_KEY: E2E_API_KEY || "" } },
+      );
+      runners.push(enterer);
+
+      // Wait for the subscriber to see the enter event
+      await waitForOutput(subscriber, enterClientId, 15000);
+
+      const output = subscriber.combined();
+      expect(output).toContain(enterClientId);
+    },
+  );
+});

--- a/test/e2e/channels/channel-presence-subscribe-e2e.test.ts
+++ b/test/e2e/channels/channel-presence-subscribe-e2e.test.ts
@@ -1,18 +1,9 @@
-import {
-  describe,
-  it,
-  beforeEach,
-  afterEach,
-  beforeAll,
-  afterAll,
-  expect,
-} from "vitest";
+import { describe, it, beforeEach, afterEach, expect } from "vitest";
 import {
   E2E_API_KEY,
   SHOULD_SKIP_E2E,
   getUniqueChannelName,
   getUniqueClientId,
-  forceExit,
   cleanupTrackedResources,
   setupTestFailureHandler,
   resetTestTracking,
@@ -27,14 +18,6 @@ import type { CliRunner } from "../../helpers/cli-runner.js";
 
 describe.skipIf(SHOULD_SKIP_E2E)("Channel Presence Subscribe E2E Tests", () => {
   const runners: CliRunner[] = [];
-
-  beforeAll(() => {
-    process.on("SIGINT", forceExit);
-  });
-
-  afterAll(() => {
-    process.removeListener("SIGINT", forceExit);
-  });
 
   beforeEach(() => {
     resetTestTracking();

--- a/test/e2e/channels/channel-subscribe-e2e.test.ts
+++ b/test/e2e/channels/channel-subscribe-e2e.test.ts
@@ -88,44 +88,38 @@ describe("Channel Subscribe E2E Tests", () => {
       `[Test Subscribe] Background subscriber process ${subscribeProcessInfo.processId} ready.`,
     );
 
-    try {
-      // Publish a message to the channel
-      console.log(
-        `[Test Subscribe] Publishing message to ${subscribeChannel}...`,
-      );
-      const testMessage = { text: "Subscribe E2E Test" };
-      await publishTestMessage(subscribeChannel, testMessage);
-      console.log(`[Test Subscribe] Message published.`);
+    // Publish a message to the channel
+    console.log(
+      `[Test Subscribe] Publishing message to ${subscribeChannel}...`,
+    );
+    const testMessage = { text: "Subscribe E2E Test" };
+    await publishTestMessage(subscribeChannel, testMessage);
+    console.log(`[Test Subscribe] Message published.`);
 
-      // Wait for the subscribe process to receive the message
-      console.log(
-        `[Test Subscribe] Waiting for message in output file ${outputPath}...`,
-      );
-      let messageReceived = false;
-      // Poll for a reasonable time after publishing
-      for (let i = 0; i < 50; i++) {
-        // ~7.5 seconds polling
-        const output = await readProcessOutput(outputPath);
-        if (output.includes("Subscribe E2E Test")) {
-          console.log(`[Test Subscribe] Message received in output.`);
-          messageReceived = true;
-          break;
-        }
-        await new Promise((resolve) => setTimeout(resolve, 150));
+    // Wait for the subscribe process to receive the message
+    console.log(
+      `[Test Subscribe] Waiting for message in output file ${outputPath}...`,
+    );
+    let messageReceived = false;
+    // Poll for a reasonable time after publishing
+    for (let i = 0; i < 50; i++) {
+      // ~7.5 seconds polling
+      const output = await readProcessOutput(outputPath);
+      if (output.includes("Subscribe E2E Test")) {
+        console.log(`[Test Subscribe] Message received in output.`);
+        messageReceived = true;
+        break;
       }
-      if (!messageReceived) {
-        const finalOutput = await readProcessOutput(outputPath);
-        console.error(
-          `[Test Subscribe] FAILED TO FIND MESSAGE. Final output:\n${finalOutput}`,
-        );
-      }
-      expect(messageReceived).toBe(true);
-    } finally {
-      // Cleanup is handled by afterEach hook
-      console.log(
-        `[Test Subscribe] Test finished, cleanup will handle process ${subscribeProcessInfo.processId}`,
+      await new Promise((resolve) => setTimeout(resolve, 150));
+    }
+    if (!messageReceived) {
+      const finalOutput = await readProcessOutput(outputPath);
+      console.error(
+        `[Test Subscribe] FAILED TO FIND MESSAGE. Final output:\n${finalOutput}`,
       );
     }
+    expect(messageReceived).toBe(true);
+    // Cleanup is handled by afterEach hook
   });
 
   // End-to-end: both subscriber AND publisher run through the CLI subprocess —
@@ -145,36 +139,30 @@ describe("Channel Subscribe E2E Tests", () => {
       { readySignal, timeoutMs: 15000 },
     );
 
-    try {
-      const messageText = `cli-to-cli-${Date.now()}`;
-      const publishResult = await runCommand([
-        "channels",
-        "publish",
-        subscribeChannel,
-        messageText,
-      ]);
-      expect(publishResult.exitCode).toBe(0);
+    const messageText = `cli-to-cli-${Date.now()}`;
+    const publishResult = await runCommand([
+      "channels",
+      "publish",
+      subscribeChannel,
+      messageText,
+    ]);
+    expect(publishResult.exitCode).toBe(0);
 
-      let messageReceived = false;
-      for (let i = 0; i < 50; i++) {
-        const output = await readProcessOutput(outputPath);
-        if (output.includes(messageText)) {
-          messageReceived = true;
-          break;
-        }
-        await new Promise((resolve) => setTimeout(resolve, 150));
+    let messageReceived = false;
+    for (let i = 0; i < 50; i++) {
+      const output = await readProcessOutput(outputPath);
+      if (output.includes(messageText)) {
+        messageReceived = true;
+        break;
       }
-      if (!messageReceived) {
-        const finalOutput = await readProcessOutput(outputPath);
-        console.error(
-          `[Test CLI-to-CLI] FAILED. Final subscriber output:\n${finalOutput}`,
-        );
-      }
-      expect(messageReceived).toBe(true);
-    } finally {
-      console.log(
-        `[Test CLI-to-CLI] Test finished, cleanup will handle process ${subscribeProcessInfo.processId}`,
+      await new Promise((resolve) => setTimeout(resolve, 150));
+    }
+    if (!messageReceived) {
+      const finalOutput = await readProcessOutput(outputPath);
+      console.error(
+        `[Test CLI-to-CLI] FAILED. Final subscriber output:\n${finalOutput}`,
       );
     }
+    expect(messageReceived).toBe(true);
   });
 });

--- a/test/e2e/channels/channel-subscribe-e2e.test.ts
+++ b/test/e2e/channels/channel-subscribe-e2e.test.ts
@@ -22,6 +22,7 @@ import {
   setupTestFailureHandler,
   resetTestTracking,
 } from "../../helpers/e2e-test-helper.js";
+import { runCommand } from "../../helpers/command-helpers.js";
 import { ChildProcess } from "node:child_process";
 
 describe("Channel Subscribe E2E Tests", () => {
@@ -123,6 +124,56 @@ describe("Channel Subscribe E2E Tests", () => {
       // Cleanup is handled by afterEach hook
       console.log(
         `[Test Subscribe] Test finished, cleanup will handle process ${subscribeProcessInfo.processId}`,
+      );
+    }
+  });
+
+  // End-to-end: both subscriber AND publisher run through the CLI subprocess —
+  // not the SDK — so regressions in the CLI publish path surface here.
+  it("should deliver a CLI-published message to a CLI subscriber", async () => {
+    setupTestFailureHandler(
+      "should deliver a CLI-published message to a CLI subscriber",
+    );
+
+    if (SHOULD_SKIP_E2E) return;
+
+    const readySignal = "Subscribed to channel";
+
+    subscribeProcessInfo = await runLongRunningBackgroundProcess(
+      `bin/run.js channels subscribe ${subscribeChannel}`,
+      outputPath,
+      { readySignal, timeoutMs: 15000 },
+    );
+
+    try {
+      const messageText = `cli-to-cli-${Date.now()}`;
+      const publishResult = await runCommand([
+        "channels",
+        "publish",
+        subscribeChannel,
+        messageText,
+      ]);
+      expect(publishResult.exitCode).toBe(0);
+
+      let messageReceived = false;
+      for (let i = 0; i < 50; i++) {
+        const output = await readProcessOutput(outputPath);
+        if (output.includes(messageText)) {
+          messageReceived = true;
+          break;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 150));
+      }
+      if (!messageReceived) {
+        const finalOutput = await readProcessOutput(outputPath);
+        console.error(
+          `[Test CLI-to-CLI] FAILED. Final subscriber output:\n${finalOutput}`,
+        );
+      }
+      expect(messageReceived).toBe(true);
+    } finally {
+      console.log(
+        `[Test CLI-to-CLI] Test finished, cleanup will handle process ${subscribeProcessInfo.processId}`,
       );
     }
   });

--- a/test/e2e/channels/channel-subscribe-e2e.test.ts
+++ b/test/e2e/channels/channel-subscribe-e2e.test.ts
@@ -1,12 +1,4 @@
-import {
-  describe,
-  it,
-  beforeEach,
-  afterEach,
-  beforeAll,
-  afterAll,
-  expect,
-} from "vitest";
+import { describe, it, beforeEach, afterEach, expect } from "vitest";
 import {
   SHOULD_SKIP_E2E,
   getUniqueChannelName,
@@ -15,7 +7,6 @@ import {
   readProcessOutput,
   publishTestMessage,
   killProcess,
-  forceExit,
   cleanupTrackedResources,
   testOutputFiles,
   testCommands,
@@ -26,18 +17,6 @@ import { runCommand } from "../../helpers/command-helpers.js";
 import { ChildProcess } from "node:child_process";
 
 describe("Channel Subscribe E2E Tests", () => {
-  // Skip all tests if API key not available
-  beforeAll(async () => {
-    if (SHOULD_SKIP_E2E) {
-      return;
-    }
-    process.on("SIGINT", forceExit);
-  });
-
-  afterAll(() => {
-    process.removeListener("SIGINT", forceExit);
-  });
-
   let subscribeChannel: string;
   let outputPath: string;
   let subscribeProcessInfo: {
@@ -81,45 +60,22 @@ describe("Channel Subscribe E2E Tests", () => {
     subscribeProcessInfo = await runLongRunningBackgroundProcess(
       `bin/run.js channels subscribe ${subscribeChannel}`,
       outputPath,
-      { readySignal, timeoutMs: 15000 }, // Pass signal and a 15s timeout
-    );
-    // If the above promise resolved, the process is ready.
-    console.log(
-      `[Test Subscribe] Background subscriber process ${subscribeProcessInfo.processId} ready.`,
+      { readySignal, timeoutMs: 15000 },
     );
 
-    // Publish a message to the channel
-    console.log(
-      `[Test Subscribe] Publishing message to ${subscribeChannel}...`,
-    );
     const testMessage = { text: "Subscribe E2E Test" };
     await publishTestMessage(subscribeChannel, testMessage);
-    console.log(`[Test Subscribe] Message published.`);
 
-    // Wait for the subscribe process to receive the message
-    console.log(
-      `[Test Subscribe] Waiting for message in output file ${outputPath}...`,
-    );
     let messageReceived = false;
-    // Poll for a reasonable time after publishing
     for (let i = 0; i < 50; i++) {
-      // ~7.5 seconds polling
       const output = await readProcessOutput(outputPath);
       if (output.includes("Subscribe E2E Test")) {
-        console.log(`[Test Subscribe] Message received in output.`);
         messageReceived = true;
         break;
       }
       await new Promise((resolve) => setTimeout(resolve, 150));
     }
-    if (!messageReceived) {
-      const finalOutput = await readProcessOutput(outputPath);
-      console.error(
-        `[Test Subscribe] FAILED TO FIND MESSAGE. Final output:\n${finalOutput}`,
-      );
-    }
     expect(messageReceived).toBe(true);
-    // Cleanup is handled by afterEach hook
   });
 
   // End-to-end: both subscriber AND publisher run through the CLI subprocess —
@@ -156,12 +112,6 @@ describe("Channel Subscribe E2E Tests", () => {
         break;
       }
       await new Promise((resolve) => setTimeout(resolve, 150));
-    }
-    if (!messageReceived) {
-      const finalOutput = await readProcessOutput(outputPath);
-      console.error(
-        `[Test CLI-to-CLI] FAILED. Final subscriber output:\n${finalOutput}`,
-      );
     }
     expect(messageReceived).toBe(true);
   });

--- a/test/e2e/channels/channels-e2e.test.ts
+++ b/test/e2e/channels/channels-e2e.test.ts
@@ -1,12 +1,4 @@
-import {
-  describe,
-  it,
-  beforeEach,
-  afterEach,
-  beforeAll,
-  afterAll,
-  expect,
-} from "vitest";
+import { describe, it, beforeEach, afterEach, beforeAll, expect } from "vitest";
 import * as Ably from "ably";
 import {
   E2E_API_KEY,
@@ -14,7 +6,6 @@ import {
   getUniqueChannelName,
   createAblyClient,
   publishTestMessage,
-  forceExit,
   cleanupTrackedResources,
   testOutputFiles,
   testCommands,
@@ -76,7 +67,6 @@ describe("Channel E2E Tests", () => {
     if (SHOULD_SKIP_E2E) {
       return;
     }
-    process.on("SIGINT", forceExit);
 
     try {
       // Set up unique channel names for the tests
@@ -97,10 +87,6 @@ describe("Channel E2E Tests", () => {
       );
       // Don't fail the entire test suite, let individual tests fail if needed
     }
-  });
-
-  afterAll(() => {
-    process.removeListener("SIGINT", forceExit);
   });
 
   beforeEach(() => {

--- a/test/e2e/config/config-e2e.test.ts
+++ b/test/e2e/config/config-e2e.test.ts
@@ -1,0 +1,96 @@
+import {
+  describe,
+  it,
+  beforeEach,
+  afterEach,
+  beforeAll,
+  afterAll,
+  expect,
+} from "vitest";
+import {
+  forceExit,
+  cleanupTrackedResources,
+  setupTestFailureHandler,
+  resetTestTracking,
+} from "../../helpers/e2e-test-helper.js";
+import { runCommand } from "../../helpers/command-helpers.js";
+
+describe("Config E2E Tests", () => {
+  beforeAll(() => {
+    process.on("SIGINT", forceExit);
+  });
+
+  afterAll(() => {
+    process.removeListener("SIGINT", forceExit);
+  });
+
+  beforeEach(() => {
+    resetTestTracking();
+  });
+
+  afterEach(async () => {
+    await cleanupTrackedResources();
+  });
+
+  describe("config show", () => {
+    it("should run config show without crashing", async () => {
+      setupTestFailureHandler("should run config show without crashing");
+
+      const result = await runCommand(["config", "show"], {
+        env: { NODE_OPTIONS: "", ABLY_CLI_NON_INTERACTIVE: "true" },
+        timeoutMs: 10000,
+      });
+
+      // Command should either succeed (config exists) or fail gracefully
+      // (config missing — exit code 1 in JSON mode, 2 in non-JSON mode).
+      expect([0, 1, 2]).toContain(result.exitCode);
+    });
+
+    it("should run config show with --json without crashing", async () => {
+      setupTestFailureHandler(
+        "should run config show with --json without crashing",
+      );
+
+      const result = await runCommand(["config", "show", "--json"], {
+        env: { NODE_OPTIONS: "", ABLY_CLI_NON_INTERACTIVE: "true" },
+        timeoutMs: 10000,
+      });
+
+      // Same as above — just verify it doesn't crash
+      expect([0, 1]).toContain(result.exitCode);
+    });
+  });
+
+  describe("config path", () => {
+    it("should print the config file path", async () => {
+      setupTestFailureHandler("should print the config file path");
+
+      const result = await runCommand(["config", "path"], {
+        env: { NODE_OPTIONS: "", ABLY_CLI_NON_INTERACTIVE: "true" },
+        timeoutMs: 10000,
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toMatch(/\.ably/);
+    });
+
+    it("should output config path as JSON", async () => {
+      setupTestFailureHandler("should output config path as JSON");
+
+      const result = await runCommand(["config", "path", "--json"], {
+        env: { NODE_OPTIONS: "", ABLY_CLI_NON_INTERACTIVE: "true" },
+        timeoutMs: 10000,
+      });
+
+      expect(result.exitCode).toBe(0);
+      const lines = result.stdout
+        .trim()
+        .split("\n")
+        .filter((l) => l.trim().startsWith("{"));
+      expect(lines.length).toBeGreaterThan(0);
+      const json = JSON.parse(lines[0]);
+      expect(json).toHaveProperty("config");
+      expect(json.config).toHaveProperty("path");
+    });
+  });
+});

--- a/test/e2e/config/config-e2e.test.ts
+++ b/test/e2e/config/config-e2e.test.ts
@@ -1,14 +1,5 @@
+import { describe, it, beforeEach, afterEach, expect } from "vitest";
 import {
-  describe,
-  it,
-  beforeEach,
-  afterEach,
-  beforeAll,
-  afterAll,
-  expect,
-} from "vitest";
-import {
-  forceExit,
   cleanupTrackedResources,
   setupTestFailureHandler,
   resetTestTracking,
@@ -16,14 +7,6 @@ import {
 import { runCommand } from "../../helpers/command-helpers.js";
 
 describe("Config E2E Tests", () => {
-  beforeAll(() => {
-    process.on("SIGINT", forceExit);
-  });
-
-  afterAll(() => {
-    process.removeListener("SIGINT", forceExit);
-  });
-
   beforeEach(() => {
     resetTestTracking();
   });

--- a/test/e2e/config/config-e2e.test.ts
+++ b/test/e2e/config/config-e2e.test.ts
@@ -58,6 +58,15 @@ describe("Config E2E Tests", () => {
 
       // Same as above — just verify it doesn't crash
       expect([0, 1]).toContain(result.exitCode);
+
+      // Validate JSON structure — both success and error produce valid JSON
+      const lines = result.stdout
+        .trim()
+        .split("\n")
+        .filter((l) => l.trim().startsWith("{"));
+      expect(lines.length).toBeGreaterThan(0);
+      const json = JSON.parse(lines[0]);
+      expect(json).toHaveProperty("type");
     });
   });
 

--- a/test/e2e/connections/connections.test.ts
+++ b/test/e2e/connections/connections.test.ts
@@ -1,16 +1,7 @@
-import {
-  describe,
-  it,
-  beforeEach,
-  afterEach,
-  beforeAll,
-  afterAll,
-  expect,
-} from "vitest";
+import { describe, it, beforeEach, afterEach, expect } from "vitest";
 import { runCommand } from "../../helpers/command-helpers.js";
 import { parseNdjsonLines } from "../../helpers/ndjson.js";
 import {
-  forceExit,
   cleanupTrackedResources,
   testOutputFiles,
   testCommands,
@@ -21,14 +12,6 @@ import { spawn } from "node:child_process";
 import { join } from "node:path";
 
 describe("Connections E2E Tests", () => {
-  beforeAll(() => {
-    process.on("SIGINT", forceExit);
-  });
-
-  afterAll(() => {
-    process.removeListener("SIGINT", forceExit);
-  });
-
   beforeEach(() => {
     resetTestTracking();
     // Clear tracked output files and commands for this test

--- a/test/e2e/control-api.test.ts
+++ b/test/e2e/control-api.test.ts
@@ -165,7 +165,7 @@ describe.skipIf(!process.env.E2E_ABLY_ACCESS_TOKEN)(
         const keyData = {
           name: `Test Key ${Date.now()}`,
           capability: {
-            "*": ["*"],
+            "[*]*": ["*"],
           },
         };
 
@@ -271,9 +271,7 @@ describe.skipIf(!process.env.E2E_ABLY_ACCESS_TOKEN)(
           },
           target: {
             url: "https://httpbin.org/post",
-            headers: {
-              "Content-Type": "application/json",
-            },
+            headers: [{ name: "Content-Type", value: "application/json" }],
           },
         };
 
@@ -310,6 +308,7 @@ describe.skipIf(!process.env.E2E_ABLY_ACCESS_TOKEN)(
 
       it("should update an integration rule", async () => {
         const updateData = {
+          ruleType: "http",
           source: {
             channelFilter: "updated-channel",
             type: "channel.message",
@@ -373,11 +372,12 @@ describe.skipIf(!process.env.E2E_ABLY_ACCESS_TOKEN)(
       });
 
       it("should get a specific namespace", async () => {
-        const namespace = await controlApi.getNamespace(
-          testAppId,
-          testNamespaceId,
-        );
+        // Individual namespace GET endpoint is no longer available;
+        // verify by listing and filtering instead.
+        const namespaces = await controlApi.listNamespaces(testAppId);
+        const namespace = namespaces.find((ns) => ns.id === testNamespaceId);
 
+        expect(namespace).toBeDefined();
         expect(namespace).toHaveProperty("id", testNamespaceId);
         expect(namespace).toHaveProperty("appId", testAppId);
       });

--- a/test/e2e/control-api.test.ts
+++ b/test/e2e/control-api.test.ts
@@ -226,7 +226,7 @@ describe.skipIf(!process.env.E2E_ABLY_ACCESS_TOKEN)(
         const queueData = {
           name: testQueueName,
           maxLength: 1000,
-          ttl: 3600,
+          ttl: 60,
           region: "us-east-1-a",
         };
 
@@ -236,7 +236,7 @@ describe.skipIf(!process.env.E2E_ABLY_ACCESS_TOKEN)(
         expect(queue).toHaveProperty("name", testQueueName);
         expect(queue).toHaveProperty("appId", testAppId);
         expect(queue).toHaveProperty("maxLength", 1000);
-        expect(queue).toHaveProperty("ttl", 3600);
+        expect(queue).toHaveProperty("ttl", 60);
         expect(queue).toHaveProperty("region", "us-east-1-a");
 
         createdResources.queues.push(testQueueName);

--- a/test/e2e/control-api.test.ts
+++ b/test/e2e/control-api.test.ts
@@ -271,6 +271,7 @@ describe.skipIf(!process.env.E2E_ABLY_ACCESS_TOKEN)(
           },
           target: {
             url: "https://httpbin.org/post",
+            format: "json",
             headers: [{ name: "Content-Type", value: "application/json" }],
           },
         };
@@ -309,12 +310,14 @@ describe.skipIf(!process.env.E2E_ABLY_ACCESS_TOKEN)(
       it("should update an integration rule", async () => {
         const updateData = {
           ruleType: "http",
+          requestMode: "single",
           source: {
             channelFilter: "updated-channel",
             type: "channel.message",
           },
           target: {
             url: "https://httpbin.org/put",
+            format: "json",
           },
         };
 
@@ -387,7 +390,7 @@ describe.skipIf(!process.env.E2E_ABLY_ACCESS_TOKEN)(
           persisted: false,
           pushEnabled: true,
           batchingEnabled: true,
-          batchingInterval: 5000,
+          batchingInterval: 500,
         };
 
         const updatedNamespace = await controlApi.updateNamespace(
@@ -400,7 +403,7 @@ describe.skipIf(!process.env.E2E_ABLY_ACCESS_TOKEN)(
         expect(updatedNamespace).toHaveProperty("persisted", false);
         expect(updatedNamespace).toHaveProperty("pushEnabled", true);
         expect(updatedNamespace).toHaveProperty("batchingEnabled", true);
-        expect(updatedNamespace).toHaveProperty("batchingInterval", 5000);
+        expect(updatedNamespace).toHaveProperty("batchingInterval", 500);
       });
 
       it("should delete a namespace", async () => {

--- a/test/e2e/control/control-api-workflows.test.ts
+++ b/test/e2e/control/control-api-workflows.test.ts
@@ -11,7 +11,6 @@ import { ControlApi } from "../../../src/services/control-api.js";
 import {
   E2E_ACCESS_TOKEN,
   runBackgroundProcessAndGetOutput,
-  forceExit,
   cleanupTrackedResources,
   testOutputFiles,
   testCommands,
@@ -19,6 +18,7 @@ import {
   resetTestTracking,
 } from "../../helpers/e2e-test-helper.js";
 import { runCommand } from "../../helpers/command-helpers.js";
+import { createTestApp } from "../../helpers/e2e-test-app.js";
 import { parseNdjsonLines } from "../../helpers/ndjson.js";
 
 describe("Control API E2E Workflow Tests", () => {
@@ -35,8 +35,6 @@ describe("Control API E2E Workflow Tests", () => {
   let shouldSkip = false;
 
   beforeAll(async () => {
-    process.on("SIGINT", forceExit);
-
     const accessToken = E2E_ACCESS_TOKEN;
     if (!accessToken) {
       console.log(
@@ -129,7 +127,6 @@ describe("Control API E2E Workflow Tests", () => {
         console.warn(`Failed to delete app ${appId}:`, error);
       }
     }
-    process.removeListener("SIGINT", forceExit);
   });
 
   beforeEach(() => {
@@ -232,35 +229,16 @@ describe("Control API E2E Workflow Tests", () => {
   describe("API Key Management Workflow", () => {
     let testAppId: string;
 
+    let teardownApp: (() => Promise<void>) | undefined;
+
     beforeAll(async () => {
       if (shouldSkip) return;
-
-      // Create a test app first
-      const appName = `E2E Key Test App ${Date.now()}`;
-      const createResult = await runCommand(
-        ["apps", "create", appName, "--json"],
-        {
-          env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN },
-        },
-      );
-
-      const result = parseNdjsonLines(createResult.stdout).find(
-        (r) => r.type === "result",
-      ) as Record<string, unknown>;
-      testAppId = (result.app as Record<string, unknown>).id as string;
+      ({ appId: testAppId, teardown: teardownApp } =
+        await createTestApp("e2e-key-test"));
     });
 
     afterAll(async () => {
-      // Clean up test app if created
-      if (testAppId) {
-        try {
-          await runCommand(["apps", "delete", testAppId, "--force"], {
-            env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN },
-          });
-        } catch (error) {
-          console.log("Error cleaning up test app:", error);
-        }
-      }
+      await teardownApp?.();
     });
 
     it("should create a new API key", async () => {
@@ -569,35 +547,16 @@ describe("Control API E2E Workflow Tests", () => {
   describe("Queue Management Workflow", () => {
     let testAppId: string;
 
+    let teardownApp: (() => Promise<void>) | undefined;
+
     beforeAll(async () => {
       if (shouldSkip) return;
-
-      // Create a test app first
-      const appName = `E2E Queue Test App ${Date.now()}`;
-      const createResult = await runCommand(
-        ["apps", "create", appName, "--json"],
-        {
-          env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN },
-        },
-      );
-
-      const result = parseNdjsonLines(createResult.stdout).find(
-        (r) => r.type === "result",
-      ) as Record<string, unknown>;
-      testAppId = (result.app as Record<string, unknown>).id as string;
+      ({ appId: testAppId, teardown: teardownApp } =
+        await createTestApp("e2e-queue-test"));
     });
 
     afterAll(async () => {
-      // Clean up test app if created
-      if (testAppId) {
-        try {
-          await runCommand(["apps", "delete", testAppId, "--force"], {
-            env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN },
-          });
-        } catch (error) {
-          console.log("Error cleaning up test app:", error);
-        }
-      }
+      await teardownApp?.();
     });
 
     it("should create a new queue", async () => {
@@ -700,35 +659,17 @@ describe("Control API E2E Workflow Tests", () => {
   describe("Integration Rules Workflow", () => {
     let testAppId: string;
 
+    let teardownApp: (() => Promise<void>) | undefined;
+
     beforeAll(async () => {
       if (shouldSkip) return;
-
-      // Create a test app first
-      const appName = `E2E Integration Test App ${Date.now()}`;
-      const createResult = await runCommand(
-        ["apps", "create", appName, "--json"],
-        {
-          env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN },
-        },
-      );
-
-      const result = parseNdjsonLines(createResult.stdout).find(
-        (r) => r.type === "result",
-      ) as Record<string, unknown>;
-      testAppId = (result.app as Record<string, unknown>).id as string;
+      ({ appId: testAppId, teardown: teardownApp } = await createTestApp(
+        "e2e-integration-test",
+      ));
     });
 
     afterAll(async () => {
-      // Clean up test app if created
-      if (testAppId) {
-        try {
-          await runCommand(["apps", "delete", testAppId, "--force"], {
-            env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN },
-          });
-        } catch (error) {
-          console.log("Error cleaning up test app:", error);
-        }
-      }
+      await teardownApp?.();
     });
 
     it("should create a new integration rule", async () => {
@@ -794,35 +735,16 @@ describe("Control API E2E Workflow Tests", () => {
   describe("Rules Workflow", () => {
     let testAppId: string;
 
+    let teardownApp: (() => Promise<void>) | undefined;
+
     beforeAll(async () => {
       if (shouldSkip) return;
-
-      // Create a test app first
-      const appName = `E2E Rules Test App ${Date.now()}`;
-      const createResult = await runCommand(
-        ["apps", "create", appName, "--json"],
-        {
-          env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN },
-        },
-      );
-
-      const result = parseNdjsonLines(createResult.stdout).find(
-        (r) => r.type === "result",
-      ) as Record<string, unknown>;
-      testAppId = (result.app as Record<string, unknown>).id as string;
+      ({ appId: testAppId, teardown: teardownApp } =
+        await createTestApp("e2e-rules-test"));
     });
 
     afterAll(async () => {
-      // Clean up test app if created
-      if (testAppId) {
-        try {
-          await runCommand(["apps", "delete", testAppId, "--force"], {
-            env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN },
-          });
-        } catch (error) {
-          console.log("Error cleaning up test app:", error);
-        }
-      }
+      await teardownApp?.();
     });
 
     it(

--- a/test/e2e/control/control-api-workflows.test.ts
+++ b/test/e2e/control/control-api-workflows.test.ts
@@ -609,8 +609,7 @@ describe("Control API E2E Workflow Tests", () => {
         ) as Record<string, unknown>;
         expect(createOutput).toHaveProperty("rule");
         const rule = createOutput.rule as Record<string, unknown>;
-        expect(rule).toHaveProperty("id");
-        expect(rule).toHaveProperty("name", ruleName);
+        expect(rule).toHaveProperty("id", ruleName);
         expect(rule).toHaveProperty("persisted", true);
         expect(rule).toHaveProperty("pushEnabled", true);
         expect(rule).toHaveProperty("authenticated", true);

--- a/test/e2e/control/control-api-workflows.test.ts
+++ b/test/e2e/control/control-api-workflows.test.ts
@@ -311,10 +311,9 @@ describe("Control API E2E Workflow Tests", () => {
           "auth",
           "keys",
           "create",
+          keyName,
           "--app",
           testAppId,
-          "--name",
-          keyName,
           "--capabilities",
           '{"[*]*":["*"]}',
           "--json",
@@ -362,10 +361,9 @@ describe("Control API E2E Workflow Tests", () => {
           "auth",
           "keys",
           "create",
+          keyName,
           "--app",
           testAppId,
-          "--name",
-          keyName,
           "--capabilities",
           '{"*":["*"]}',
           "--json",
@@ -432,10 +430,9 @@ describe("Control API E2E Workflow Tests", () => {
           "auth",
           "keys",
           "create",
+          keyName,
           "--app",
           testAppId,
-          "--name",
-          keyName,
           "--capabilities",
           '{"[*]*":["*"]}',
           "--json",
@@ -496,10 +493,9 @@ describe("Control API E2E Workflow Tests", () => {
           "auth",
           "keys",
           "create",
+          keyName,
           "--app",
           testAppId,
-          "--name",
-          keyName,
           "--capabilities",
           '{"*":["*"]}',
           "--json",
@@ -1065,7 +1061,9 @@ describe("Control API E2E Workflow Tests", () => {
       });
 
       expect(result.exitCode).not.toBe(0);
-      expect(result.stderr + result.stdout).toContain("Missing required flag");
+      expect(result.stderr + result.stdout).toMatch(
+        /Missing (1 )?required (arg|flag)/,
+      );
     });
   });
 

--- a/test/e2e/control/control-api-workflows.test.ts
+++ b/test/e2e/control/control-api-workflows.test.ts
@@ -9,6 +9,7 @@ import {
 } from "vitest";
 import { ControlApi } from "../../../src/services/control-api.js";
 import {
+  E2E_ACCESS_TOKEN,
   runBackgroundProcessAndGetOutput,
   forceExit,
   cleanupTrackedResources,
@@ -36,7 +37,7 @@ describe("Control API E2E Workflow Tests", () => {
   beforeAll(async () => {
     process.on("SIGINT", forceExit);
 
-    const accessToken = process.env.E2E_ABLY_ACCESS_TOKEN;
+    const accessToken = E2E_ACCESS_TOKEN;
     if (!accessToken) {
       console.log(
         "E2E_ABLY_ACCESS_TOKEN not available, skipping Control API E2E tests",
@@ -157,7 +158,7 @@ describe("Control API E2E Workflow Tests", () => {
 
         // 1. Create app
         const createResult = await runBackgroundProcessAndGetOutput(
-          `ABLY_ACCESS_TOKEN=${process.env.E2E_ABLY_ACCESS_TOKEN} ${cliPath} apps create "${appName}" --json`,
+          `ABLY_ACCESS_TOKEN=${E2E_ACCESS_TOKEN} ${cliPath} apps create "${appName}" --json`,
           30000,
         );
 
@@ -177,7 +178,7 @@ describe("Control API E2E Workflow Tests", () => {
 
         // 2. List apps and verify our app is included
         const listResult = await runBackgroundProcessAndGetOutput(
-          `ABLY_ACCESS_TOKEN=${process.env.E2E_ABLY_ACCESS_TOKEN} ${cliPath} apps list --json`,
+          `ABLY_ACCESS_TOKEN=${E2E_ACCESS_TOKEN} ${cliPath} apps list --json`,
           30000,
         );
 
@@ -206,7 +207,7 @@ describe("Control API E2E Workflow Tests", () => {
             "--json",
           ],
           {
-            env: { ABLY_ACCESS_TOKEN: process.env.E2E_ABLY_ACCESS_TOKEN },
+            env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN },
           },
         );
 
@@ -239,7 +240,7 @@ describe("Control API E2E Workflow Tests", () => {
       const createResult = await runCommand(
         ["apps", "create", appName, "--json"],
         {
-          env: { ABLY_ACCESS_TOKEN: process.env.E2E_ABLY_ACCESS_TOKEN },
+          env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN },
         },
       );
 
@@ -254,7 +255,7 @@ describe("Control API E2E Workflow Tests", () => {
       if (testAppId) {
         try {
           await runCommand(["apps", "delete", testAppId, "--force"], {
-            env: { ABLY_ACCESS_TOKEN: process.env.E2E_ABLY_ACCESS_TOKEN },
+            env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN },
           });
         } catch (error) {
           console.log("Error cleaning up test app:", error);
@@ -281,7 +282,7 @@ describe("Control API E2E Workflow Tests", () => {
           "--json",
         ],
         {
-          env: { ABLY_ACCESS_TOKEN: process.env.E2E_ABLY_ACCESS_TOKEN },
+          env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN },
         },
       );
 
@@ -297,6 +298,108 @@ describe("Control API E2E Workflow Tests", () => {
       expect(result.key as Record<string, unknown>).toHaveProperty("key");
     });
 
+    it("should create an API key with channels-and-queues wildcard capability", async () => {
+      setupTestFailureHandler(
+        "should create an API key with channels-and-queues wildcard capability",
+      );
+
+      if (shouldSkip) return;
+
+      const keyName = `Test-Key-AllResourcesWildcard-${Date.now()}`;
+      const createResult = await runCommand(
+        [
+          "auth",
+          "keys",
+          "create",
+          "--app",
+          testAppId,
+          "--name",
+          keyName,
+          "--capabilities",
+          '{"[*]*":["*"]}',
+          "--json",
+        ],
+        {
+          env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN },
+        },
+      );
+
+      const result = parseNdjsonLines(createResult.stdout).find(
+        (r) => r.type === "result",
+      ) as Record<string, unknown>;
+      expect(result).toBeDefined();
+      expect(result).toHaveProperty("success", true);
+
+      const key = result.key as Record<string, unknown>;
+      expect(key).toHaveProperty("name", keyName);
+      expect(key).toHaveProperty("key");
+
+      // Ably expands ["*"] server-side into the full op list.
+      const capability =
+        typeof key.capability === "string"
+          ? (JSON.parse(key.capability) as Record<string, string[]>)
+          : (key.capability as Record<string, string[]>);
+      expect(Object.keys(capability)).toEqual(["[*]*"]);
+      expect(capability["[*]*"]).toEqual(
+        expect.arrayContaining(["publish", "subscribe"]),
+      );
+
+      if (key.id) {
+        createdResources.keys.push(key.id as string);
+      }
+    });
+
+    it("should create an API key with channels-only wildcard capability", async () => {
+      setupTestFailureHandler(
+        "should create an API key with channels-only wildcard capability",
+      );
+
+      if (shouldSkip) return;
+
+      const keyName = `Test-Key-ChannelsWildcard-${Date.now()}`;
+      const createResult = await runCommand(
+        [
+          "auth",
+          "keys",
+          "create",
+          "--app",
+          testAppId,
+          "--name",
+          keyName,
+          "--capabilities",
+          '{"*":["*"]}',
+          "--json",
+        ],
+        {
+          env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN },
+        },
+      );
+
+      const result = parseNdjsonLines(createResult.stdout).find(
+        (r) => r.type === "result",
+      ) as Record<string, unknown>;
+      expect(result).toBeDefined();
+      expect(result).toHaveProperty("success", true);
+
+      const key = result.key as Record<string, unknown>;
+      expect(key).toHaveProperty("name", keyName);
+      expect(key).toHaveProperty("key");
+
+      // Ably expands ["*"] server-side into the full op list.
+      const capability =
+        typeof key.capability === "string"
+          ? (JSON.parse(key.capability) as Record<string, string[]>)
+          : (key.capability as Record<string, string[]>);
+      expect(Object.keys(capability)).toEqual(["*"]);
+      expect(capability["*"]).toEqual(
+        expect.arrayContaining(["publish", "subscribe"]),
+      );
+
+      if (key.id) {
+        createdResources.keys.push(key.id as string);
+      }
+    });
+
     it("should list API keys", async () => {
       setupTestFailureHandler("should list API keys");
 
@@ -305,7 +408,7 @@ describe("Control API E2E Workflow Tests", () => {
       const listResult = await runCommand(
         ["auth", "keys", "list", "--app", testAppId, "--json"],
         {
-          env: { ABLY_ACCESS_TOKEN: process.env.E2E_ABLY_ACCESS_TOKEN },
+          env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN },
         },
       );
 
@@ -315,6 +418,155 @@ describe("Control API E2E Workflow Tests", () => {
       expect(result).toHaveProperty("success", true);
       expect(Array.isArray(result.keys)).toBe(true);
       expect((result.keys as unknown[]).length).toBeGreaterThan(0);
+    });
+
+    it("should revoke an API key", async () => {
+      setupTestFailureHandler("should revoke an API key");
+
+      if (shouldSkip) return;
+
+      // Create a throwaway key so we don't revoke one used by other tests
+      const keyName = `Test-Key-Revoke-${Date.now()}`;
+      const createResult = await runCommand(
+        [
+          "auth",
+          "keys",
+          "create",
+          "--app",
+          testAppId,
+          "--name",
+          keyName,
+          "--capabilities",
+          '{"[*]*":["*"]}',
+          "--json",
+        ],
+        {
+          env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN },
+        },
+      );
+
+      const created = parseNdjsonLines(createResult.stdout).find(
+        (r) => r.type === "result",
+      ) as Record<string, unknown>;
+      const createdKey = created.key as Record<string, unknown>;
+      const keyId = createdKey.id as string;
+      expect(keyId).toBeTruthy();
+
+      const revokeResult = await runCommand(
+        [
+          "auth",
+          "keys",
+          "revoke",
+          `${testAppId}.${keyId}`,
+          "--force",
+          "--json",
+        ],
+        {
+          env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN },
+        },
+      );
+
+      expect(revokeResult.exitCode).toBe(0);
+      const result = parseNdjsonLines(revokeResult.stdout).find(
+        (r) => r.type === "result",
+      ) as Record<string, unknown>;
+      expect(result).toBeDefined();
+      expect(result).toHaveProperty("success", true);
+      expect(result.key as Record<string, unknown>).toHaveProperty(
+        "keyName",
+        `${testAppId}.${keyId}`,
+      );
+      expect(result.key as Record<string, unknown>).toHaveProperty(
+        "message",
+        "Key has been revoked",
+      );
+    });
+
+    it("should reject publish attempts using a revoked API key", async () => {
+      setupTestFailureHandler(
+        "should reject publish attempts using a revoked API key",
+      );
+
+      if (shouldSkip) return;
+
+      // 1. Create a throwaway key with publish capability
+      const keyName = `Test-Key-RevokedUsable-${Date.now()}`;
+      const createResult = await runCommand(
+        [
+          "auth",
+          "keys",
+          "create",
+          "--app",
+          testAppId,
+          "--name",
+          keyName,
+          "--capabilities",
+          '{"*":["*"]}',
+          "--json",
+        ],
+        {
+          env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN },
+        },
+      );
+
+      const created = parseNdjsonLines(createResult.stdout).find(
+        (r) => r.type === "result",
+      ) as Record<string, unknown>;
+      const createdKey = created.key as Record<string, unknown>;
+      const keyId = createdKey.id as string;
+      const fullKey = createdKey.key as string;
+      expect(keyId).toBeTruthy();
+      expect(fullKey).toBeTruthy();
+
+      const channel = `revoked-key-test-${Date.now()}`;
+
+      // 2. Sanity check: key works before revocation
+      const preRevokePublish = await runCommand(
+        ["channels", "publish", channel, "hello-before-revoke", "--json"],
+        { env: { ABLY_API_KEY: fullKey } },
+      );
+      expect(preRevokePublish.exitCode).toBe(0);
+
+      // 3. Revoke the key via the CLI
+      const revokeResult = await runCommand(
+        [
+          "auth",
+          "keys",
+          "revoke",
+          `${testAppId}.${keyId}`,
+          "--force",
+          "--json",
+        ],
+        {
+          env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN },
+        },
+      );
+      expect(revokeResult.exitCode).toBe(0);
+
+      // Wait for revocation to propagate.
+      await new Promise((resolve) => setTimeout(resolve, 5000));
+
+      const postRevokePublish = await runCommand(
+        ["channels", "publish", channel, "hello-after-revoke", "--json"],
+        { env: { ABLY_API_KEY: fullKey } },
+      );
+
+      // `channels publish` reports per-message errors inline, not via fail().
+      const result = parseNdjsonLines(postRevokePublish.stdout).find(
+        (r) => r.type === "result",
+      ) as Record<string, unknown>;
+      expect(result).toBeDefined();
+      const publish = result.publish as {
+        errors: number;
+        published: number;
+        allSucceeded: boolean;
+        results: Array<{ success: boolean; error?: { message: string } }>;
+      };
+      expect(publish.errors).toBeGreaterThanOrEqual(1);
+      expect(publish.published).toBe(0);
+      expect(publish.allSucceeded).toBe(false);
+      expect(publish.results[0].success).toBe(false);
+      expect(publish.results[0].error?.message).toBeTruthy();
     });
   });
 
@@ -329,7 +581,7 @@ describe("Control API E2E Workflow Tests", () => {
       const createResult = await runCommand(
         ["apps", "create", appName, "--json"],
         {
-          env: { ABLY_ACCESS_TOKEN: process.env.E2E_ABLY_ACCESS_TOKEN },
+          env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN },
         },
       );
 
@@ -344,7 +596,7 @@ describe("Control API E2E Workflow Tests", () => {
       if (testAppId) {
         try {
           await runCommand(["apps", "delete", testAppId, "--force"], {
-            env: { ABLY_ACCESS_TOKEN: process.env.E2E_ABLY_ACCESS_TOKEN },
+            env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN },
           });
         } catch (error) {
           console.log("Error cleaning up test app:", error);
@@ -374,7 +626,7 @@ describe("Control API E2E Workflow Tests", () => {
           "--json",
         ],
         {
-          env: { ABLY_ACCESS_TOKEN: process.env.E2E_ABLY_ACCESS_TOKEN },
+          env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN },
         },
       );
 
@@ -401,7 +653,7 @@ describe("Control API E2E Workflow Tests", () => {
       const listResult = await runCommand(
         ["queues", "list", "--app", testAppId, "--json"],
         {
-          env: { ABLY_ACCESS_TOKEN: process.env.E2E_ABLY_ACCESS_TOKEN },
+          env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN },
         },
       );
 
@@ -422,7 +674,7 @@ describe("Control API E2E Workflow Tests", () => {
       const createResult = await runCommand(
         ["queues", "create", queueName, "--app", testAppId, "--json"],
         {
-          env: { ABLY_ACCESS_TOKEN: process.env.E2E_ABLY_ACCESS_TOKEN },
+          env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN },
         },
       );
 
@@ -435,7 +687,7 @@ describe("Control API E2E Workflow Tests", () => {
       const deleteResult = await runCommand(
         ["queues", "delete", queueId, "--app", testAppId, "--force"],
         {
-          env: { ABLY_ACCESS_TOKEN: process.env.E2E_ABLY_ACCESS_TOKEN },
+          env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN },
         },
       );
 
@@ -460,7 +712,7 @@ describe("Control API E2E Workflow Tests", () => {
       const createResult = await runCommand(
         ["apps", "create", appName, "--json"],
         {
-          env: { ABLY_ACCESS_TOKEN: process.env.E2E_ABLY_ACCESS_TOKEN },
+          env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN },
         },
       );
 
@@ -475,7 +727,7 @@ describe("Control API E2E Workflow Tests", () => {
       if (testAppId) {
         try {
           await runCommand(["apps", "delete", testAppId, "--force"], {
-            env: { ABLY_ACCESS_TOKEN: process.env.E2E_ABLY_ACCESS_TOKEN },
+            env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN },
           });
         } catch (error) {
           console.log("Error cleaning up test app:", error);
@@ -505,7 +757,7 @@ describe("Control API E2E Workflow Tests", () => {
           "--json",
         ],
         {
-          env: { ABLY_ACCESS_TOKEN: process.env.E2E_ABLY_ACCESS_TOKEN },
+          env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN },
         },
       );
 
@@ -530,7 +782,7 @@ describe("Control API E2E Workflow Tests", () => {
       const listResult = await runCommand(
         ["integrations", "list", "--app", testAppId, "--json"],
         {
-          env: { ABLY_ACCESS_TOKEN: process.env.E2E_ABLY_ACCESS_TOKEN },
+          env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN },
         },
       );
 
@@ -554,7 +806,7 @@ describe("Control API E2E Workflow Tests", () => {
       const createResult = await runCommand(
         ["apps", "create", appName, "--json"],
         {
-          env: { ABLY_ACCESS_TOKEN: process.env.E2E_ABLY_ACCESS_TOKEN },
+          env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN },
         },
       );
 
@@ -569,7 +821,7 @@ describe("Control API E2E Workflow Tests", () => {
       if (testAppId) {
         try {
           await runCommand(["apps", "delete", testAppId, "--force"], {
-            env: { ABLY_ACCESS_TOKEN: process.env.E2E_ABLY_ACCESS_TOKEN },
+            env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN },
           });
         } catch (error) {
           console.log("Error cleaning up test app:", error);
@@ -602,7 +854,7 @@ describe("Control API E2E Workflow Tests", () => {
             "--json",
           ],
           {
-            env: { ABLY_ACCESS_TOKEN: process.env.E2E_ABLY_ACCESS_TOKEN },
+            env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN },
           },
         );
 
@@ -624,7 +876,7 @@ describe("Control API E2E Workflow Tests", () => {
         const listResult = await runCommand(
           ["apps", "rules", "list", "--app", testAppId, "--json"],
           {
-            env: { ABLY_ACCESS_TOKEN: process.env.E2E_ABLY_ACCESS_TOKEN },
+            env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN },
           },
         );
 
@@ -664,7 +916,7 @@ describe("Control API E2E Workflow Tests", () => {
           "--json",
         ],
         {
-          env: { ABLY_ACCESS_TOKEN: process.env.E2E_ABLY_ACCESS_TOKEN },
+          env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN },
         },
       );
 
@@ -694,7 +946,7 @@ describe("Control API E2E Workflow Tests", () => {
           "--json",
         ],
         {
-          env: { ABLY_ACCESS_TOKEN: process.env.E2E_ABLY_ACCESS_TOKEN },
+          env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN },
         },
       );
 
@@ -725,7 +977,7 @@ describe("Control API E2E Workflow Tests", () => {
       const createResult = await runCommand(
         ["apps", "rules", "create", ruleName, "--app", testAppId, "--json"],
         {
-          env: { ABLY_ACCESS_TOKEN: process.env.E2E_ABLY_ACCESS_TOKEN },
+          env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN },
         },
       );
 
@@ -742,7 +994,7 @@ describe("Control API E2E Workflow Tests", () => {
       const deleteResult = await runCommand(
         ["apps", "rules", "delete", namespaceId, "--app", testAppId, "--force"],
         {
-          env: { ABLY_ACCESS_TOKEN: process.env.E2E_ABLY_ACCESS_TOKEN },
+          env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN },
         },
       );
 
@@ -752,7 +1004,7 @@ describe("Control API E2E Workflow Tests", () => {
       const listResult = await runCommand(
         ["apps", "rules", "list", "--app", testAppId, "--json"],
         {
-          env: { ABLY_ACCESS_TOKEN: process.env.E2E_ABLY_ACCESS_TOKEN },
+          env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN },
         },
       );
 
@@ -795,7 +1047,7 @@ describe("Control API E2E Workflow Tests", () => {
       const result = await runCommand(
         ["apps", "update", "non-existent-app-id", "--name", "Test", "--json"],
         {
-          env: { ABLY_ACCESS_TOKEN: process.env.E2E_ABLY_ACCESS_TOKEN },
+          env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN },
         },
       );
 
@@ -809,7 +1061,7 @@ describe("Control API E2E Workflow Tests", () => {
       if (shouldSkip) return;
 
       const result = await runCommand(["apps", "create"], {
-        env: { ABLY_ACCESS_TOKEN: process.env.E2E_ABLY_ACCESS_TOKEN },
+        env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN },
       });
 
       expect(result.exitCode).not.toBe(0);
@@ -835,7 +1087,7 @@ describe("Control API E2E Workflow Tests", () => {
         const createAppResult = await runCommand(
           ["apps", "create", appName, "--json"],
           {
-            env: { ABLY_ACCESS_TOKEN: process.env.E2E_ABLY_ACCESS_TOKEN },
+            env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN },
           },
         );
 
@@ -859,7 +1111,7 @@ describe("Control API E2E Workflow Tests", () => {
             "--json",
           ],
           {
-            env: { ABLY_ACCESS_TOKEN: process.env.E2E_ABLY_ACCESS_TOKEN },
+            env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN },
           },
         );
 
@@ -873,7 +1125,7 @@ describe("Control API E2E Workflow Tests", () => {
         const createQueueResult = await runCommand(
           ["queues", "create", queueName, "--app", appId, "--json"],
           {
-            env: { ABLY_ACCESS_TOKEN: process.env.E2E_ABLY_ACCESS_TOKEN },
+            env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN },
           },
         );
 
@@ -902,7 +1154,7 @@ describe("Control API E2E Workflow Tests", () => {
             "--json",
           ],
           {
-            env: { ABLY_ACCESS_TOKEN: process.env.E2E_ABLY_ACCESS_TOKEN },
+            env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN },
           },
         );
 
@@ -916,7 +1168,7 @@ describe("Control API E2E Workflow Tests", () => {
 
         // 5. Verify all resources exist by listing them
         const listAppsResult = await runCommand(["apps", "list", "--json"], {
-          env: { ABLY_ACCESS_TOKEN: process.env.E2E_ABLY_ACCESS_TOKEN },
+          env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN },
         });
 
         const appsOutput = parseNdjsonLines(listAppsResult.stdout).find(
@@ -931,7 +1183,7 @@ describe("Control API E2E Workflow Tests", () => {
         const listKeysResult = await runCommand(
           ["auth", "keys", "list", "--app", appId, "--json"],
           {
-            env: { ABLY_ACCESS_TOKEN: process.env.E2E_ABLY_ACCESS_TOKEN },
+            env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN },
           },
         );
 
@@ -947,7 +1199,7 @@ describe("Control API E2E Workflow Tests", () => {
         const listQueuesResult = await runCommand(
           ["queues", "list", "--app", appId, "--json"],
           {
-            env: { ABLY_ACCESS_TOKEN: process.env.E2E_ABLY_ACCESS_TOKEN },
+            env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN },
           },
         );
 
@@ -963,7 +1215,7 @@ describe("Control API E2E Workflow Tests", () => {
         const listIntegrationsResult = await runCommand(
           ["integrations", "list", "--app", appId, "--json"],
           {
-            env: { ABLY_ACCESS_TOKEN: process.env.E2E_ABLY_ACCESS_TOKEN },
+            env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN },
           },
         );
 

--- a/test/e2e/control/control-api-workflows.test.ts
+++ b/test/e2e/control/control-api-workflows.test.ts
@@ -182,12 +182,14 @@ describe("Control API E2E Workflow Tests", () => {
         );
 
         expect(listResult.exitCode).toBe(0);
-        const listOutput = JSON.parse(listResult.stdout);
+        const listOutput = parseNdjsonLines(listResult.stdout).find(
+          (r) => r.type === "result",
+        ) as Record<string, unknown>;
         expect(listOutput).toHaveProperty("apps");
         expect(Array.isArray(listOutput.apps)).toBe(true);
 
-        const foundApp = listOutput.apps.find(
-          (app: { id: string }) => app.id === appId,
+        const foundApp = (listOutput.apps as Array<{ id: string }>).find(
+          (app) => app.id === appId,
         );
         expect(foundApp).toBeDefined();
 
@@ -265,9 +267,19 @@ describe("Control API E2E Workflow Tests", () => {
 
       if (shouldSkip) return;
 
-      const keyName = `Test Key ${Date.now()}`;
+      const keyName = `Test-Key-${Date.now()}`;
       const createResult = await runCommand(
-        ["auth", "keys", "create", keyName, "--app", testAppId, "--json"],
+        [
+          "auth",
+          "keys",
+          "create",
+          keyName,
+          "--app",
+          testAppId,
+          "--capabilities",
+          '{"[*]*":["*"]}',
+          "--json",
+        ],
         {
           env: { ABLY_ACCESS_TOKEN: process.env.E2E_ABLY_ACCESS_TOKEN },
         },
@@ -297,10 +309,12 @@ describe("Control API E2E Workflow Tests", () => {
         },
       );
 
-      const result = JSON.parse(listResult.stdout);
+      const result = parseNdjsonLines(listResult.stdout).find(
+        (r) => r.type === "result",
+      ) as Record<string, unknown>;
       expect(result).toHaveProperty("success", true);
       expect(Array.isArray(result.keys)).toBe(true);
-      expect(result.keys.length).toBeGreaterThan(0);
+      expect((result.keys as unknown[]).length).toBeGreaterThan(0);
     });
   });
 
@@ -364,11 +378,22 @@ describe("Control API E2E Workflow Tests", () => {
         },
       );
 
-      const result = JSON.parse(createResult.stdout);
+      const result = parseNdjsonLines(createResult.stdout).find(
+        (r) => r.type === "result",
+      ) as Record<string, unknown>;
       expect(result).toHaveProperty("success", true);
-      expect(result.queue).toHaveProperty("name", queueName);
-      expect(result.queue).toHaveProperty("maxLength", 5000);
-      expect(result.queue).toHaveProperty("ttl", 1800);
+      expect(result.queue as Record<string, unknown>).toHaveProperty(
+        "name",
+        queueName,
+      );
+      expect(result.queue as Record<string, unknown>).toHaveProperty(
+        "maxLength",
+        5000,
+      );
+      expect(result.queue as Record<string, unknown>).toHaveProperty(
+        "ttl",
+        1800,
+      );
     });
 
     it("should list queues", async () => {
@@ -383,7 +408,9 @@ describe("Control API E2E Workflow Tests", () => {
         },
       );
 
-      const result = JSON.parse(listResult.stdout);
+      const result = parseNdjsonLines(listResult.stdout).find(
+        (r) => r.type === "result",
+      ) as Record<string, unknown>;
       expect(result).toHaveProperty("success", true);
       expect(Array.isArray(result.queues)).toBe(true);
     });
@@ -479,11 +506,17 @@ describe("Control API E2E Workflow Tests", () => {
         },
       );
 
-      const result = JSON.parse(createResult.stdout);
+      const result = parseNdjsonLines(createResult.stdout).find(
+        (r) => r.type === "result",
+      ) as Record<string, unknown>;
       expect(result).toHaveProperty("success", true);
-      expect(result.rule).toHaveProperty("ruleType", "http");
-      expect(result.rule).toHaveProperty("source");
-      expect(result.rule.source).toHaveProperty("channelFilter", "e2e-test-*");
+      const integration = result.integration as Record<string, unknown>;
+      expect(integration).toHaveProperty("ruleType", "http");
+      expect(integration).toHaveProperty("source");
+      expect(integration.source as Record<string, unknown>).toHaveProperty(
+        "channelFilter",
+        "e2e-test-*",
+      );
     });
 
     it("should list integration rules", async () => {
@@ -498,10 +531,12 @@ describe("Control API E2E Workflow Tests", () => {
         },
       );
 
-      const result = JSON.parse(listResult.stdout);
+      const result = parseNdjsonLines(listResult.stdout).find(
+        (r) => r.type === "result",
+      ) as Record<string, unknown>;
       expect(result).toHaveProperty("success", true);
-      expect(Array.isArray(result.rules)).toBe(true);
-      expect(result.rules.length).toBeGreaterThan(0);
+      expect(Array.isArray(result.integrations)).toBe(true);
+      expect((result.integrations as unknown[]).length).toBeGreaterThan(0);
     });
   });
 
@@ -569,15 +604,18 @@ describe("Control API E2E Workflow Tests", () => {
         );
 
         expect(createResult.stderr).toBe("");
-        const createOutput = JSON.parse(createResult.stdout);
+        const createOutput = parseNdjsonLines(createResult.stdout).find(
+          (r) => r.type === "result",
+        ) as Record<string, unknown>;
         expect(createOutput).toHaveProperty("rule");
-        expect(createOutput.rule).toHaveProperty("id");
-        expect(createOutput.rule).toHaveProperty("name", ruleName);
-        expect(createOutput.rule).toHaveProperty("persisted", true);
-        expect(createOutput.rule).toHaveProperty("pushEnabled", true);
-        expect(createOutput.rule).toHaveProperty("authenticated", true);
+        const rule = createOutput.rule as Record<string, unknown>;
+        expect(rule).toHaveProperty("id");
+        expect(rule).toHaveProperty("name", ruleName);
+        expect(rule).toHaveProperty("persisted", true);
+        expect(rule).toHaveProperty("pushEnabled", true);
+        expect(rule).toHaveProperty("authenticated", true);
 
-        const namespaceId = createOutput.rule.id;
+        const namespaceId = rule.id as string;
         createdResources.namespaces.push(namespaceId);
 
         // 2. List rules and verify our rule is included
@@ -589,12 +627,14 @@ describe("Control API E2E Workflow Tests", () => {
         );
 
         expect(listResult.stderr).toBe("");
-        const listOutput = JSON.parse(listResult.stdout);
+        const listOutput = parseNdjsonLines(listResult.stdout).find(
+          (r) => r.type === "result",
+        ) as Record<string, unknown>;
         expect(listOutput).toHaveProperty("rules");
         expect(Array.isArray(listOutput.rules)).toBe(true);
 
-        const foundRule = listOutput.rules.find(
-          (ns: { id: string }) => ns.id === namespaceId,
+        const foundRule = (listOutput.rules as Array<{ id: string }>).find(
+          (ns) => ns.id === namespaceId,
         );
         expect(foundRule).toBeDefined();
         expect(foundRule).toHaveProperty("persisted", true);
@@ -627,12 +667,15 @@ describe("Control API E2E Workflow Tests", () => {
       );
 
       expect(createResult.stderr).toBe("");
-      const createOutput = JSON.parse(createResult.stdout);
+      const createOutput = parseNdjsonLines(createResult.stdout).find(
+        (r) => r.type === "result",
+      ) as Record<string, unknown>;
       expect(createOutput).toHaveProperty("success", true);
-      expect(createOutput.rule).toHaveProperty("persisted", true);
-      expect(createOutput.rule).toHaveProperty("pushEnabled", false);
+      const createRule = createOutput.rule as Record<string, unknown>;
+      expect(createRule).toHaveProperty("persisted", true);
+      expect(createRule).toHaveProperty("pushEnabled", false);
 
-      const namespaceId = createOutput.rule.id;
+      const namespaceId = createRule.id as string;
       createdResources.namespaces.push(namespaceId);
 
       // 2. Update rule - enable push, disable persisted
@@ -654,16 +697,19 @@ describe("Control API E2E Workflow Tests", () => {
       );
 
       expect(updateResult.stderr).toBe("");
-      const updateOutput = JSON.parse(updateResult.stdout);
+      const updateOutput = parseNdjsonLines(updateResult.stdout).find(
+        (r) => r.type === "result",
+      ) as Record<string, unknown>;
       expect(updateOutput).toHaveProperty("success", true);
-      expect(updateOutput.rule).toHaveProperty("id", namespaceId);
-      expect(updateOutput.rule).toHaveProperty("pushEnabled", true);
-      expect(updateOutput.rule).toHaveProperty("persisted", false);
+      const updatedRule = updateOutput.rule as Record<string, unknown>;
+      expect(updatedRule).toHaveProperty("id", namespaceId);
+      expect(updatedRule).toHaveProperty("pushEnabled", true);
+      expect(updatedRule).toHaveProperty("persisted", false);
 
       // Verify null batchingInterval/conflationInterval don't cause errors
       // These fields may be null in the response
-      expect(updateOutput.rule).toHaveProperty("batchingInterval");
-      expect(updateOutput.rule).toHaveProperty("conflationInterval");
+      expect(updatedRule).toHaveProperty("batchingInterval");
+      expect(updatedRule).toHaveProperty("conflationInterval");
     });
 
     it("should delete a rule through CLI", { timeout: 20000 }, async () => {
@@ -682,9 +728,12 @@ describe("Control API E2E Workflow Tests", () => {
       );
 
       expect(createResult.stderr).toBe("");
-      const createOutput = JSON.parse(createResult.stdout);
+      const createOutput = parseNdjsonLines(createResult.stdout).find(
+        (r) => r.type === "result",
+      ) as Record<string, unknown>;
       expect(createOutput).toHaveProperty("success", true);
-      const namespaceId = createOutput.rule.id;
+      const namespaceId = (createOutput.rule as Record<string, unknown>)
+        .id as string;
       createdResources.namespaces.push(namespaceId);
 
       // 2. Delete rule with --force
@@ -705,9 +754,11 @@ describe("Control API E2E Workflow Tests", () => {
         },
       );
 
-      const listOutput = JSON.parse(listResult.stdout);
-      const deletedRule = listOutput.rules.find(
-        (ns: { id: string }) => ns.id === namespaceId,
+      const listOutput = parseNdjsonLines(listResult.stdout).find(
+        (r) => r.type === "result",
+      ) as Record<string, unknown>;
+      const deletedRule = (listOutput.rules as Array<{ id: string }>).find(
+        (ns) => ns.id === namespaceId,
       );
       expect(deletedRule).toBeUndefined();
     });
@@ -775,7 +826,7 @@ describe("Control API E2E Workflow Tests", () => {
 
         const timestamp = Date.now();
         const appName = `E2E Complete Workflow ${timestamp}`;
-        const keyName = `E2E Workflow Key ${timestamp}`;
+        const keyName = `E2E-Workflow-Key-${timestamp}`;
         const queueName = `e2e-workflow-queue-${timestamp}`;
 
         // 1. Create app
@@ -794,7 +845,17 @@ describe("Control API E2E Workflow Tests", () => {
 
         // 2. Create API key
         const createKeyResult = await runCommand(
-          ["auth", "keys", "create", keyName, "--app", appId, "--json"],
+          [
+            "auth",
+            "keys",
+            "create",
+            keyName,
+            "--app",
+            appId,
+            "--capabilities",
+            '{"[*]*":["*"]}',
+            "--json",
+          ],
           {
             env: { ABLY_ACCESS_TOKEN: process.env.E2E_ABLY_ACCESS_TOKEN },
           },
@@ -814,8 +875,11 @@ describe("Control API E2E Workflow Tests", () => {
           },
         );
 
-        const queueOutput = JSON.parse(createQueueResult.stdout);
-        expect(queueOutput).toHaveProperty("name", queueName);
+        const queueOutput = parseNdjsonLines(createQueueResult.stdout).find(
+          (r) => r.type === "result",
+        ) as Record<string, unknown>;
+        const queue = queueOutput.queue as Record<string, unknown>;
+        expect(queue).toHaveProperty("name", queueName);
         createdResources.queues.push(queueName);
 
         // 4. Create integration
@@ -840,8 +904,12 @@ describe("Control API E2E Workflow Tests", () => {
           },
         );
 
-        const integrationOutput = JSON.parse(createIntegrationResult.stdout);
-        const ruleId = integrationOutput.id;
+        const integrationOutput = parseNdjsonLines(
+          createIntegrationResult.stdout,
+        ).find((r) => r.type === "result") as Record<string, unknown>;
+        const ruleId = (
+          integrationOutput.integration as Record<string, unknown>
+        ).id as string;
         createdResources.rules.push(ruleId);
 
         // 5. Verify all resources exist by listing them
@@ -849,9 +917,13 @@ describe("Control API E2E Workflow Tests", () => {
           env: { ABLY_ACCESS_TOKEN: process.env.E2E_ABLY_ACCESS_TOKEN },
         });
 
-        const appsOutput = JSON.parse(listAppsResult.stdout);
+        const appsOutput = parseNdjsonLines(listAppsResult.stdout).find(
+          (r) => r.type === "result",
+        ) as Record<string, unknown>;
         expect(
-          appsOutput.apps.find((app: { id: string }) => app.id === appId),
+          (appsOutput.apps as Array<{ id: string }>).find(
+            (app) => app.id === appId,
+          ),
         ).toBeDefined();
 
         const listKeysResult = await runCommand(
@@ -861,9 +933,13 @@ describe("Control API E2E Workflow Tests", () => {
           },
         );
 
-        const keysOutput = JSON.parse(listKeysResult.stdout);
+        const keysOutput = parseNdjsonLines(listKeysResult.stdout).find(
+          (r) => r.type === "result",
+        ) as Record<string, unknown>;
         expect(
-          keysOutput.keys.find((key: { id: string }) => key.id === keyId),
+          (keysOutput.keys as Array<{ id: string }>).find(
+            (key) => key.id === keyId,
+          ),
         ).toBeDefined();
 
         const listQueuesResult = await runCommand(
@@ -873,10 +949,12 @@ describe("Control API E2E Workflow Tests", () => {
           },
         );
 
-        const queuesOutput = JSON.parse(listQueuesResult.stdout);
+        const queuesOutput = parseNdjsonLines(listQueuesResult.stdout).find(
+          (r) => r.type === "result",
+        ) as Record<string, unknown>;
         expect(
-          queuesOutput.queues.find(
-            (queue: { name: string }) => queue.name === queueName,
+          (queuesOutput.queues as Array<{ name: string }>).find(
+            (q) => q.name === queueName,
           ),
         ).toBeDefined();
 
@@ -887,10 +965,12 @@ describe("Control API E2E Workflow Tests", () => {
           },
         );
 
-        const integrationsOutput = JSON.parse(listIntegrationsResult.stdout);
+        const integrationsOutput = parseNdjsonLines(
+          listIntegrationsResult.stdout,
+        ).find((r) => r.type === "result") as Record<string, unknown>;
         expect(
-          integrationsOutput.rules.find(
-            (rule: { id: string }) => rule.id === ruleId,
+          (integrationsOutput.integrations as Array<{ id: string }>).find(
+            (rule) => rule.id === ruleId,
           ),
         ).toBeDefined();
       },

--- a/test/e2e/control/control-api-workflows.test.ts
+++ b/test/e2e/control/control-api-workflows.test.ts
@@ -368,7 +368,7 @@ describe("Control API E2E Workflow Tests", () => {
           "--max-length",
           "5000",
           "--ttl",
-          "1800",
+          "60",
           "--region",
           "eu-west-1-a",
           "--json",
@@ -390,10 +390,7 @@ describe("Control API E2E Workflow Tests", () => {
         "maxLength",
         5000,
       );
-      expect(result.queue as Record<string, unknown>).toHaveProperty(
-        "ttl",
-        1800,
-      );
+      expect(result.queue as Record<string, unknown>).toHaveProperty("ttl", 60);
     });
 
     it("should list queues", async () => {
@@ -421,16 +418,22 @@ describe("Control API E2E Workflow Tests", () => {
       if (shouldSkip) return;
 
       const queueName = `test-delete-queue-${Date.now()}`;
-      // First create a queue
-      await runCommand(
+      // First create a queue and capture its ID
+      const createResult = await runCommand(
         ["queues", "create", queueName, "--app", testAppId, "--json"],
         {
           env: { ABLY_ACCESS_TOKEN: process.env.E2E_ABLY_ACCESS_TOKEN },
         },
       );
 
+      const createOutput = parseNdjsonLines(createResult.stdout).find(
+        (r) => r.type === "result",
+      ) as Record<string, unknown>;
+      const queueId = (createOutput.queue as Record<string, unknown>)
+        .id as string;
+
       const deleteResult = await runCommand(
-        ["queues", "delete", queueName, "--app", testAppId, "--force"],
+        ["queues", "delete", queueId, "--app", testAppId, "--force"],
         {
           env: { ABLY_ACCESS_TOKEN: process.env.E2E_ABLY_ACCESS_TOKEN },
         },

--- a/test/e2e/core/basic-cli-minimal.test.ts
+++ b/test/e2e/core/basic-cli-minimal.test.ts
@@ -1,15 +1,6 @@
-import {
-  describe,
-  it,
-  beforeEach,
-  afterEach,
-  beforeAll,
-  afterAll,
-  expect,
-} from "vitest";
+import { describe, it, beforeEach, afterEach, expect } from "vitest";
 import { runCommand } from "../../helpers/command-helpers.js";
 import {
-  forceExit,
   cleanupTrackedResources,
   testOutputFiles,
   testCommands,
@@ -25,14 +16,6 @@ const commandOptions = {
 
 // Very simple tests to see if the CLI works at all
 describe("Minimal CLI E2E Tests", () => {
-  beforeAll(() => {
-    process.on("SIGINT", forceExit);
-  });
-
-  afterAll(() => {
-    process.removeListener("SIGINT", forceExit);
-  });
-
   beforeEach(() => {
     resetTestTracking();
     // Clear tracked output files and commands for this test

--- a/test/e2e/core/basic-cli.test.ts
+++ b/test/e2e/core/basic-cli.test.ts
@@ -1,16 +1,7 @@
-import {
-  describe,
-  it,
-  beforeEach,
-  afterEach,
-  beforeAll,
-  afterAll,
-  expect,
-} from "vitest";
+import { describe, it, beforeEach, afterEach, expect } from "vitest";
 import stripAnsi from "strip-ansi";
 import { runCommand } from "../../helpers/command-helpers.js";
 import {
-  forceExit,
   cleanupTrackedResources,
   testOutputFiles,
   testCommands,
@@ -54,14 +45,6 @@ const _parseJsonFromOutput = (output: string): unknown => {
 
 // These tests check the basic CLI functionality in a real environment
 describe("Basic CLI E2E", () => {
-  beforeAll(() => {
-    process.on("SIGINT", forceExit);
-  });
-
-  afterAll(() => {
-    process.removeListener("SIGINT", forceExit);
-  });
-
   beforeEach(() => {
     resetTestTracking();
     // Clear tracked output files and commands for this test

--- a/test/e2e/integrations/integrations-e2e.test.ts
+++ b/test/e2e/integrations/integrations-e2e.test.ts
@@ -10,52 +10,26 @@ import {
 import {
   E2E_ACCESS_TOKEN,
   SHOULD_SKIP_CONTROL_E2E,
-  forceExit,
   cleanupTrackedResources,
   setupTestFailureHandler,
   resetTestTracking,
 } from "../../helpers/e2e-test-helper.js";
 import { runCommand } from "../../helpers/command-helpers.js";
 import { parseNdjsonLines } from "../../helpers/ndjson.js";
+import { createTestApp } from "../../helpers/e2e-test-app.js";
 
 describe.skipIf(SHOULD_SKIP_CONTROL_E2E)("Integrations E2E Tests", () => {
   let testAppId: string;
+  let teardown: (() => Promise<void>) | undefined;
 
   beforeAll(async () => {
-    process.on("SIGINT", forceExit);
-
-    // Create a test app for integration operations
-    const createResult = await runCommand(
-      ["apps", "create", `e2e-integrations-test-${Date.now()}`, "--json"],
-      {
-        env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN || "" },
-      },
-    );
-
-    if (createResult.exitCode !== 0) {
-      throw new Error(`Failed to create test app: ${createResult.stderr}`);
-    }
-    const result = parseNdjsonLines(createResult.stdout).find(
-      (r) => r.type === "result",
-    ) as Record<string, unknown>;
-    const app = result.app as Record<string, unknown>;
-    testAppId = (app.id ?? app.appId) as string;
-    if (!testAppId) {
-      throw new Error(`No app ID found in result: ${JSON.stringify(result)}`);
-    }
+    ({ appId: testAppId, teardown } = await createTestApp(
+      "e2e-integrations-test",
+    ));
   });
 
   afterAll(async () => {
-    if (testAppId) {
-      try {
-        await runCommand(["apps", "delete", testAppId, "--force"], {
-          env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN || "" },
-        });
-      } catch {
-        // Ignore cleanup errors — the app may already be deleted
-      }
-    }
-    process.removeListener("SIGINT", forceExit);
+    await teardown?.();
   });
 
   beforeEach(() => {

--- a/test/e2e/integrations/integrations-e2e.test.ts
+++ b/test/e2e/integrations/integrations-e2e.test.ts
@@ -83,6 +83,14 @@ describe.skipIf(SHOULD_SKIP_CONTROL_E2E)("Integrations E2E Tests", () => {
     );
 
     expect(listResult.exitCode).toBe(0);
+
+    const listRecords = parseNdjsonLines(listResult.stdout);
+    const listRecord = listRecords.find((r) => r.type === "result");
+    expect(listRecord).toBeDefined();
+    expect(listRecord!.success).toBe(true);
+    expect(Array.isArray(listRecord!.integrations)).toBe(true);
+    expect(listRecord).toHaveProperty("appId");
+    expect(listRecord).toHaveProperty("total");
   });
 
   it(

--- a/test/e2e/integrations/integrations-e2e.test.ts
+++ b/test/e2e/integrations/integrations-e2e.test.ts
@@ -26,13 +26,7 @@ describe.skipIf(SHOULD_SKIP_CONTROL_E2E)("Integrations E2E Tests", () => {
 
     // Create a test app for integration operations
     const createResult = await runCommand(
-      [
-        "apps",
-        "create",
-        "--name",
-        `e2e-integrations-test-${Date.now()}`,
-        "--json",
-      ],
+      ["apps", "create", `e2e-integrations-test-${Date.now()}`, "--json"],
       {
         env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN || "" },
       },

--- a/test/e2e/integrations/integrations-e2e.test.ts
+++ b/test/e2e/integrations/integrations-e2e.test.ts
@@ -1,0 +1,150 @@
+import {
+  describe,
+  it,
+  beforeEach,
+  afterEach,
+  beforeAll,
+  afterAll,
+  expect,
+} from "vitest";
+import {
+  E2E_ACCESS_TOKEN,
+  SHOULD_SKIP_CONTROL_E2E,
+  forceExit,
+  cleanupTrackedResources,
+  setupTestFailureHandler,
+  resetTestTracking,
+} from "../../helpers/e2e-test-helper.js";
+import { runCommand } from "../../helpers/command-helpers.js";
+import { parseNdjsonLines } from "../../helpers/ndjson.js";
+
+describe.skipIf(SHOULD_SKIP_CONTROL_E2E)("Integrations E2E Tests", () => {
+  let testAppId: string;
+
+  beforeAll(async () => {
+    process.on("SIGINT", forceExit);
+
+    // Create a test app for integration operations
+    const createResult = await runCommand(
+      [
+        "apps",
+        "create",
+        "--name",
+        `e2e-integrations-test-${Date.now()}`,
+        "--json",
+      ],
+      {
+        env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN || "" },
+      },
+    );
+
+    if (createResult.exitCode !== 0) {
+      throw new Error(`Failed to create test app: ${createResult.stderr}`);
+    }
+    const result = parseNdjsonLines(createResult.stdout).find(
+      (r) => r.type === "result",
+    ) as Record<string, unknown>;
+    const app = result.app as Record<string, unknown>;
+    testAppId = (app.id ?? app.appId) as string;
+    if (!testAppId) {
+      throw new Error(`No app ID found in result: ${JSON.stringify(result)}`);
+    }
+  });
+
+  afterAll(async () => {
+    if (testAppId) {
+      try {
+        await runCommand(["apps", "delete", testAppId, "--force"], {
+          env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN || "" },
+        });
+      } catch {
+        // Ignore cleanup errors — the app may already be deleted
+      }
+    }
+    process.removeListener("SIGINT", forceExit);
+  });
+
+  beforeEach(() => {
+    resetTestTracking();
+  });
+
+  afterEach(async () => {
+    await cleanupTrackedResources();
+  });
+
+  it("should list integrations for an app", { timeout: 15000 }, async () => {
+    setupTestFailureHandler("should list integrations for an app");
+
+    const listResult = await runCommand(
+      ["integrations", "list", "--app", testAppId, "--json"],
+      {
+        env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN || "" },
+      },
+    );
+
+    expect(listResult.exitCode).toBe(0);
+  });
+
+  it(
+    "should create, get, and delete an integration rule",
+    { timeout: 30000 },
+    async () => {
+      setupTestFailureHandler(
+        "should create, get, and delete an integration rule",
+      );
+
+      // Create an HTTP integration rule
+      const createResult = await runCommand(
+        [
+          "integrations",
+          "create",
+          "--app",
+          testAppId,
+          "--rule-type",
+          "http",
+          "--source-type",
+          "channel.message",
+          "--target-url",
+          "https://example.com/e2e-webhook-test",
+          "--json",
+        ],
+        {
+          env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN || "" },
+        },
+      );
+
+      expect(createResult.exitCode).toBe(0);
+
+      // Extract the rule ID from the result
+      const createLines = parseNdjsonLines(createResult.stdout);
+      const createRecord = createLines.find((r) => r.type === "result");
+      expect(createRecord).toBeDefined();
+
+      const rule = (createRecord?.rule ?? createRecord?.integration) as
+        | Record<string, unknown>
+        | undefined;
+      const ruleId = (rule?.id ?? rule?.ruleId ?? "") as string;
+      expect(ruleId).toBeTruthy();
+
+      // Get the integration rule by ID
+      const getResult = await runCommand(
+        ["integrations", "get", ruleId, "--app", testAppId, "--json"],
+        {
+          env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN || "" },
+        },
+      );
+
+      expect(getResult.exitCode).toBe(0);
+
+      // Delete the integration rule
+      const deleteResult = await runCommand(
+        ["integrations", "delete", ruleId, "--app", testAppId, "--force"],
+        {
+          env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN || "" },
+        },
+      );
+
+      expect(deleteResult.exitCode).toBe(0);
+    },
+  );
+});

--- a/test/e2e/logs/logs-e2e.test.ts
+++ b/test/e2e/logs/logs-e2e.test.ts
@@ -1,17 +1,8 @@
-import {
-  describe,
-  it,
-  beforeEach,
-  afterEach,
-  beforeAll,
-  afterAll,
-  expect,
-} from "vitest";
+import { describe, it, beforeEach, afterEach, expect } from "vitest";
 import {
   E2E_API_KEY,
   SHOULD_SKIP_E2E,
   getUniqueChannelName,
-  forceExit,
   cleanupTrackedResources,
   setupTestFailureHandler,
   resetTestTracking,
@@ -25,14 +16,6 @@ import type { CliRunner } from "../../helpers/cli-runner.js";
 import { parseNdjsonLines } from "../../helpers/ndjson.js";
 
 describe.skipIf(SHOULD_SKIP_E2E)("Logs E2E Tests", () => {
-  beforeAll(() => {
-    process.on("SIGINT", forceExit);
-  });
-
-  afterAll(() => {
-    process.removeListener("SIGINT", forceExit);
-  });
-
   beforeEach(() => {
     resetTestTracking();
   });

--- a/test/e2e/logs/logs-e2e.test.ts
+++ b/test/e2e/logs/logs-e2e.test.ts
@@ -22,6 +22,7 @@ import {
   cleanupRunners,
 } from "../../helpers/command-helpers.js";
 import type { CliRunner } from "../../helpers/cli-runner.js";
+import { parseNdjsonLines } from "../../helpers/ndjson.js";
 
 describe.skipIf(SHOULD_SKIP_E2E)("Logs E2E Tests", () => {
   beforeAll(() => {
@@ -51,6 +52,13 @@ describe.skipIf(SHOULD_SKIP_E2E)("Logs E2E Tests", () => {
 
       // Should succeed even if empty
       expect(result.exitCode).toBe(0);
+
+      const records = parseNdjsonLines(result.stdout);
+      const resultRecord = records.find((r) => r.type === "result");
+      expect(resultRecord).toBeDefined();
+      expect(resultRecord!.success).toBe(true);
+      expect(Array.isArray(resultRecord!.messages)).toBe(true);
+      expect(resultRecord).toHaveProperty("hasMore");
     });
   });
 
@@ -163,6 +171,13 @@ describe.skipIf(SHOULD_SKIP_E2E)("Logs E2E Tests", () => {
       );
 
       expect(result.exitCode).toBe(0);
+
+      const records = parseNdjsonLines(result.stdout);
+      const resultRecord = records.find((r) => r.type === "result");
+      expect(resultRecord).toBeDefined();
+      expect(resultRecord!.success).toBe(true);
+      expect(Array.isArray(resultRecord!.messages)).toBe(true);
+      expect(resultRecord).toHaveProperty("hasMore");
     });
   });
 
@@ -177,6 +192,13 @@ describe.skipIf(SHOULD_SKIP_E2E)("Logs E2E Tests", () => {
 
       // Should succeed even if empty
       expect(result.exitCode).toBe(0);
+
+      const records = parseNdjsonLines(result.stdout);
+      const resultRecord = records.find((r) => r.type === "result");
+      expect(resultRecord).toBeDefined();
+      expect(resultRecord!.success).toBe(true);
+      expect(Array.isArray(resultRecord!.messages)).toBe(true);
+      expect(resultRecord).toHaveProperty("hasMore");
     });
 
     it("should subscribe to push logs", { timeout: 60000 }, async () => {

--- a/test/e2e/logs/logs-e2e.test.ts
+++ b/test/e2e/logs/logs-e2e.test.ts
@@ -1,0 +1,205 @@
+import {
+  describe,
+  it,
+  beforeEach,
+  afterEach,
+  beforeAll,
+  afterAll,
+  expect,
+} from "vitest";
+import {
+  E2E_API_KEY,
+  SHOULD_SKIP_E2E,
+  getUniqueChannelName,
+  forceExit,
+  cleanupTrackedResources,
+  setupTestFailureHandler,
+  resetTestTracking,
+} from "../../helpers/e2e-test-helper.js";
+import {
+  runCommand,
+  startSubscribeCommand,
+  cleanupRunners,
+} from "../../helpers/command-helpers.js";
+import type { CliRunner } from "../../helpers/cli-runner.js";
+
+describe.skipIf(SHOULD_SKIP_E2E)("Logs E2E Tests", () => {
+  beforeAll(() => {
+    process.on("SIGINT", forceExit);
+  });
+
+  afterAll(() => {
+    process.removeListener("SIGINT", forceExit);
+  });
+
+  beforeEach(() => {
+    resetTestTracking();
+  });
+
+  afterEach(async () => {
+    await cleanupTrackedResources();
+  });
+
+  describe("logs history", () => {
+    it("should retrieve application log history", async () => {
+      setupTestFailureHandler("should retrieve application log history");
+
+      const result = await runCommand(["logs", "history", "--json"], {
+        env: { ABLY_API_KEY: E2E_API_KEY || "" },
+        timeoutMs: 15000,
+      });
+
+      // Should succeed even if empty
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("logs subscribe", () => {
+    it(
+      "should subscribe to live application logs",
+      { timeout: 60000 },
+      async () => {
+        setupTestFailureHandler("should subscribe to live application logs");
+
+        let subscriber: CliRunner | null = null;
+
+        try {
+          // Start subscribing to logs
+          subscriber = await startSubscribeCommand(
+            ["logs", "subscribe", "--rewind", "1", "--duration", "30"],
+            /Listening for log events/,
+            {
+              env: { ABLY_API_KEY: E2E_API_KEY || "" },
+              timeoutMs: 30000,
+            },
+          );
+
+          // The subscriber connected successfully - that's the smoke test
+          expect(subscriber.isRunning()).toBe(true);
+        } finally {
+          if (subscriber) {
+            await cleanupRunners([subscriber]);
+          }
+        }
+      },
+    );
+  });
+
+  describe("logs channel-lifecycle subscribe", () => {
+    it(
+      "should subscribe to channel lifecycle events",
+      { timeout: 60000 },
+      async () => {
+        setupTestFailureHandler("should subscribe to channel lifecycle events");
+
+        let subscriber: CliRunner | null = null;
+
+        try {
+          subscriber = await startSubscribeCommand(
+            ["logs", "channel-lifecycle", "subscribe", "--duration", "30"],
+            /Listening for channel lifecycle/,
+            {
+              env: { ABLY_API_KEY: E2E_API_KEY || "" },
+              timeoutMs: 30000,
+            },
+          );
+
+          expect(subscriber.isRunning()).toBe(true);
+
+          // Trigger a channel lifecycle event by publishing to a new channel
+          const channelName = getUniqueChannelName("lifecycle-trigger");
+          await runCommand(["channels", "publish", channelName, "trigger"], {
+            env: { ABLY_API_KEY: E2E_API_KEY || "" },
+            timeoutMs: 15000,
+          });
+        } finally {
+          if (subscriber) {
+            await cleanupRunners([subscriber]);
+          }
+        }
+      },
+    );
+  });
+
+  describe("logs connection-lifecycle", () => {
+    it(
+      "should subscribe to connection lifecycle events",
+      { timeout: 60000 },
+      async () => {
+        setupTestFailureHandler(
+          "should subscribe to connection lifecycle events",
+        );
+
+        let subscriber: CliRunner | null = null;
+
+        try {
+          subscriber = await startSubscribeCommand(
+            ["logs", "connection-lifecycle", "subscribe", "--duration", "30"],
+            /Listening for connection lifecycle/,
+            {
+              env: { ABLY_API_KEY: E2E_API_KEY || "" },
+              timeoutMs: 30000,
+            },
+          );
+
+          expect(subscriber.isRunning()).toBe(true);
+        } finally {
+          if (subscriber) {
+            await cleanupRunners([subscriber]);
+          }
+        }
+      },
+    );
+
+    it("should retrieve connection lifecycle history", async () => {
+      setupTestFailureHandler("should retrieve connection lifecycle history");
+
+      const result = await runCommand(
+        ["logs", "connection-lifecycle", "history", "--json"],
+        {
+          env: { ABLY_API_KEY: E2E_API_KEY || "" },
+          timeoutMs: 15000,
+        },
+      );
+
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("logs push", () => {
+    it("should retrieve push log history", async () => {
+      setupTestFailureHandler("should retrieve push log history");
+
+      const result = await runCommand(["logs", "push", "history", "--json"], {
+        env: { ABLY_API_KEY: E2E_API_KEY || "" },
+        timeoutMs: 15000,
+      });
+
+      // Should succeed even if empty
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should subscribe to push logs", { timeout: 60000 }, async () => {
+      setupTestFailureHandler("should subscribe to push logs");
+
+      let subscriber: CliRunner | null = null;
+
+      try {
+        subscriber = await startSubscribeCommand(
+          ["logs", "push", "subscribe", "--duration", "30"],
+          /Listening for push logs/,
+          {
+            env: { ABLY_API_KEY: E2E_API_KEY || "" },
+            timeoutMs: 30000,
+          },
+        );
+
+        expect(subscriber.isRunning()).toBe(true);
+      } finally {
+        if (subscriber) {
+          await cleanupRunners([subscriber]);
+        }
+      }
+    });
+  });
+});

--- a/test/e2e/output/output-format-e2e.test.ts
+++ b/test/e2e/output/output-format-e2e.test.ts
@@ -231,7 +231,7 @@ describe.skipIf(SHOULD_SKIP_E2E)("--json error envelope consistency", () => {
 
       // Create throwaway app
       const appCreate = await runCommand(
-        ["apps", "create", "--name", `e2e-hint-test-${Date.now()}`, "--json"],
+        ["apps", "create", `e2e-hint-test-${Date.now()}`, "--json"],
         {
           env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN || "" },
         },
@@ -249,10 +249,9 @@ describe.skipIf(SHOULD_SKIP_E2E)("--json error envelope consistency", () => {
             "auth",
             "keys",
             "create",
+            "hint-scoped-key",
             "--app",
             appId,
-            "--name",
-            "hint-scoped-key",
             "--capabilities",
             '{"allowed-*":["publish"]}',
             "--json",

--- a/test/e2e/output/output-format-e2e.test.ts
+++ b/test/e2e/output/output-format-e2e.test.ts
@@ -1,13 +1,13 @@
-import { describe, it, beforeAll, afterAll, expect } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   E2E_API_KEY,
   E2E_ACCESS_TOKEN,
   SHOULD_SKIP_E2E,
   SHOULD_SKIP_CONTROL_E2E,
-  forceExit,
   setupTestFailureHandler,
 } from "../../helpers/e2e-test-helper.js";
 import { runCommand } from "../../helpers/command-helpers.js";
+import { createTestApp } from "../../helpers/e2e-test-app.js";
 import { parseAllJsonRecords } from "../../helpers/ndjson.js";
 import stripAnsi from "strip-ansi";
 
@@ -40,14 +40,6 @@ function assertErrorEnvelope(
 }
 
 describe.skipIf(SHOULD_SKIP_E2E)("--pretty-json output shape", () => {
-  beforeAll(() => {
-    process.on("SIGINT", forceExit);
-  });
-
-  afterAll(() => {
-    process.removeListener("SIGINT", forceExit);
-  });
-
   it(
     "channels publish emits multi-line, indented, parseable JSON under --pretty-json",
     { timeout: 20000 },
@@ -147,14 +139,6 @@ describe.skipIf(SHOULD_SKIP_E2E)("--pretty-json output shape", () => {
 });
 
 describe.skipIf(SHOULD_SKIP_E2E)("--json error envelope consistency", () => {
-  beforeAll(() => {
-    process.on("SIGINT", forceExit);
-  });
-
-  afterAll(() => {
-    process.removeListener("SIGINT", forceExit);
-  });
-
   // `channels publish` reports per-message errors inline; `channels history`
   // funnels through this.fail() and emits the error envelope.
   it(
@@ -230,16 +214,7 @@ describe.skipIf(SHOULD_SKIP_E2E)("--json error envelope consistency", () => {
       );
 
       // Create throwaway app
-      const appCreate = await runCommand(
-        ["apps", "create", `e2e-hint-test-${Date.now()}`, "--json"],
-        {
-          env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN || "" },
-        },
-      );
-      const appRecord = parseAllJsonRecords(stripAnsi(appCreate.stdout)).find(
-        (r) => r.type === "result",
-      ) as Record<string, unknown>;
-      const appId = (appRecord.app as Record<string, unknown>).id as string;
+      const { appId, teardown } = await createTestApp("e2e-hint-test");
       expect(appId).toBeTruthy();
 
       try {
@@ -282,9 +257,7 @@ describe.skipIf(SHOULD_SKIP_E2E)("--json error envelope consistency", () => {
         // The 40160 hint directs users at the auth keys list workflow
         expect(err.hint as string).toMatch(/ably auth keys list/);
       } finally {
-        await runCommand(["apps", "delete", appId, "--force"], {
-          env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN || "" },
-        });
+        await teardown();
       }
     },
   );

--- a/test/e2e/output/output-format-e2e.test.ts
+++ b/test/e2e/output/output-format-e2e.test.ts
@@ -1,0 +1,292 @@
+import { describe, it, beforeAll, afterAll, expect } from "vitest";
+import {
+  E2E_API_KEY,
+  E2E_ACCESS_TOKEN,
+  SHOULD_SKIP_E2E,
+  SHOULD_SKIP_CONTROL_E2E,
+  forceExit,
+  setupTestFailureHandler,
+} from "../../helpers/e2e-test-helper.js";
+import { runCommand } from "../../helpers/command-helpers.js";
+import { parseAllJsonRecords } from "../../helpers/ndjson.js";
+import stripAnsi from "strip-ansi";
+
+function assertErrorEnvelope(
+  stdout: string,
+  ctx: string,
+): Record<string, unknown> {
+  const records = parseAllJsonRecords(stripAnsi(stdout));
+  const errorRecord = records.find((r) => r.type === "error");
+  expect(errorRecord, `[${ctx}] expected type:error record`).toBeDefined();
+  expect(errorRecord).toHaveProperty("type", "error");
+  expect(errorRecord).toHaveProperty("success", false);
+  expect(errorRecord).toHaveProperty("command");
+  expect(errorRecord).toHaveProperty("error");
+  const err = (errorRecord as Record<string, unknown>).error as Record<
+    string,
+    unknown
+  >;
+  expect(err, `[${ctx}] error object must be present`).toBeDefined();
+  expect(err).toHaveProperty("message");
+  expect(typeof err.message).toBe("string");
+
+  const completed = records.find(
+    (r) => r.type === "status" && r.status === "completed",
+  );
+  expect(completed).toBeDefined();
+  expect(completed).toHaveProperty("exitCode", 1);
+
+  return err;
+}
+
+describe.skipIf(SHOULD_SKIP_E2E)("--pretty-json output shape", () => {
+  beforeAll(() => {
+    process.on("SIGINT", forceExit);
+  });
+
+  afterAll(() => {
+    process.removeListener("SIGINT", forceExit);
+  });
+
+  it(
+    "channels publish emits multi-line, indented, parseable JSON under --pretty-json",
+    { timeout: 20000 },
+    async () => {
+      setupTestFailureHandler(
+        "channels publish emits multi-line, indented, parseable JSON under --pretty-json",
+      );
+
+      const channel = `pretty-json-test-${Date.now()}`;
+      const result = await runCommand(
+        ["channels", "publish", channel, "hello-pretty", "--pretty-json"],
+        {
+          env: { ABLY_API_KEY: E2E_API_KEY || "" },
+        },
+      );
+
+      expect(result.exitCode).toBe(0);
+
+      // CLI may emit ANSI color codes in CI — strip before shape assertions
+      const clean = stripAnsi(result.stdout);
+
+      // pretty-json should span multiple lines (not compact single-line NDJSON)
+      const lines = clean.split("\n").filter((l) => l.length > 0);
+      expect(lines.length).toBeGreaterThan(1);
+
+      // pretty-json should contain indentation whitespace
+      expect(clean).toMatch(/\n\s{2,}"/);
+
+      // Every emitted JSON object must parse cleanly
+      const parsed = parseAllJsonRecords(clean);
+      expect(parsed.length).toBeGreaterThanOrEqual(2); // result + completed
+
+      const resultRecord = parsed.find((r) => r.type === "result");
+      const completedRecord = parsed.find(
+        (r) => r.type === "status" && r.status === "completed",
+      );
+
+      expect(resultRecord).toBeDefined();
+      expect(resultRecord).toHaveProperty("success", true);
+      expect(resultRecord).toHaveProperty("command");
+      expect(completedRecord).toBeDefined();
+      expect(completedRecord).toHaveProperty("exitCode", 0);
+    },
+  );
+
+  it(
+    "channels history emits parseable pretty JSON matching the --json envelope shape",
+    { timeout: 20000 },
+    async () => {
+      setupTestFailureHandler(
+        "channels history emits parseable pretty JSON matching the --json envelope shape",
+      );
+
+      const channel = `pretty-json-history-${Date.now()}`;
+      // Publish one message so history has something to return
+      await runCommand(
+        ["channels", "publish", channel, "msg-for-history", "--json"],
+        { env: { ABLY_API_KEY: E2E_API_KEY || "" } },
+      );
+      await new Promise((r) => setTimeout(r, 1500));
+
+      const [pretty, compact] = await Promise.all([
+        runCommand(["channels", "history", channel, "--pretty-json"], {
+          env: { ABLY_API_KEY: E2E_API_KEY || "" },
+        }),
+        runCommand(["channels", "history", channel, "--json"], {
+          env: { ABLY_API_KEY: E2E_API_KEY || "" },
+        }),
+      ]);
+
+      expect(pretty.exitCode).toBe(0);
+      expect(compact.exitCode).toBe(0);
+
+      const prettyClean = stripAnsi(pretty.stdout);
+      const compactClean = stripAnsi(compact.stdout);
+
+      // pretty is multi-line, compact is single-line per record
+      expect(prettyClean.split("\n").length).toBeGreaterThan(
+        compactClean.split("\n").length,
+      );
+
+      const prettyResult = parseAllJsonRecords(prettyClean).find(
+        (r) => r.type === "result",
+      ) as Record<string, unknown>;
+
+      const compactResult = parseAllJsonRecords(compactClean).find(
+        (r) => r.type === "result",
+      ) as Record<string, unknown>;
+
+      // Envelope fields should match between the two formats
+      expect(prettyResult.type).toEqual(compactResult.type);
+      expect(prettyResult.command).toEqual(compactResult.command);
+      expect(prettyResult.success).toEqual(compactResult.success);
+      expect(Array.isArray(prettyResult.messages)).toBe(true);
+    },
+  );
+});
+
+describe.skipIf(SHOULD_SKIP_E2E)("--json error envelope consistency", () => {
+  beforeAll(() => {
+    process.on("SIGINT", forceExit);
+  });
+
+  afterAll(() => {
+    process.removeListener("SIGINT", forceExit);
+  });
+
+  // `channels publish` reports per-message errors inline; `channels history`
+  // funnels through this.fail() and emits the error envelope.
+  it(
+    "channels history with an invalid API key produces the standard error envelope",
+    { timeout: 15000 },
+    async () => {
+      setupTestFailureHandler(
+        "channels history with an invalid API key produces the standard error envelope",
+      );
+
+      const result = await runCommand(
+        ["channels", "history", "anything", "--json"],
+        {
+          env: { ABLY_API_KEY: "fake.app:deadbeefdeadbeefdeadbeefdeadbeef" },
+        },
+      );
+
+      expect(result.exitCode).not.toBe(0);
+      const err = assertErrorEnvelope(result.stdout, "invalid-api-key");
+      // Should carry an Ably error code and HTTP status
+      expect(err).toHaveProperty("code");
+      expect(err).toHaveProperty("statusCode");
+    },
+  );
+
+  it.skipIf(SHOULD_SKIP_CONTROL_E2E)(
+    "auth keys get with a non-existent key produces the standard error envelope",
+    { timeout: 15000 },
+    async () => {
+      setupTestFailureHandler(
+        "auth keys get with a non-existent key produces the standard error envelope",
+      );
+
+      const result = await runCommand(
+        ["auth", "keys", "get", "nonexistentapp.nonexistentkey", "--json"],
+        {
+          env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN || "" },
+        },
+      );
+
+      expect(result.exitCode).not.toBe(0);
+      assertErrorEnvelope(result.stdout, "nonexistent-key");
+    },
+  );
+
+  it.skipIf(SHOULD_SKIP_CONTROL_E2E)(
+    "apps delete on a non-existent app produces the standard error envelope",
+    { timeout: 15000 },
+    async () => {
+      setupTestFailureHandler(
+        "apps delete on a non-existent app produces the standard error envelope",
+      );
+
+      const result = await runCommand(
+        ["apps", "delete", "nonexistentapp000000", "--force", "--json"],
+        {
+          env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN || "" },
+        },
+      );
+
+      expect(result.exitCode).not.toBe(0);
+      assertErrorEnvelope(result.stdout, "nonexistent-app");
+    },
+  );
+
+  // Pins src/utils/errors.ts → envelope.error.hint wiring for Ably 40160.
+  it.skipIf(SHOULD_SKIP_CONTROL_E2E)(
+    "error envelope includes a friendly hint for known Ably error codes",
+    { timeout: 45000 },
+    async () => {
+      setupTestFailureHandler(
+        "error envelope includes a friendly hint for known Ably error codes",
+      );
+
+      // Create throwaway app
+      const appCreate = await runCommand(
+        ["apps", "create", "--name", `e2e-hint-test-${Date.now()}`, "--json"],
+        {
+          env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN || "" },
+        },
+      );
+      const appRecord = parseAllJsonRecords(stripAnsi(appCreate.stdout)).find(
+        (r) => r.type === "result",
+      ) as Record<string, unknown>;
+      const appId = (appRecord.app as Record<string, unknown>).id as string;
+      expect(appId).toBeTruthy();
+
+      try {
+        // Create a key scoped to publish on "allowed-*" only
+        const keyCreate = await runCommand(
+          [
+            "auth",
+            "keys",
+            "create",
+            "--app",
+            appId,
+            "--name",
+            "hint-scoped-key",
+            "--capabilities",
+            '{"allowed-*":["publish"]}',
+            "--json",
+          ],
+          {
+            env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN || "" },
+          },
+        );
+        const keyRecord = parseAllJsonRecords(stripAnsi(keyCreate.stdout)).find(
+          (r) => r.type === "result",
+        ) as Record<string, unknown>;
+        const scopedKey = (keyRecord.key as Record<string, unknown>)
+          .key as string;
+        expect(scopedKey).toBeTruthy();
+
+        // Key lacks `history` op → Ably 40160, emitted via this.fail().
+        const history = await runCommand(
+          ["channels", "history", "allowed-history-test", "--json"],
+          { env: { ABLY_API_KEY: scopedKey } },
+        );
+
+        expect(history.exitCode).not.toBe(0);
+        const err = assertErrorEnvelope(history.stdout, "40160-with-hint");
+
+        expect(err).toHaveProperty("code", 40160);
+        expect(err).toHaveProperty("hint");
+        expect(typeof err.hint).toBe("string");
+        // The 40160 hint directs users at the auth keys list workflow
+        expect(err.hint as string).toMatch(/ably auth keys list/);
+      } finally {
+        await runCommand(["apps", "delete", appId, "--force"], {
+          env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN || "" },
+        });
+      }
+    },
+  );
+});

--- a/test/e2e/push/channels-e2e.test.ts
+++ b/test/e2e/push/channels-e2e.test.ts
@@ -11,7 +11,6 @@ import * as Ably from "ably";
 import {
   E2E_API_KEY,
   SHOULD_SKIP_E2E,
-  forceExit,
   cleanupTrackedResources,
   setupTestFailureHandler,
   resetTestTracking,
@@ -26,8 +25,6 @@ describe.skipIf(SHOULD_SKIP_E2E)("Push Channel Subscriptions E2E Tests", () => {
   let testDeviceId: string;
 
   beforeAll(async () => {
-    process.on("SIGINT", forceExit);
-
     // Generate unique device ID base for this test run
     testDeviceIdBase = `cli-e2e-channel-test-${Date.now()}`;
     testDeviceId = `${testDeviceIdBase}-device`;
@@ -57,8 +54,6 @@ describe.skipIf(SHOULD_SKIP_E2E)("Push Channel Subscriptions E2E Tests", () => {
     } catch {
       // Ignore cleanup errors
     }
-
-    process.removeListener("SIGINT", forceExit);
   });
 
   beforeEach(() => {

--- a/test/e2e/push/devices-e2e.test.ts
+++ b/test/e2e/push/devices-e2e.test.ts
@@ -11,7 +11,6 @@ import * as Ably from "ably";
 import {
   E2E_API_KEY,
   SHOULD_SKIP_E2E,
-  forceExit,
   cleanupTrackedResources,
   setupTestFailureHandler,
   resetTestTracking,
@@ -25,17 +24,11 @@ describe.skipIf(SHOULD_SKIP_E2E)("Push Devices E2E Tests", () => {
   let client: Ably.Rest;
 
   beforeAll(async () => {
-    process.on("SIGINT", forceExit);
-
     // Generate unique device ID base for this test run
     testDeviceIdBase = `cli-e2e-test-${Date.now()}`;
 
     // Create Ably client for verification
     client = createAblyClient();
-  });
-
-  afterAll(() => {
-    process.removeListener("SIGINT", forceExit);
   });
 
   beforeEach(() => {

--- a/test/e2e/push/publish-e2e.test.ts
+++ b/test/e2e/push/publish-e2e.test.ts
@@ -11,7 +11,6 @@ import * as Ably from "ably";
 import {
   E2E_API_KEY,
   SHOULD_SKIP_E2E,
-  forceExit,
   cleanupTrackedResources,
   setupTestFailureHandler,
   resetTestTracking,
@@ -25,8 +24,6 @@ describe.skipIf(SHOULD_SKIP_E2E)("Push Publish E2E Tests", () => {
   let client: Ably.Rest;
 
   beforeAll(async () => {
-    process.on("SIGINT", forceExit);
-
     // Generate unique device ID for this test run
     testDeviceId = `cli-e2e-publish-test-${Date.now()}`;
 
@@ -55,8 +52,6 @@ describe.skipIf(SHOULD_SKIP_E2E)("Push Publish E2E Tests", () => {
     } catch {
       // Ignore cleanup errors
     }
-
-    process.removeListener("SIGINT", forceExit);
   });
 
   beforeEach(() => {

--- a/test/e2e/push/push-config-e2e.test.ts
+++ b/test/e2e/push/push-config-e2e.test.ts
@@ -100,9 +100,16 @@ describe("Push Config E2E Tests", () => {
           (r) => r.type === "result",
         )!;
         expect(output).toHaveProperty("success", true);
-        expect(output).toHaveProperty("appId", testAppId);
-        expect(output.apns).toHaveProperty("configured", false);
-        expect(output.fcm).toHaveProperty("configured", false);
+        const config = output.config as Record<string, unknown>;
+        expect(config).toHaveProperty("appId", testAppId);
+        expect(config.apns as Record<string, unknown>).toHaveProperty(
+          "configured",
+          false,
+        );
+        expect(config.fcm as Record<string, unknown>).toHaveProperty(
+          "configured",
+          false,
+        );
       },
     );
 
@@ -171,7 +178,8 @@ describe("Push Config E2E Tests", () => {
           (r) => r.type === "result",
         )!;
         expect(setOutput).toHaveProperty("success", true);
-        expect(setOutput).toHaveProperty("method", "p8");
+        const setConfig = setOutput.config as Record<string, unknown>;
+        expect(setConfig).toHaveProperty("method", "p8");
 
         // 2. Verify config was set by showing it
         const showResult = await runCommand(
@@ -187,16 +195,15 @@ describe("Push Config E2E Tests", () => {
         const showOutput = parseNdjsonLines(showResult.stdout).find(
           (r) => r.type === "result",
         )!;
-        expect(showOutput.apns).toHaveProperty("configured", true);
-        expect(showOutput.apns).toHaveProperty("hasP8Key", true);
-        expect(showOutput.apns).toHaveProperty("useSandbox", true);
-        expect(showOutput.apns).toHaveProperty("authType", "token");
-        expect(showOutput.apns).toHaveProperty("keyId", "ABC123DEFG");
-        expect(showOutput.apns).toHaveProperty("teamId", "TEAM123456");
-        expect(showOutput.apns).toHaveProperty(
-          "bundleId",
-          "com.example.pushtest",
-        );
+        const showConfig = showOutput.config as Record<string, unknown>;
+        const apns = showConfig.apns as Record<string, unknown>;
+        expect(apns).toHaveProperty("configured", true);
+        expect(apns).toHaveProperty("hasP8Key", true);
+        expect(apns).toHaveProperty("useSandbox", true);
+        expect(apns).toHaveProperty("authType", "token");
+        expect(apns).toHaveProperty("keyId", "ABC123DEFG");
+        expect(apns).toHaveProperty("teamId", "TEAM123456");
+        expect(apns).toHaveProperty("bundleId", "com.example.pushtest");
       },
     );
 
@@ -243,7 +250,8 @@ describe("Push Config E2E Tests", () => {
         (r) => r.type === "result",
       )!;
       expect(clearOutput).toHaveProperty("success", true);
-      expect(clearOutput).toHaveProperty("cleared", "apns");
+      const clearConfig = clearOutput.config as Record<string, unknown>;
+      expect(clearConfig).toHaveProperty("cleared", "apns");
 
       // 3. Verify config was cleared
       const showResult = await runCommand(
@@ -259,8 +267,10 @@ describe("Push Config E2E Tests", () => {
       const showOutput = parseNdjsonLines(showResult.stdout).find(
         (r) => r.type === "result",
       )!;
-      expect(showOutput.apns).toHaveProperty("configured", false);
-      expect(showOutput.apns).toHaveProperty("hasP8Key", false);
+      const showConfig = showOutput.config as Record<string, unknown>;
+      const apns = showConfig.apns as Record<string, unknown>;
+      expect(apns).toHaveProperty("configured", false);
+      expect(apns).toHaveProperty("hasP8Key", false);
     });
   });
 
@@ -314,7 +324,11 @@ describe("Push Config E2E Tests", () => {
         const showOutput = parseNdjsonLines(showResult.stdout).find(
           (r) => r.type === "result",
         )!;
-        expect(showOutput.fcm).toHaveProperty("configured", true);
+        const showConfig = showOutput.config as Record<string, unknown>;
+        expect(showConfig.fcm as Record<string, unknown>).toHaveProperty(
+          "configured",
+          true,
+        );
       },
     );
 
@@ -355,7 +369,8 @@ describe("Push Config E2E Tests", () => {
         (r) => r.type === "result",
       )!;
       expect(clearOutput).toHaveProperty("success", true);
-      expect(clearOutput).toHaveProperty("cleared", "fcm");
+      const clearConfig = clearOutput.config as Record<string, unknown>;
+      expect(clearConfig).toHaveProperty("cleared", "fcm");
 
       // 3. Verify config was cleared
       const showResult = await runCommand(
@@ -371,7 +386,11 @@ describe("Push Config E2E Tests", () => {
       const showOutput = parseNdjsonLines(showResult.stdout).find(
         (r) => r.type === "result",
       )!;
-      expect(showOutput.fcm).toHaveProperty("configured", false);
+      const showConfig = showOutput.config as Record<string, unknown>;
+      expect(showConfig.fcm as Record<string, unknown>).toHaveProperty(
+        "configured",
+        false,
+      );
     });
   });
 

--- a/test/e2e/push/push-config-e2e.test.ts
+++ b/test/e2e/push/push-config-e2e.test.ts
@@ -7,27 +7,23 @@ import {
   afterAll,
   expect,
 } from "vitest";
-import { ControlApi } from "../../../src/services/control-api.js";
 import {
-  forceExit,
   cleanupTrackedResources,
   setupTestFailureHandler,
   resetTestTracking,
 } from "../../helpers/e2e-test-helper.js";
 import { runCommand } from "../../helpers/command-helpers.js";
+import { createTestApp } from "../../helpers/e2e-test-app.js";
 import { parseNdjsonLines } from "../../helpers/ndjson.js";
 import { resolve } from "node:path";
 
 describe("Push Config E2E Tests", () => {
-  let controlApi: ControlApi;
   let testAppId: string;
+  let teardownApp: (() => Promise<void>) | undefined;
   let shouldSkip = false;
 
   beforeAll(async () => {
-    process.on("SIGINT", forceExit);
-
-    const accessToken = process.env.E2E_ABLY_ACCESS_TOKEN;
-    if (!accessToken) {
+    if (!process.env.E2E_ABLY_ACCESS_TOKEN) {
       console.log(
         "E2E_ABLY_ACCESS_TOKEN not available, skipping Push Config E2E tests",
       );
@@ -35,38 +31,13 @@ describe("Push Config E2E Tests", () => {
       return;
     }
 
-    controlApi = new ControlApi({
-      accessToken,
-      logErrors: false,
-    });
-
-    // Create a dedicated test app for push config tests
-    // Let setup failures propagate — only missing credentials should skip
-    const appName = `E2E Push Config Test ${Date.now()}`;
-    const createResult = await runCommand(
-      ["apps", "create", appName, "--json"],
-      {
-        env: { ABLY_ACCESS_TOKEN: accessToken },
-      },
-    );
-
-    const result = parseNdjsonLines(createResult.stdout).find(
-      (r) => r.type === "result",
-    )!;
-    testAppId = (result.app as Record<string, unknown>).id as string;
-    console.log(`Created test app for push config: ${testAppId}`);
+    ({ appId: testAppId, teardown: teardownApp } = await createTestApp(
+      "e2e-push-config-test",
+    ));
   });
 
   afterAll(async () => {
-    if (testAppId) {
-      try {
-        await controlApi.deleteApp(testAppId);
-        console.log(`Deleted test app: ${testAppId}`);
-      } catch (error) {
-        console.warn(`Failed to delete test app ${testAppId}:`, error);
-      }
-    }
-    process.removeListener("SIGINT", forceExit);
+    await teardownApp?.();
   });
 
   beforeEach(() => {

--- a/test/e2e/push/push-config-e2e.test.ts
+++ b/test/e2e/push/push-config-e2e.test.ts
@@ -11,8 +11,6 @@ import { ControlApi } from "../../../src/services/control-api.js";
 import {
   forceExit,
   cleanupTrackedResources,
-  testOutputFiles,
-  testCommands,
   setupTestFailureHandler,
   resetTestTracking,
 } from "../../helpers/e2e-test-helper.js";
@@ -73,8 +71,6 @@ describe("Push Config E2E Tests", () => {
 
   beforeEach(() => {
     resetTestTracking();
-    testOutputFiles.clear();
-    testCommands.length = 0;
   });
 
   afterEach(async () => {

--- a/test/e2e/rooms/rooms-e2e.test.ts
+++ b/test/e2e/rooms/rooms-e2e.test.ts
@@ -1,17 +1,8 @@
-import {
-  describe,
-  it,
-  beforeEach,
-  afterEach,
-  beforeAll,
-  afterAll,
-  expect,
-} from "vitest";
+import { describe, it, beforeEach, afterEach, expect } from "vitest";
 import {
   SHOULD_SKIP_E2E,
   getUniqueChannelName,
   getUniqueClientId,
-  forceExit,
   cleanupTrackedResources,
   testOutputFiles,
   testCommands,
@@ -28,15 +19,6 @@ import {
 import { CliRunner } from "../../helpers/cli-runner.js";
 
 describe("Rooms E2E Tests", () => {
-  // Skip all tests if API key not available
-  beforeAll(() => {
-    process.on("SIGINT", forceExit);
-  });
-
-  afterAll(() => {
-    process.removeListener("SIGINT", forceExit);
-  });
-
   let testRoom: string;
   let client1Id: string;
   let client2Id: string;

--- a/test/e2e/rooms/rooms-list-e2e.test.ts
+++ b/test/e2e/rooms/rooms-list-e2e.test.ts
@@ -1,0 +1,64 @@
+import {
+  describe,
+  it,
+  beforeEach,
+  afterEach,
+  beforeAll,
+  afterAll,
+  expect,
+} from "vitest";
+import {
+  E2E_API_KEY,
+  SHOULD_SKIP_E2E,
+  forceExit,
+  cleanupTrackedResources,
+  setupTestFailureHandler,
+  resetTestTracking,
+} from "../../helpers/e2e-test-helper.js";
+import { runCommand } from "../../helpers/command-helpers.js";
+
+describe.skipIf(SHOULD_SKIP_E2E)("Rooms List E2E Tests", () => {
+  beforeAll(() => {
+    process.on("SIGINT", forceExit);
+  });
+
+  afterAll(() => {
+    process.removeListener("SIGINT", forceExit);
+  });
+
+  beforeEach(() => {
+    resetTestTracking();
+  });
+
+  afterEach(async () => {
+    await cleanupTrackedResources();
+  });
+
+  describe("rooms list", () => {
+    it("should list rooms", async () => {
+      setupTestFailureHandler("should list rooms");
+
+      const result = await runCommand(["rooms", "list", "--json"], {
+        env: { ABLY_API_KEY: E2E_API_KEY || "" },
+        timeoutMs: 15000,
+      });
+
+      // Should succeed even if the list is empty
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should list rooms with limit", async () => {
+      setupTestFailureHandler("should list rooms with limit");
+
+      const result = await runCommand(
+        ["rooms", "list", "--limit", "5", "--json"],
+        {
+          env: { ABLY_API_KEY: E2E_API_KEY || "" },
+          timeoutMs: 15000,
+        },
+      );
+
+      expect(result.exitCode).toBe(0);
+    });
+  });
+});

--- a/test/e2e/rooms/rooms-list-e2e.test.ts
+++ b/test/e2e/rooms/rooms-list-e2e.test.ts
@@ -1,16 +1,7 @@
-import {
-  describe,
-  it,
-  beforeEach,
-  afterEach,
-  beforeAll,
-  afterAll,
-  expect,
-} from "vitest";
+import { describe, it, beforeEach, afterEach, expect } from "vitest";
 import {
   E2E_API_KEY,
   SHOULD_SKIP_E2E,
-  forceExit,
   cleanupTrackedResources,
   setupTestFailureHandler,
   resetTestTracking,
@@ -19,14 +10,6 @@ import { runCommand } from "../../helpers/command-helpers.js";
 import { parseNdjsonLines } from "../../helpers/ndjson.js";
 
 describe.skipIf(SHOULD_SKIP_E2E)("Rooms List E2E Tests", () => {
-  beforeAll(() => {
-    process.on("SIGINT", forceExit);
-  });
-
-  afterAll(() => {
-    process.removeListener("SIGINT", forceExit);
-  });
-
   beforeEach(() => {
     resetTestTracking();
   });

--- a/test/e2e/rooms/rooms-list-e2e.test.ts
+++ b/test/e2e/rooms/rooms-list-e2e.test.ts
@@ -16,6 +16,7 @@ import {
   resetTestTracking,
 } from "../../helpers/e2e-test-helper.js";
 import { runCommand } from "../../helpers/command-helpers.js";
+import { parseNdjsonLines } from "../../helpers/ndjson.js";
 
 describe.skipIf(SHOULD_SKIP_E2E)("Rooms List E2E Tests", () => {
   beforeAll(() => {
@@ -45,6 +46,14 @@ describe.skipIf(SHOULD_SKIP_E2E)("Rooms List E2E Tests", () => {
 
       // Should succeed even if the list is empty
       expect(result.exitCode).toBe(0);
+
+      const records = parseNdjsonLines(result.stdout);
+      const resultRecord = records.find((r) => r.type === "result");
+      expect(resultRecord).toBeDefined();
+      expect(resultRecord!.success).toBe(true);
+      expect(Array.isArray(resultRecord!.rooms)).toBe(true);
+      expect(resultRecord).toHaveProperty("total");
+      expect(resultRecord).toHaveProperty("hasMore");
     });
 
     it("should list rooms with limit", async () => {
@@ -59,6 +68,14 @@ describe.skipIf(SHOULD_SKIP_E2E)("Rooms List E2E Tests", () => {
       );
 
       expect(result.exitCode).toBe(0);
+
+      const records = parseNdjsonLines(result.stdout);
+      const resultRecord = records.find((r) => r.type === "result");
+      expect(resultRecord).toBeDefined();
+      expect(resultRecord!.success).toBe(true);
+      expect(Array.isArray(resultRecord!.rooms)).toBe(true);
+      expect(resultRecord).toHaveProperty("total");
+      expect(resultRecord).toHaveProperty("hasMore");
     });
   });
 });

--- a/test/e2e/rooms/rooms-messages-e2e.test.ts
+++ b/test/e2e/rooms/rooms-messages-e2e.test.ts
@@ -1,0 +1,226 @@
+import {
+  describe,
+  it,
+  beforeEach,
+  afterEach,
+  beforeAll,
+  afterAll,
+  expect,
+} from "vitest";
+import {
+  E2E_API_KEY,
+  SHOULD_SKIP_E2E,
+  getUniqueChannelName,
+  getUniqueClientId,
+  forceExit,
+  cleanupTrackedResources,
+  setupTestFailureHandler,
+  resetTestTracking,
+} from "../../helpers/e2e-test-helper.js";
+import { runCommand } from "../../helpers/command-helpers.js";
+import { parseNdjsonLines } from "../../helpers/ndjson.js";
+
+describe.skipIf(SHOULD_SKIP_E2E)("Rooms Messages E2E Tests", () => {
+  beforeAll(() => {
+    process.on("SIGINT", forceExit);
+  });
+
+  afterAll(() => {
+    process.removeListener("SIGINT", forceExit);
+  });
+
+  let testRoom: string;
+  let clientId: string;
+
+  beforeEach(() => {
+    resetTestTracking();
+    testRoom = getUniqueChannelName("room-msg");
+    clientId = getUniqueClientId("msg-client");
+  });
+
+  afterEach(async () => {
+    await cleanupTrackedResources();
+  });
+
+  describe("rooms messages send and history", () => {
+    it("should send a message to a room", async () => {
+      setupTestFailureHandler("should send a message to a room");
+
+      const result = await runCommand(
+        [
+          "rooms",
+          "messages",
+          "send",
+          testRoom,
+          "hello-e2e-test",
+          "--client-id",
+          clientId,
+          "--json",
+        ],
+        {
+          env: { ABLY_API_KEY: E2E_API_KEY || "" },
+          timeoutMs: 30000,
+        },
+      );
+
+      expect(result.exitCode).toBe(0);
+    });
+
+    it(
+      "should retrieve message history for a room",
+      { timeout: 60000 },
+      async () => {
+        setupTestFailureHandler("should retrieve message history for a room");
+
+        // First send a message
+        await runCommand(
+          [
+            "rooms",
+            "messages",
+            "send",
+            testRoom,
+            "history-test-msg",
+            "--client-id",
+            clientId,
+            "--json",
+          ],
+          {
+            env: { ABLY_API_KEY: E2E_API_KEY || "" },
+            timeoutMs: 30000,
+          },
+        );
+
+        // Wait a moment for the message to be available in history
+        await new Promise((resolve) => setTimeout(resolve, 2000));
+
+        // Get history
+        const historyResult = await runCommand(
+          ["rooms", "messages", "history", testRoom, "--json"],
+          {
+            env: { ABLY_API_KEY: E2E_API_KEY || "" },
+            timeoutMs: 30000,
+          },
+        );
+
+        expect(historyResult.exitCode).toBe(0);
+        const jsonLines = parseNdjsonLines(historyResult.stdout);
+        expect(jsonLines.length).toBeGreaterThan(0);
+      },
+    );
+  });
+
+  describe("rooms messages update and delete", () => {
+    it("should update a room message", { timeout: 60000 }, async () => {
+      setupTestFailureHandler("should update a room message");
+
+      // Send a message and get its serial from the JSON response
+      const sendResult = await runCommand(
+        [
+          "rooms",
+          "messages",
+          "send",
+          testRoom,
+          "original-msg",
+          "--client-id",
+          clientId,
+          "--json",
+        ],
+        {
+          env: { ABLY_API_KEY: E2E_API_KEY || "" },
+          timeoutMs: 30000,
+        },
+      );
+
+      expect(sendResult.exitCode).toBe(0);
+
+      // Parse the serial from the send result
+      const sendJsonLines = parseNdjsonLines(sendResult.stdout);
+      const resultLine = sendJsonLines.find((l) => l.type === "result");
+      expect(resultLine).toBeDefined();
+
+      // Extract serial - it could be nested under a domain key
+      const message = (resultLine?.message ?? resultLine) as Record<
+        string,
+        unknown
+      >;
+      const serial = message.serial as string | undefined;
+      expect(serial).toBeDefined();
+
+      // Update the message
+      const updateResult = await runCommand(
+        [
+          "rooms",
+          "messages",
+          "update",
+          testRoom,
+          serial!,
+          "updated-msg",
+          "--client-id",
+          clientId,
+          "--json",
+        ],
+        {
+          env: { ABLY_API_KEY: E2E_API_KEY || "" },
+          timeoutMs: 30000,
+        },
+      );
+
+      expect(updateResult.exitCode).toBe(0);
+    });
+
+    it("should delete a room message", { timeout: 60000 }, async () => {
+      setupTestFailureHandler("should delete a room message");
+
+      // Send a message
+      const sendResult = await runCommand(
+        [
+          "rooms",
+          "messages",
+          "send",
+          testRoom,
+          "to-delete-msg",
+          "--client-id",
+          clientId,
+          "--json",
+        ],
+        {
+          env: { ABLY_API_KEY: E2E_API_KEY || "" },
+          timeoutMs: 30000,
+        },
+      );
+
+      expect(sendResult.exitCode).toBe(0);
+
+      const sendJsonLines = parseNdjsonLines(sendResult.stdout);
+      const resultLine = sendJsonLines.find((l) => l.type === "result");
+      expect(resultLine).toBeDefined();
+
+      const message = (resultLine?.message ?? resultLine) as Record<
+        string,
+        unknown
+      >;
+      const serial = message.serial as string | undefined;
+      expect(serial).toBeDefined();
+
+      // Delete the message
+      const deleteResult = await runCommand(
+        [
+          "rooms",
+          "messages",
+          "delete",
+          testRoom,
+          serial!,
+          "--client-id",
+          clientId,
+          "--json",
+        ],
+        {
+          env: { ABLY_API_KEY: E2E_API_KEY || "" },
+          timeoutMs: 30000,
+        },
+      );
+
+      expect(deleteResult.exitCode).toBe(0);
+    });
+  });
+});

--- a/test/e2e/rooms/rooms-messages-e2e.test.ts
+++ b/test/e2e/rooms/rooms-messages-e2e.test.ts
@@ -1,18 +1,9 @@
-import {
-  describe,
-  it,
-  beforeEach,
-  afterEach,
-  beforeAll,
-  afterAll,
-  expect,
-} from "vitest";
+import { describe, it, beforeEach, afterEach, expect } from "vitest";
 import {
   E2E_API_KEY,
   SHOULD_SKIP_E2E,
   getUniqueChannelName,
   getUniqueClientId,
-  forceExit,
   cleanupTrackedResources,
   setupTestFailureHandler,
   resetTestTracking,
@@ -21,14 +12,6 @@ import { runCommand } from "../../helpers/command-helpers.js";
 import { parseNdjsonLines } from "../../helpers/ndjson.js";
 
 describe.skipIf(SHOULD_SKIP_E2E)("Rooms Messages E2E Tests", () => {
-  beforeAll(() => {
-    process.on("SIGINT", forceExit);
-  });
-
-  afterAll(() => {
-    process.removeListener("SIGINT", forceExit);
-  });
-
   let testRoom: string;
   let clientId: string;
 
@@ -166,6 +149,31 @@ describe.skipIf(SHOULD_SKIP_E2E)("Rooms Messages E2E Tests", () => {
       );
 
       expect(updateResult.exitCode).toBe(0);
+
+      // Wait for the update to land in history, then verify via history
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+
+      const historyResult = await runCommand(
+        ["rooms", "messages", "history", testRoom, "--json"],
+        {
+          env: { ABLY_API_KEY: E2E_API_KEY || "" },
+          timeoutMs: 30000,
+        },
+      );
+      expect(historyResult.exitCode).toBe(0);
+
+      const historyLines = parseNdjsonLines(historyResult.stdout);
+      const historyRecord = historyLines.find((l) => l.type === "result");
+      expect(historyRecord).toBeDefined();
+      const messages = historyRecord!.messages as Array<{
+        serial: string;
+        text: string;
+        action: string;
+      }>;
+      const updated = messages.find((m) => m.serial === serial);
+      expect(updated).toBeDefined();
+      expect(updated!.text).toBe("updated-msg");
+      expect(updated!.action).toBe("message.update");
     });
 
     it("should delete a room message", { timeout: 60000 }, async () => {
@@ -221,6 +229,29 @@ describe.skipIf(SHOULD_SKIP_E2E)("Rooms Messages E2E Tests", () => {
       );
 
       expect(deleteResult.exitCode).toBe(0);
+
+      // Wait for the delete to land in history, then verify via history
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+
+      const historyResult = await runCommand(
+        ["rooms", "messages", "history", testRoom, "--json"],
+        {
+          env: { ABLY_API_KEY: E2E_API_KEY || "" },
+          timeoutMs: 30000,
+        },
+      );
+      expect(historyResult.exitCode).toBe(0);
+
+      const historyLines = parseNdjsonLines(historyResult.stdout);
+      const historyRecord = historyLines.find((l) => l.type === "result");
+      expect(historyRecord).toBeDefined();
+      const messages = historyRecord!.messages as Array<{
+        serial: string;
+        action: string;
+      }>;
+      const deleted = messages.find((m) => m.serial === serial);
+      expect(deleted).toBeDefined();
+      expect(deleted!.action).toBe("message.delete");
     });
   });
 });

--- a/test/e2e/rooms/rooms-messages-reactions-e2e.test.ts
+++ b/test/e2e/rooms/rooms-messages-reactions-e2e.test.ts
@@ -1,18 +1,9 @@
-import {
-  describe,
-  it,
-  beforeEach,
-  afterEach,
-  beforeAll,
-  afterAll,
-  expect,
-} from "vitest";
+import { describe, it, beforeEach, afterEach, expect } from "vitest";
 import {
   E2E_API_KEY,
   SHOULD_SKIP_E2E,
   getUniqueChannelName,
   getUniqueClientId,
-  forceExit,
   cleanupTrackedResources,
   setupTestFailureHandler,
   resetTestTracking,
@@ -27,14 +18,6 @@ import type { CliRunner } from "../../helpers/cli-runner.js";
 import { parseNdjsonLines } from "../../helpers/ndjson.js";
 
 describe.skipIf(SHOULD_SKIP_E2E)("Rooms Message Reactions E2E Tests", () => {
-  beforeAll(() => {
-    process.on("SIGINT", forceExit);
-  });
-
-  afterAll(() => {
-    process.removeListener("SIGINT", forceExit);
-  });
-
   let testRoom: string;
   let client1Id: string;
   let client2Id: string;

--- a/test/e2e/rooms/rooms-messages-reactions-e2e.test.ts
+++ b/test/e2e/rooms/rooms-messages-reactions-e2e.test.ts
@@ -1,0 +1,280 @@
+import {
+  describe,
+  it,
+  beforeEach,
+  afterEach,
+  beforeAll,
+  afterAll,
+  expect,
+} from "vitest";
+import {
+  E2E_API_KEY,
+  SHOULD_SKIP_E2E,
+  getUniqueChannelName,
+  getUniqueClientId,
+  forceExit,
+  cleanupTrackedResources,
+  setupTestFailureHandler,
+  resetTestTracking,
+} from "../../helpers/e2e-test-helper.js";
+import {
+  runCommand,
+  startSubscribeCommand,
+  waitForOutput,
+  cleanupRunners,
+} from "../../helpers/command-helpers.js";
+import type { CliRunner } from "../../helpers/cli-runner.js";
+import { parseNdjsonLines } from "../../helpers/ndjson.js";
+
+describe.skipIf(SHOULD_SKIP_E2E)("Rooms Message Reactions E2E Tests", () => {
+  beforeAll(() => {
+    process.on("SIGINT", forceExit);
+  });
+
+  afterAll(() => {
+    process.removeListener("SIGINT", forceExit);
+  });
+
+  let testRoom: string;
+  let client1Id: string;
+  let client2Id: string;
+
+  beforeEach(() => {
+    resetTestTracking();
+    testRoom = getUniqueChannelName("room-msgreact");
+    client1Id = getUniqueClientId("msgreact-sub");
+    client2Id = getUniqueClientId("msgreact-send");
+  });
+
+  afterEach(async () => {
+    await cleanupTrackedResources();
+  });
+
+  describe("rooms messages reactions", () => {
+    it("should send a message reaction", { timeout: 60000 }, async () => {
+      setupTestFailureHandler("should send a message reaction");
+
+      // First send a message to get a serial
+      const sendResult = await runCommand(
+        [
+          "rooms",
+          "messages",
+          "send",
+          testRoom,
+          "reaction-target",
+          "--client-id",
+          client1Id,
+          "--json",
+        ],
+        {
+          env: { ABLY_API_KEY: E2E_API_KEY || "" },
+          timeoutMs: 30000,
+        },
+      );
+
+      expect(sendResult.exitCode).toBe(0);
+
+      const sendJsonLines = parseNdjsonLines(sendResult.stdout);
+      const resultLine = sendJsonLines.find((l) => l.type === "result");
+      expect(resultLine).toBeDefined();
+
+      const message = (resultLine?.message ?? resultLine) as Record<
+        string,
+        unknown
+      >;
+      const serial = message.serial as string | undefined;
+      expect(serial).toBeDefined();
+
+      // Send a reaction to the message
+      const reactionResult = await runCommand(
+        [
+          "rooms",
+          "messages",
+          "reactions",
+          "send",
+          testRoom,
+          serial!,
+          "like",
+          "--client-id",
+          client2Id,
+          "--json",
+        ],
+        {
+          env: { ABLY_API_KEY: E2E_API_KEY || "" },
+          timeoutMs: 15000,
+        },
+      );
+
+      expect(reactionResult.exitCode).toBe(0);
+    });
+
+    it(
+      "should subscribe to message reactions and receive events",
+      { timeout: 60000 },
+      async () => {
+        setupTestFailureHandler(
+          "should subscribe to message reactions and receive events",
+        );
+
+        let subscriber: CliRunner | null = null;
+
+        try {
+          // Start subscribing to message reactions
+          subscriber = await startSubscribeCommand(
+            [
+              "rooms",
+              "messages",
+              "reactions",
+              "subscribe",
+              testRoom,
+              "--client-id",
+              client1Id,
+              "--duration",
+              "30",
+            ],
+            /Listening for message reactions/,
+            {
+              env: { ABLY_API_KEY: E2E_API_KEY || "" },
+              timeoutMs: 30000,
+            },
+          );
+
+          // Send a message first
+          const sendResult = await runCommand(
+            [
+              "rooms",
+              "messages",
+              "send",
+              testRoom,
+              "react-subscribe-target",
+              "--client-id",
+              client1Id,
+              "--json",
+            ],
+            {
+              env: { ABLY_API_KEY: E2E_API_KEY || "" },
+              timeoutMs: 15000,
+            },
+          );
+
+          expect(sendResult.exitCode).toBe(0);
+
+          const sendJsonLines = parseNdjsonLines(sendResult.stdout);
+          const resultLine = sendJsonLines.find((l) => l.type === "result");
+          const message = (resultLine?.message ?? resultLine) as Record<
+            string,
+            unknown
+          >;
+          const serial = message.serial as string | undefined;
+
+          if (serial) {
+            // Send a reaction
+            await runCommand(
+              [
+                "rooms",
+                "messages",
+                "reactions",
+                "send",
+                testRoom,
+                serial,
+                "heart",
+                "--client-id",
+                client2Id,
+              ],
+              {
+                env: { ABLY_API_KEY: E2E_API_KEY || "" },
+                timeoutMs: 15000,
+              },
+            );
+
+            // Wait for the reaction event in subscriber output
+            await waitForOutput(subscriber, "heart", 15000);
+          }
+        } finally {
+          if (subscriber) {
+            await cleanupRunners([subscriber]);
+          }
+        }
+      },
+    );
+
+    it("should remove a message reaction", { timeout: 60000 }, async () => {
+      setupTestFailureHandler("should remove a message reaction");
+
+      // Send a message
+      const sendResult = await runCommand(
+        [
+          "rooms",
+          "messages",
+          "send",
+          testRoom,
+          "remove-react-target",
+          "--client-id",
+          client1Id,
+          "--json",
+        ],
+        {
+          env: { ABLY_API_KEY: E2E_API_KEY || "" },
+          timeoutMs: 30000,
+        },
+      );
+
+      expect(sendResult.exitCode).toBe(0);
+
+      const sendJsonLines = parseNdjsonLines(sendResult.stdout);
+      const resultLine = sendJsonLines.find((l) => l.type === "result");
+      expect(resultLine).toBeDefined();
+
+      const message = (resultLine?.message ?? resultLine) as Record<
+        string,
+        unknown
+      >;
+      const serial = message.serial as string | undefined;
+      expect(serial).toBeDefined();
+
+      // Send a reaction first
+      const addResult = await runCommand(
+        [
+          "rooms",
+          "messages",
+          "reactions",
+          "send",
+          testRoom,
+          serial!,
+          "thumbsup",
+          "--client-id",
+          client2Id,
+          "--json",
+        ],
+        {
+          env: { ABLY_API_KEY: E2E_API_KEY || "" },
+          timeoutMs: 15000,
+        },
+      );
+
+      expect(addResult.exitCode).toBe(0);
+
+      // Remove the reaction
+      const removeResult = await runCommand(
+        [
+          "rooms",
+          "messages",
+          "reactions",
+          "remove",
+          testRoom,
+          serial!,
+          "thumbsup",
+          "--client-id",
+          client2Id,
+          "--json",
+        ],
+        {
+          env: { ABLY_API_KEY: E2E_API_KEY || "" },
+          timeoutMs: 15000,
+        },
+      );
+
+      expect(removeResult.exitCode).toBe(0);
+    });
+  });
+});

--- a/test/e2e/rooms/rooms-messages-subscribe-e2e.test.ts
+++ b/test/e2e/rooms/rooms-messages-subscribe-e2e.test.ts
@@ -1,0 +1,112 @@
+import {
+  describe,
+  it,
+  beforeEach,
+  afterEach,
+  beforeAll,
+  afterAll,
+  expect,
+} from "vitest";
+import {
+  E2E_API_KEY,
+  SHOULD_SKIP_E2E,
+  getUniqueChannelName,
+  getUniqueClientId,
+  forceExit,
+  cleanupTrackedResources,
+  setupTestFailureHandler,
+  resetTestTracking,
+} from "../../helpers/e2e-test-helper.js";
+import {
+  runCommand,
+  startSubscribeCommand,
+  waitForOutput,
+  cleanupRunners,
+} from "../../helpers/command-helpers.js";
+import type { CliRunner } from "../../helpers/cli-runner.js";
+
+describe.skipIf(SHOULD_SKIP_E2E)("Rooms Messages Subscribe E2E Tests", () => {
+  beforeAll(() => {
+    process.on("SIGINT", forceExit);
+  });
+
+  afterAll(() => {
+    process.removeListener("SIGINT", forceExit);
+  });
+
+  let testRoom: string;
+  let subscriberId: string;
+  let senderId: string;
+
+  beforeEach(() => {
+    resetTestTracking();
+    testRoom = getUniqueChannelName("room-sub");
+    subscriberId = getUniqueClientId("subscriber");
+    senderId = getUniqueClientId("sender");
+  });
+
+  afterEach(async () => {
+    await cleanupTrackedResources();
+  });
+
+  describe("rooms messages subscribe", () => {
+    it(
+      "should subscribe to room messages and receive a sent message",
+      { timeout: 60000 },
+      async () => {
+        setupTestFailureHandler(
+          "should subscribe to room messages and receive a sent message",
+        );
+
+        let subscriber: CliRunner | null = null;
+
+        try {
+          // Start subscribing to room messages
+          subscriber = await startSubscribeCommand(
+            [
+              "rooms",
+              "messages",
+              "subscribe",
+              testRoom,
+              "--client-id",
+              subscriberId,
+              "--duration",
+              "30",
+            ],
+            /Listening for messages/,
+            {
+              env: { ABLY_API_KEY: E2E_API_KEY || "" },
+              timeoutMs: 30000,
+            },
+          );
+
+          // Send a message to the room
+          const sendResult = await runCommand(
+            [
+              "rooms",
+              "messages",
+              "send",
+              testRoom,
+              "subscribe-test-msg",
+              "--client-id",
+              senderId,
+            ],
+            {
+              env: { ABLY_API_KEY: E2E_API_KEY || "" },
+              timeoutMs: 15000,
+            },
+          );
+
+          expect(sendResult.exitCode).toBe(0);
+
+          // Wait for the message to appear in subscriber output
+          await waitForOutput(subscriber, "subscribe-test-msg", 15000);
+        } finally {
+          if (subscriber) {
+            await cleanupRunners([subscriber]);
+          }
+        }
+      },
+    );
+  });
+});

--- a/test/e2e/rooms/rooms-messages-subscribe-e2e.test.ts
+++ b/test/e2e/rooms/rooms-messages-subscribe-e2e.test.ts
@@ -1,18 +1,9 @@
-import {
-  describe,
-  it,
-  beforeEach,
-  afterEach,
-  beforeAll,
-  afterAll,
-  expect,
-} from "vitest";
+import { describe, it, beforeEach, afterEach, expect } from "vitest";
 import {
   E2E_API_KEY,
   SHOULD_SKIP_E2E,
   getUniqueChannelName,
   getUniqueClientId,
-  forceExit,
   cleanupTrackedResources,
   setupTestFailureHandler,
   resetTestTracking,
@@ -26,14 +17,6 @@ import {
 import type { CliRunner } from "../../helpers/cli-runner.js";
 
 describe.skipIf(SHOULD_SKIP_E2E)("Rooms Messages Subscribe E2E Tests", () => {
-  beforeAll(() => {
-    process.on("SIGINT", forceExit);
-  });
-
-  afterAll(() => {
-    process.removeListener("SIGINT", forceExit);
-  });
-
   let testRoom: string;
   let subscriberId: string;
   let senderId: string;

--- a/test/e2e/rooms/rooms-occupancy-e2e.test.ts
+++ b/test/e2e/rooms/rooms-occupancy-e2e.test.ts
@@ -1,0 +1,149 @@
+import {
+  describe,
+  it,
+  beforeEach,
+  afterEach,
+  beforeAll,
+  afterAll,
+  expect,
+} from "vitest";
+import {
+  E2E_API_KEY,
+  SHOULD_SKIP_E2E,
+  getUniqueChannelName,
+  getUniqueClientId,
+  forceExit,
+  cleanupTrackedResources,
+  setupTestFailureHandler,
+  resetTestTracking,
+} from "../../helpers/e2e-test-helper.js";
+import {
+  runCommand,
+  startSubscribeCommand,
+  startPresenceCommand,
+  waitForOutput,
+  cleanupRunners,
+} from "../../helpers/command-helpers.js";
+import type { CliRunner } from "../../helpers/cli-runner.js";
+import { parseNdjsonLines } from "../../helpers/ndjson.js";
+
+describe.skipIf(SHOULD_SKIP_E2E)("Rooms Occupancy E2E Tests", () => {
+  let testRoom: string;
+  let clientId: string;
+
+  beforeAll(() => {
+    process.on("SIGINT", forceExit);
+  });
+
+  afterAll(() => {
+    process.removeListener("SIGINT", forceExit);
+  });
+
+  beforeEach(() => {
+    resetTestTracking();
+    testRoom = getUniqueChannelName("room-occ");
+    clientId = getUniqueClientId("occ-client");
+  });
+
+  afterEach(async () => {
+    await cleanupTrackedResources();
+  });
+
+  describe("rooms occupancy get", () => {
+    it("should get occupancy metrics for a room", async () => {
+      setupTestFailureHandler("should get occupancy metrics for a room");
+
+      const result = await runCommand(
+        ["rooms", "occupancy", "get", testRoom, "--json"],
+        {
+          env: { ABLY_API_KEY: E2E_API_KEY || "" },
+          timeoutMs: 30000,
+        },
+      );
+
+      expect(result.exitCode).toBe(0);
+      const records = parseNdjsonLines(result.stdout);
+      const resultRecord = records.find((r) => r.type === "result");
+      expect(resultRecord).toBeDefined();
+      expect(resultRecord!.occupancy).toBeDefined();
+
+      const occupancy = resultRecord!.occupancy as {
+        room: string;
+        metrics: { connections?: number; presenceMembers?: number };
+      };
+      expect(occupancy.room).toBe(testRoom);
+      expect(occupancy.metrics).toBeDefined();
+    }, 60000);
+  });
+
+  describe("rooms occupancy subscribe", () => {
+    it("should receive occupancy updates when members join a room", async () => {
+      setupTestFailureHandler(
+        "should receive occupancy updates when members join a room",
+      );
+
+      let subscriber: CliRunner | null = null;
+      let enterer: CliRunner | null = null;
+      try {
+        // Start occupancy subscriber
+        subscriber = await startSubscribeCommand(
+          [
+            "rooms",
+            "occupancy",
+            "subscribe",
+            testRoom,
+            "--client-id",
+            clientId,
+            "--duration",
+            "30",
+          ],
+          /Listening for occupancy|Subscribed to occupancy/i,
+          {
+            env: { ABLY_API_KEY: E2E_API_KEY || "" },
+            timeoutMs: 30000,
+          },
+        );
+
+        // Wait for subscription to be established
+        await new Promise((resolve) => setTimeout(resolve, 2000));
+
+        // Enter presence to trigger an occupancy change
+        const enterClientId = getUniqueClientId("occ-enter");
+        enterer = await startPresenceCommand(
+          [
+            "rooms",
+            "presence",
+            "enter",
+            testRoom,
+            "--client-id",
+            enterClientId,
+            "--duration",
+            "15",
+          ],
+          /Entered presence|Holding|entering/i,
+          {
+            env: { ABLY_API_KEY: E2E_API_KEY || "" },
+            timeoutMs: 30000,
+          },
+        );
+
+        // Wait for the occupancy subscriber to receive an update
+        await waitForOutput(
+          subscriber,
+          /connections|presenceMembers|Connections|Presence/i,
+          15000,
+        );
+
+        // Verify subscriber is still running and received output
+        expect(subscriber.combined()).toMatch(
+          /connections|presenceMembers|Connections|Presence/i,
+        );
+      } finally {
+        const runnersToCleanup = [subscriber, enterer].filter(
+          Boolean,
+        ) as CliRunner[];
+        await cleanupRunners(runnersToCleanup);
+      }
+    }, 60000);
+  });
+});

--- a/test/e2e/rooms/rooms-occupancy-e2e.test.ts
+++ b/test/e2e/rooms/rooms-occupancy-e2e.test.ts
@@ -1,18 +1,9 @@
-import {
-  describe,
-  it,
-  beforeEach,
-  afterEach,
-  beforeAll,
-  afterAll,
-  expect,
-} from "vitest";
+import { describe, it, beforeEach, afterEach, expect } from "vitest";
 import {
   E2E_API_KEY,
   SHOULD_SKIP_E2E,
   getUniqueChannelName,
   getUniqueClientId,
-  forceExit,
   cleanupTrackedResources,
   setupTestFailureHandler,
   resetTestTracking,
@@ -30,14 +21,6 @@ import { parseNdjsonLines } from "../../helpers/ndjson.js";
 describe.skipIf(SHOULD_SKIP_E2E)("Rooms Occupancy E2E Tests", () => {
   let testRoom: string;
   let clientId: string;
-
-  beforeAll(() => {
-    process.on("SIGINT", forceExit);
-  });
-
-  afterAll(() => {
-    process.removeListener("SIGINT", forceExit);
-  });
 
   beforeEach(() => {
     resetTestTracking();

--- a/test/e2e/rooms/rooms-presence-e2e.test.ts
+++ b/test/e2e/rooms/rooms-presence-e2e.test.ts
@@ -1,18 +1,9 @@
-import {
-  describe,
-  it,
-  beforeEach,
-  afterEach,
-  beforeAll,
-  afterAll,
-  expect,
-} from "vitest";
+import { describe, it, beforeEach, afterEach, expect } from "vitest";
 import {
   E2E_API_KEY,
   SHOULD_SKIP_E2E,
   getUniqueChannelName,
   getUniqueClientId,
-  forceExit,
   cleanupTrackedResources,
   setupTestFailureHandler,
   resetTestTracking,
@@ -28,14 +19,6 @@ import { parseNdjsonLines } from "../../helpers/ndjson.js";
 describe.skipIf(SHOULD_SKIP_E2E)("Rooms Presence E2E Tests", () => {
   let testRoom: string;
   let clientId: string;
-
-  beforeAll(() => {
-    process.on("SIGINT", forceExit);
-  });
-
-  afterAll(() => {
-    process.removeListener("SIGINT", forceExit);
-  });
 
   beforeEach(() => {
     resetTestTracking();

--- a/test/e2e/rooms/rooms-presence-e2e.test.ts
+++ b/test/e2e/rooms/rooms-presence-e2e.test.ts
@@ -1,0 +1,170 @@
+import {
+  describe,
+  it,
+  beforeEach,
+  afterEach,
+  beforeAll,
+  afterAll,
+  expect,
+} from "vitest";
+import {
+  E2E_API_KEY,
+  SHOULD_SKIP_E2E,
+  getUniqueChannelName,
+  getUniqueClientId,
+  forceExit,
+  cleanupTrackedResources,
+  setupTestFailureHandler,
+  resetTestTracking,
+} from "../../helpers/e2e-test-helper.js";
+import {
+  runCommand,
+  startPresenceCommand,
+  cleanupRunners,
+} from "../../helpers/command-helpers.js";
+import type { CliRunner } from "../../helpers/cli-runner.js";
+import { parseNdjsonLines } from "../../helpers/ndjson.js";
+
+describe.skipIf(SHOULD_SKIP_E2E)("Rooms Presence E2E Tests", () => {
+  let testRoom: string;
+  let clientId: string;
+
+  beforeAll(() => {
+    process.on("SIGINT", forceExit);
+  });
+
+  afterAll(() => {
+    process.removeListener("SIGINT", forceExit);
+  });
+
+  beforeEach(() => {
+    resetTestTracking();
+    testRoom = getUniqueChannelName("room-pres");
+    clientId = getUniqueClientId("pres-client");
+  });
+
+  afterEach(async () => {
+    await cleanupTrackedResources();
+  });
+
+  describe("rooms presence enter", () => {
+    it("should enter presence in a room and hold", async () => {
+      setupTestFailureHandler("should enter presence in a room and hold");
+
+      let runner: CliRunner | null = null;
+      try {
+        runner = await startPresenceCommand(
+          [
+            "rooms",
+            "presence",
+            "enter",
+            testRoom,
+            "--client-id",
+            clientId,
+            "--duration",
+            "10",
+          ],
+          /Entered presence|Holding|entering/i,
+          {
+            env: { ABLY_API_KEY: E2E_API_KEY || "" },
+            timeoutMs: 30000,
+          },
+        );
+
+        // Verify the command started and entered presence
+        const output = runner.combined();
+        expect(output).toMatch(/presence|enter|hold/i);
+      } finally {
+        if (runner) {
+          await cleanupRunners([runner]);
+        }
+      }
+    }, 60000);
+
+    it("should enter presence with JSON output", async () => {
+      setupTestFailureHandler("should enter presence with JSON output");
+
+      let runner: CliRunner | null = null;
+      try {
+        runner = await startPresenceCommand(
+          [
+            "rooms",
+            "presence",
+            "enter",
+            testRoom,
+            "--client-id",
+            clientId,
+            "--duration",
+            "10",
+            "--json",
+          ],
+          /presenceMessage|action.*enter|holding/i,
+          {
+            env: { ABLY_API_KEY: E2E_API_KEY || "" },
+            timeoutMs: 30000,
+          },
+        );
+
+        // Wait a moment for JSON output to settle
+        await new Promise((resolve) => setTimeout(resolve, 2000));
+        const records = parseNdjsonLines(runner.stdout());
+        // Verify we got some JSON output from the command
+        expect(records.length).toBeGreaterThan(0);
+      } finally {
+        if (runner) {
+          await cleanupRunners([runner]);
+        }
+      }
+    }, 60000);
+  });
+
+  describe("rooms presence get", () => {
+    it("should get presence members for a room", async () => {
+      setupTestFailureHandler("should get presence members for a room");
+
+      let enterRunner: CliRunner | null = null;
+      try {
+        // First enter presence so there's a member to find
+        enterRunner = await startPresenceCommand(
+          [
+            "rooms",
+            "presence",
+            "enter",
+            testRoom,
+            "--client-id",
+            clientId,
+            "--duration",
+            "15",
+          ],
+          /Entered presence|Holding|entering/i,
+          {
+            env: { ABLY_API_KEY: E2E_API_KEY || "" },
+            timeoutMs: 30000,
+          },
+        );
+
+        // Wait for presence to propagate
+        await new Promise((resolve) => setTimeout(resolve, 3000));
+
+        // Now query presence members
+        const result = await runCommand(
+          ["rooms", "presence", "get", testRoom, "--json"],
+          {
+            env: { ABLY_API_KEY: E2E_API_KEY || "" },
+            timeoutMs: 30000,
+          },
+        );
+
+        expect(result.exitCode).toBe(0);
+        const records = parseNdjsonLines(result.stdout);
+        const resultRecord = records.find((r) => r.type === "result");
+        expect(resultRecord).toBeDefined();
+        expect(resultRecord!.members).toBeDefined();
+      } finally {
+        if (enterRunner) {
+          await cleanupRunners([enterRunner]);
+        }
+      }
+    }, 60000);
+  });
+});

--- a/test/e2e/rooms/rooms-presence-subscribe-e2e.test.ts
+++ b/test/e2e/rooms/rooms-presence-subscribe-e2e.test.ts
@@ -1,18 +1,9 @@
-import {
-  describe,
-  it,
-  beforeEach,
-  afterEach,
-  beforeAll,
-  afterAll,
-  expect,
-} from "vitest";
+import { describe, it, beforeEach, afterEach, expect } from "vitest";
 import {
   E2E_API_KEY,
   SHOULD_SKIP_E2E,
   getUniqueChannelName,
   getUniqueClientId,
-  forceExit,
   cleanupTrackedResources,
   setupTestFailureHandler,
   resetTestTracking,
@@ -27,14 +18,6 @@ import type { CliRunner } from "../../helpers/cli-runner.js";
 
 describe.skipIf(SHOULD_SKIP_E2E)("Rooms Presence Subscribe E2E Tests", () => {
   const runners: CliRunner[] = [];
-
-  beforeAll(() => {
-    process.on("SIGINT", forceExit);
-  });
-
-  afterAll(() => {
-    process.removeListener("SIGINT", forceExit);
-  });
 
   beforeEach(() => {
     resetTestTracking();

--- a/test/e2e/rooms/rooms-presence-subscribe-e2e.test.ts
+++ b/test/e2e/rooms/rooms-presence-subscribe-e2e.test.ts
@@ -1,0 +1,107 @@
+import {
+  describe,
+  it,
+  beforeEach,
+  afterEach,
+  beforeAll,
+  afterAll,
+  expect,
+} from "vitest";
+import {
+  E2E_API_KEY,
+  SHOULD_SKIP_E2E,
+  getUniqueChannelName,
+  getUniqueClientId,
+  forceExit,
+  cleanupTrackedResources,
+  setupTestFailureHandler,
+  resetTestTracking,
+} from "../../helpers/e2e-test-helper.js";
+import {
+  startSubscribeCommand,
+  startPresenceCommand,
+  waitForOutput,
+  cleanupRunners,
+} from "../../helpers/command-helpers.js";
+import type { CliRunner } from "../../helpers/cli-runner.js";
+
+describe.skipIf(SHOULD_SKIP_E2E)("Rooms Presence Subscribe E2E Tests", () => {
+  const runners: CliRunner[] = [];
+
+  beforeAll(() => {
+    process.on("SIGINT", forceExit);
+  });
+
+  afterAll(() => {
+    process.removeListener("SIGINT", forceExit);
+  });
+
+  beforeEach(() => {
+    resetTestTracking();
+  });
+
+  afterEach(async () => {
+    await cleanupRunners(runners);
+    runners.length = 0;
+    await cleanupTrackedResources();
+  });
+
+  it("should receive presence enter events when a member enters a room", async () => {
+    setupTestFailureHandler(
+      "should receive presence enter events when a member enters a room",
+    );
+
+    const testRoom = getUniqueChannelName("room-pres-sub");
+    const subClientId = getUniqueClientId("pres-sub");
+    const enterClientId = getUniqueClientId("pres-enter");
+
+    // Start presence subscriber
+    const subscriber = await startSubscribeCommand(
+      [
+        "rooms",
+        "presence",
+        "subscribe",
+        testRoom,
+        "--client-id",
+        subClientId,
+        "--duration",
+        "30",
+      ],
+      /Listening for presence|Subscribed to presence/i,
+      {
+        env: { ABLY_API_KEY: E2E_API_KEY || "" },
+        timeoutMs: 30000,
+      },
+    );
+    runners.push(subscriber);
+
+    // Wait a moment for subscription to be ready
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+
+    // Enter presence with a different client
+    const enterer = await startPresenceCommand(
+      [
+        "rooms",
+        "presence",
+        "enter",
+        testRoom,
+        "--client-id",
+        enterClientId,
+        "--duration",
+        "15",
+      ],
+      /Entered presence|Holding|entering/i,
+      {
+        env: { ABLY_API_KEY: E2E_API_KEY || "" },
+        timeoutMs: 30000,
+      },
+    );
+    runners.push(enterer);
+
+    // Wait for the subscriber to see the enter event
+    await waitForOutput(subscriber, enterClientId, 15000);
+
+    // Verify the enter event appeared in subscriber output
+    expect(subscriber.combined()).toContain(enterClientId);
+  }, 60000);
+});

--- a/test/e2e/rooms/rooms-reactions-e2e.test.ts
+++ b/test/e2e/rooms/rooms-reactions-e2e.test.ts
@@ -1,0 +1,112 @@
+import {
+  describe,
+  it,
+  beforeEach,
+  afterEach,
+  beforeAll,
+  afterAll,
+  expect,
+} from "vitest";
+import {
+  E2E_API_KEY,
+  SHOULD_SKIP_E2E,
+  getUniqueChannelName,
+  getUniqueClientId,
+  forceExit,
+  cleanupTrackedResources,
+  setupTestFailureHandler,
+  resetTestTracking,
+} from "../../helpers/e2e-test-helper.js";
+import {
+  runCommand,
+  startSubscribeCommand,
+  waitForOutput,
+  cleanupRunners,
+} from "../../helpers/command-helpers.js";
+import type { CliRunner } from "../../helpers/cli-runner.js";
+
+describe.skipIf(SHOULD_SKIP_E2E)("Rooms Reactions E2E Tests", () => {
+  beforeAll(() => {
+    process.on("SIGINT", forceExit);
+  });
+
+  afterAll(() => {
+    process.removeListener("SIGINT", forceExit);
+  });
+
+  let testRoom: string;
+  let client1Id: string;
+  let client2Id: string;
+
+  beforeEach(() => {
+    resetTestTracking();
+    testRoom = getUniqueChannelName("room-react");
+    client1Id = getUniqueClientId("react-sub");
+    client2Id = getUniqueClientId("react-send");
+  });
+
+  afterEach(async () => {
+    await cleanupTrackedResources();
+  });
+
+  describe("rooms reactions send and subscribe", () => {
+    it(
+      "should send a room reaction and receive it via subscribe",
+      { timeout: 60000 },
+      async () => {
+        setupTestFailureHandler(
+          "should send a room reaction and receive it via subscribe",
+        );
+
+        let subscriber: CliRunner | null = null;
+
+        try {
+          // Start subscribing to room reactions
+          subscriber = await startSubscribeCommand(
+            [
+              "rooms",
+              "reactions",
+              "subscribe",
+              testRoom,
+              "--client-id",
+              client1Id,
+              "--duration",
+              "30",
+            ],
+            /Listening for reactions/,
+            {
+              env: { ABLY_API_KEY: E2E_API_KEY || "" },
+              timeoutMs: 30000,
+            },
+          );
+
+          // Send a reaction
+          const sendResult = await runCommand(
+            [
+              "rooms",
+              "reactions",
+              "send",
+              testRoom,
+              "thumbsup",
+              "--client-id",
+              client2Id,
+            ],
+            {
+              env: { ABLY_API_KEY: E2E_API_KEY || "" },
+              timeoutMs: 15000,
+            },
+          );
+
+          expect(sendResult.exitCode).toBe(0);
+
+          // Wait for the reaction to appear in subscriber output
+          await waitForOutput(subscriber, "thumbsup", 15000);
+        } finally {
+          if (subscriber) {
+            await cleanupRunners([subscriber]);
+          }
+        }
+      },
+    );
+  });
+});

--- a/test/e2e/rooms/rooms-reactions-e2e.test.ts
+++ b/test/e2e/rooms/rooms-reactions-e2e.test.ts
@@ -1,18 +1,9 @@
-import {
-  describe,
-  it,
-  beforeEach,
-  afterEach,
-  beforeAll,
-  afterAll,
-  expect,
-} from "vitest";
+import { describe, it, beforeEach, afterEach, expect } from "vitest";
 import {
   E2E_API_KEY,
   SHOULD_SKIP_E2E,
   getUniqueChannelName,
   getUniqueClientId,
-  forceExit,
   cleanupTrackedResources,
   setupTestFailureHandler,
   resetTestTracking,
@@ -26,14 +17,6 @@ import {
 import type { CliRunner } from "../../helpers/cli-runner.js";
 
 describe.skipIf(SHOULD_SKIP_E2E)("Rooms Reactions E2E Tests", () => {
-  beforeAll(() => {
-    process.on("SIGINT", forceExit);
-  });
-
-  afterAll(() => {
-    process.removeListener("SIGINT", forceExit);
-  });
-
   let testRoom: string;
   let client1Id: string;
   let client2Id: string;

--- a/test/e2e/rooms/rooms-typing-e2e.test.ts
+++ b/test/e2e/rooms/rooms-typing-e2e.test.ts
@@ -1,0 +1,104 @@
+import {
+  describe,
+  it,
+  beforeEach,
+  afterEach,
+  beforeAll,
+  afterAll,
+  expect,
+} from "vitest";
+import {
+  E2E_API_KEY,
+  SHOULD_SKIP_E2E,
+  getUniqueChannelName,
+  getUniqueClientId,
+  forceExit,
+  cleanupTrackedResources,
+  setupTestFailureHandler,
+  resetTestTracking,
+} from "../../helpers/e2e-test-helper.js";
+import {
+  runCommand,
+  startSubscribeCommand,
+  waitForOutput,
+  cleanupRunners,
+} from "../../helpers/command-helpers.js";
+import type { CliRunner } from "../../helpers/cli-runner.js";
+
+describe.skipIf(SHOULD_SKIP_E2E)("Rooms Typing E2E Tests", () => {
+  beforeAll(() => {
+    process.on("SIGINT", forceExit);
+  });
+
+  afterAll(() => {
+    process.removeListener("SIGINT", forceExit);
+  });
+
+  let testRoom: string;
+  let subscriberId: string;
+  let typerId: string;
+
+  beforeEach(() => {
+    resetTestTracking();
+    testRoom = getUniqueChannelName("room-typing");
+    subscriberId = getUniqueClientId("type-sub");
+    typerId = getUniqueClientId("typer");
+  });
+
+  afterEach(async () => {
+    await cleanupTrackedResources();
+  });
+
+  describe("rooms typing keystroke and subscribe", () => {
+    it(
+      "should send a keystroke and receive it via subscribe",
+      { timeout: 60000 },
+      async () => {
+        setupTestFailureHandler(
+          "should send a keystroke and receive it via subscribe",
+        );
+
+        let subscriber: CliRunner | null = null;
+
+        try {
+          // Start subscribing to typing events
+          subscriber = await startSubscribeCommand(
+            [
+              "rooms",
+              "typing",
+              "subscribe",
+              testRoom,
+              "--client-id",
+              subscriberId,
+              "--duration",
+              "30",
+            ],
+            /Listening for typing/,
+            {
+              env: { ABLY_API_KEY: E2E_API_KEY || "" },
+              timeoutMs: 30000,
+            },
+          );
+
+          // Send a keystroke
+          const keystrokeResult = await runCommand(
+            ["rooms", "typing", "keystroke", testRoom, "--client-id", typerId],
+            {
+              env: { ABLY_API_KEY: E2E_API_KEY || "" },
+              timeoutMs: 15000,
+            },
+          );
+
+          expect(keystrokeResult.exitCode).toBe(0);
+
+          // Wait for the typing event to appear in subscriber output
+          await waitForOutput(subscriber, typerId, 15000);
+        } finally {
+          if (subscriber) {
+            await cleanupRunners([subscriber]);
+          }
+        }
+      },
+    );
+  });
+});

--- a/test/e2e/rooms/rooms-typing-e2e.test.ts
+++ b/test/e2e/rooms/rooms-typing-e2e.test.ts
@@ -1,18 +1,9 @@
-import {
-  describe,
-  it,
-  beforeEach,
-  afterEach,
-  beforeAll,
-  afterAll,
-  expect,
-} from "vitest";
+import { describe, it, beforeEach, afterEach, expect } from "vitest";
 import {
   E2E_API_KEY,
   SHOULD_SKIP_E2E,
   getUniqueChannelName,
   getUniqueClientId,
-  forceExit,
   cleanupTrackedResources,
   setupTestFailureHandler,
   resetTestTracking,
@@ -26,14 +17,6 @@ import {
 import type { CliRunner } from "../../helpers/cli-runner.js";
 
 describe.skipIf(SHOULD_SKIP_E2E)("Rooms Typing E2E Tests", () => {
-  beforeAll(() => {
-    process.on("SIGINT", forceExit);
-  });
-
-  afterAll(() => {
-    process.removeListener("SIGINT", forceExit);
-  });
-
   let testRoom: string;
   let subscriberId: string;
   let typerId: string;

--- a/test/e2e/setup.ts
+++ b/test/e2e/setup.ts
@@ -1,0 +1,10 @@
+import { forceExit } from "../helpers/e2e-test-helper.js";
+
+/**
+ * Register SIGINT handler once for the E2E test process. Individual test files
+ * used to register and unregister this in every `beforeAll`/`afterAll` pair —
+ * that was pure duplication, because node's SIGINT listener lives on the
+ * process, not the describe block. A single registration at process start is
+ * sufficient, and the listener is cleaned up when the process exits.
+ */
+process.on("SIGINT", forceExit);

--- a/test/e2e/spaces/spaces-crud-e2e.test.ts
+++ b/test/e2e/spaces/spaces-crud-e2e.test.ts
@@ -1,0 +1,122 @@
+import {
+  describe,
+  it,
+  beforeEach,
+  afterEach,
+  beforeAll,
+  afterAll,
+  expect,
+} from "vitest";
+import {
+  E2E_API_KEY,
+  SHOULD_SKIP_E2E,
+  getUniqueChannelName,
+  getUniqueClientId,
+  forceExit,
+  cleanupTrackedResources,
+  setupTestFailureHandler,
+  resetTestTracking,
+} from "../../helpers/e2e-test-helper.js";
+import {
+  runCommand,
+  startSubscribeCommand,
+  cleanupRunners,
+} from "../../helpers/command-helpers.js";
+import type { CliRunner } from "../../helpers/cli-runner.js";
+
+describe.skipIf(SHOULD_SKIP_E2E)("Spaces CRUD E2E Tests", () => {
+  beforeAll(() => {
+    process.on("SIGINT", forceExit);
+  });
+
+  afterAll(() => {
+    process.removeListener("SIGINT", forceExit);
+  });
+
+  let spaceName: string;
+  let clientId: string;
+
+  beforeEach(() => {
+    resetTestTracking();
+    spaceName = getUniqueChannelName("space");
+    clientId = getUniqueClientId("space-client");
+  });
+
+  afterEach(async () => {
+    await cleanupTrackedResources();
+  });
+
+  describe("spaces create", () => {
+    it("should create a space", async () => {
+      setupTestFailureHandler("should create a space");
+
+      const result = await runCommand(
+        ["spaces", "create", spaceName, "--client-id", clientId, "--json"],
+        {
+          env: { ABLY_API_KEY: E2E_API_KEY || "" },
+          timeoutMs: 30000,
+        },
+      );
+
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("spaces list", () => {
+    it("should list spaces", async () => {
+      setupTestFailureHandler("should list spaces");
+
+      const result = await runCommand(["spaces", "list", "--json"], {
+        env: { ABLY_API_KEY: E2E_API_KEY || "" },
+        timeoutMs: 15000,
+      });
+
+      // Should succeed even if the list is empty
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("spaces get", () => {
+    it("should get space details", { timeout: 60000 }, async () => {
+      setupTestFailureHandler("should get space details");
+
+      let member: CliRunner | null = null;
+
+      try {
+        // Enter a member into the space and keep it present (spaces only exist while members are present)
+        member = await startSubscribeCommand(
+          [
+            "spaces",
+            "members",
+            "enter",
+            spaceName,
+            "--client-id",
+            clientId,
+            "--duration",
+            "30",
+          ],
+          /Holding presence/,
+          {
+            env: { ABLY_API_KEY: E2E_API_KEY || "" },
+            timeoutMs: 30000,
+          },
+        );
+
+        // Get space details while the member is still present
+        const result = await runCommand(
+          ["spaces", "get", spaceName, "--json"],
+          {
+            env: { ABLY_API_KEY: E2E_API_KEY || "" },
+            timeoutMs: 15000,
+          },
+        );
+
+        expect(result.exitCode).toBe(0);
+      } finally {
+        if (member) {
+          await cleanupRunners([member]);
+        }
+      }
+    });
+  });
+});

--- a/test/e2e/spaces/spaces-crud-e2e.test.ts
+++ b/test/e2e/spaces/spaces-crud-e2e.test.ts
@@ -23,6 +23,7 @@ import {
   cleanupRunners,
 } from "../../helpers/command-helpers.js";
 import type { CliRunner } from "../../helpers/cli-runner.js";
+import { parseNdjsonLines } from "../../helpers/ndjson.js";
 
 describe.skipIf(SHOULD_SKIP_E2E)("Spaces CRUD E2E Tests", () => {
   beforeAll(() => {
@@ -59,6 +60,14 @@ describe.skipIf(SHOULD_SKIP_E2E)("Spaces CRUD E2E Tests", () => {
       );
 
       expect(result.exitCode).toBe(0);
+
+      const records = parseNdjsonLines(result.stdout);
+      const resultRecord = records.find((r) => r.type === "result");
+      expect(resultRecord).toBeDefined();
+      expect(resultRecord!.success).toBe(true);
+      const space = resultRecord!.space as { name: string };
+      expect(space).toBeDefined();
+      expect(space.name).toBe(spaceName);
     });
   });
 
@@ -73,6 +82,14 @@ describe.skipIf(SHOULD_SKIP_E2E)("Spaces CRUD E2E Tests", () => {
 
       // Should succeed even if the list is empty
       expect(result.exitCode).toBe(0);
+
+      const records = parseNdjsonLines(result.stdout);
+      const resultRecord = records.find((r) => r.type === "result");
+      expect(resultRecord).toBeDefined();
+      expect(resultRecord!.success).toBe(true);
+      expect(Array.isArray(resultRecord!.spaces)).toBe(true);
+      expect(resultRecord).toHaveProperty("total");
+      expect(resultRecord).toHaveProperty("hasMore");
     });
   });
 
@@ -112,6 +129,20 @@ describe.skipIf(SHOULD_SKIP_E2E)("Spaces CRUD E2E Tests", () => {
         );
 
         expect(result.exitCode).toBe(0);
+
+        const records = parseNdjsonLines(result.stdout);
+        const resultRecord = records.find((r) => r.type === "result");
+        expect(resultRecord).toBeDefined();
+        expect(resultRecord!.success).toBe(true);
+        const space = resultRecord!.space as {
+          name: string;
+          members: Array<{ clientId: string }>;
+        };
+        expect(space).toBeDefined();
+        expect(space.name).toBe(spaceName);
+        expect(Array.isArray(space.members)).toBe(true);
+        expect(space.members.length).toBeGreaterThan(0);
+        expect(space.members[0].clientId).toBe(clientId);
       } finally {
         if (member) {
           await cleanupRunners([member]);

--- a/test/e2e/spaces/spaces-crud-e2e.test.ts
+++ b/test/e2e/spaces/spaces-crud-e2e.test.ts
@@ -1,18 +1,9 @@
-import {
-  describe,
-  it,
-  beforeEach,
-  afterEach,
-  beforeAll,
-  afterAll,
-  expect,
-} from "vitest";
+import { describe, it, beforeEach, afterEach, expect } from "vitest";
 import {
   E2E_API_KEY,
   SHOULD_SKIP_E2E,
   getUniqueChannelName,
   getUniqueClientId,
-  forceExit,
   cleanupTrackedResources,
   setupTestFailureHandler,
   resetTestTracking,
@@ -26,14 +17,6 @@ import type { CliRunner } from "../../helpers/cli-runner.js";
 import { parseNdjsonLines } from "../../helpers/ndjson.js";
 
 describe.skipIf(SHOULD_SKIP_E2E)("Spaces CRUD E2E Tests", () => {
-  beforeAll(() => {
-    process.on("SIGINT", forceExit);
-  });
-
-  afterAll(() => {
-    process.removeListener("SIGINT", forceExit);
-  });
-
   let spaceName: string;
   let clientId: string;
 

--- a/test/e2e/spaces/spaces-e2e.test.ts
+++ b/test/e2e/spaces/spaces-e2e.test.ts
@@ -1,12 +1,4 @@
-import {
-  describe,
-  it,
-  beforeEach,
-  afterEach,
-  beforeAll,
-  afterAll,
-  expect,
-} from "vitest";
+import { describe, it, beforeEach, afterEach, expect } from "vitest";
 import {
   SHOULD_SKIP_E2E,
   getUniqueChannelName,
@@ -16,7 +8,6 @@ import {
   readProcessOutput,
   runBackgroundProcessAndGetOutput,
   killProcess,
-  forceExit,
   cleanupTrackedResources,
   trackTestOutputFile,
   testOutputFiles,
@@ -27,15 +18,6 @@ import {
 import { ChildProcess } from "node:child_process";
 
 describe("Spaces E2E Tests", () => {
-  // Skip all tests if API key not available
-  beforeAll(() => {
-    process.on("SIGINT", forceExit);
-  });
-
-  afterAll(() => {
-    process.removeListener("SIGINT", forceExit);
-  });
-
   let testSpaceId: string;
   let client1Id: string;
   let client2Id: string;

--- a/test/e2e/spaces/spaces-locations-e2e.test.ts
+++ b/test/e2e/spaces/spaces-locations-e2e.test.ts
@@ -1,18 +1,9 @@
-import {
-  describe,
-  it,
-  beforeEach,
-  afterEach,
-  beforeAll,
-  afterAll,
-  expect,
-} from "vitest";
+import { describe, it, beforeEach, afterEach, expect } from "vitest";
 import {
   E2E_API_KEY,
   SHOULD_SKIP_E2E,
   getUniqueChannelName,
   getUniqueClientId,
-  forceExit,
   cleanupTrackedResources,
   setupTestFailureHandler,
   resetTestTracking,
@@ -29,14 +20,6 @@ import { parseNdjsonLines } from "../../helpers/ndjson.js";
 describe.skipIf(SHOULD_SKIP_E2E)(
   "Spaces Locations, Cursors, and Locks E2E Tests",
   () => {
-    beforeAll(() => {
-      process.on("SIGINT", forceExit);
-    });
-
-    afterAll(() => {
-      process.removeListener("SIGINT", forceExit);
-    });
-
     let spaceName: string;
     let clientId: string;
 

--- a/test/e2e/spaces/spaces-locations-e2e.test.ts
+++ b/test/e2e/spaces/spaces-locations-e2e.test.ts
@@ -24,6 +24,7 @@ import {
   cleanupRunners,
 } from "../../helpers/command-helpers.js";
 import type { CliRunner } from "../../helpers/cli-runner.js";
+import { parseNdjsonLines } from "../../helpers/ndjson.js";
 
 describe.skipIf(SHOULD_SKIP_E2E)(
   "Spaces Locations, Cursors, and Locks E2E Tests",
@@ -93,6 +94,19 @@ describe.skipIf(SHOULD_SKIP_E2E)(
             );
 
             expect(getResult.exitCode).toBe(0);
+
+            const records = parseNdjsonLines(getResult.stdout);
+            const resultRecord = records.find((r) => r.type === "result");
+            expect(resultRecord).toBeDefined();
+            expect(resultRecord!.success).toBe(true);
+            const locations = resultRecord!.locations as Array<{
+              connectionId: string;
+              location: unknown;
+            }>;
+            expect(locations).toBeDefined();
+            expect(locations.length).toBeGreaterThan(0);
+            expect(locations[0]).toHaveProperty("connectionId");
+            expect(locations[0]).toHaveProperty("location");
           } finally {
             if (locationRunner) {
               await cleanupRunners([locationRunner]);
@@ -172,6 +186,19 @@ describe.skipIf(SHOULD_SKIP_E2E)(
           );
 
           expect(getResult.exitCode).toBe(0);
+
+          const cursorRecords = parseNdjsonLines(getResult.stdout);
+          const cursorResult = cursorRecords.find((r) => r.type === "result");
+          expect(cursorResult).toBeDefined();
+          expect(cursorResult!.success).toBe(true);
+          const cursors = cursorResult!.cursors as Array<{
+            position: { x: number; y: number };
+          }>;
+          expect(cursors).toBeDefined();
+          expect(cursors.length).toBeGreaterThan(0);
+          expect(cursors[0].position).toBeDefined();
+          expect(typeof cursors[0].position.x).toBe("number");
+          expect(typeof cursors[0].position.y).toBe("number");
         } finally {
           const runners: CliRunner[] = [];
           if (subscriberRunner) runners.push(subscriberRunner);
@@ -224,6 +251,24 @@ describe.skipIf(SHOULD_SKIP_E2E)(
             );
 
             expect(getResult.exitCode).toBe(0);
+
+            const lockRecords = parseNdjsonLines(getResult.stdout);
+            const lockResult = lockRecords.find((r) => r.type === "result");
+            expect(lockResult).toBeDefined();
+            expect(lockResult!.success).toBe(true);
+            const locks = lockResult!.locks as Array<{
+              id: string;
+              status: string;
+              member: { clientId: string };
+              timestamp: string;
+            }>;
+            expect(locks).toBeDefined();
+            expect(locks.length).toBeGreaterThan(0);
+            expect(locks[0].id).toBe("test-lock-1");
+            expect(locks[0].status).toBe("locked");
+            expect(locks[0].member).toBeDefined();
+            expect(locks[0].member.clientId).toBe(clientId);
+            expect(locks[0].timestamp).toBeDefined();
           } finally {
             if (lockRunner) {
               await cleanupRunners([lockRunner]);

--- a/test/e2e/spaces/spaces-locations-e2e.test.ts
+++ b/test/e2e/spaces/spaces-locations-e2e.test.ts
@@ -1,0 +1,236 @@
+import {
+  describe,
+  it,
+  beforeEach,
+  afterEach,
+  beforeAll,
+  afterAll,
+  expect,
+} from "vitest";
+import {
+  E2E_API_KEY,
+  SHOULD_SKIP_E2E,
+  getUniqueChannelName,
+  getUniqueClientId,
+  forceExit,
+  cleanupTrackedResources,
+  setupTestFailureHandler,
+  resetTestTracking,
+} from "../../helpers/e2e-test-helper.js";
+import {
+  runCommand,
+  startPresenceCommand,
+  startSubscribeCommand,
+  cleanupRunners,
+} from "../../helpers/command-helpers.js";
+import type { CliRunner } from "../../helpers/cli-runner.js";
+
+describe.skipIf(SHOULD_SKIP_E2E)(
+  "Spaces Locations, Cursors, and Locks E2E Tests",
+  () => {
+    beforeAll(() => {
+      process.on("SIGINT", forceExit);
+    });
+
+    afterAll(() => {
+      process.removeListener("SIGINT", forceExit);
+    });
+
+    let spaceName: string;
+    let clientId: string;
+
+    beforeEach(() => {
+      resetTestTracking();
+      spaceName = getUniqueChannelName("space-loc");
+      clientId = getUniqueClientId("loc-client");
+    });
+
+    afterEach(async () => {
+      await cleanupTrackedResources();
+    });
+
+    describe("spaces locations", () => {
+      it(
+        "should set location and get locations",
+        { timeout: 60000 },
+        async () => {
+          setupTestFailureHandler("should set location and get locations");
+
+          let locationRunner: CliRunner | null = null;
+
+          try {
+            // Set location (long-running hold command)
+            locationRunner = await startPresenceCommand(
+              [
+                "spaces",
+                "locations",
+                "set",
+                spaceName,
+                "--location",
+                '{"slide":1}',
+                "--client-id",
+                clientId,
+                "--duration",
+                "15",
+              ],
+              /Holding|Set location|location/i,
+              {
+                env: { ABLY_API_KEY: E2E_API_KEY || "" },
+                timeoutMs: 30000,
+              },
+            );
+
+            // Wait a moment for the location to propagate
+            await new Promise((resolve) => setTimeout(resolve, 2000));
+
+            // Get locations
+            const getResult = await runCommand(
+              ["spaces", "locations", "get", spaceName, "--json"],
+              {
+                env: { ABLY_API_KEY: E2E_API_KEY || "" },
+                timeoutMs: 15000,
+              },
+            );
+
+            expect(getResult.exitCode).toBe(0);
+          } finally {
+            if (locationRunner) {
+              await cleanupRunners([locationRunner]);
+            }
+          }
+        },
+      );
+    });
+
+    describe("spaces cursors", () => {
+      it("should set cursor and get cursors", { timeout: 60000 }, async () => {
+        setupTestFailureHandler("should set cursor and get cursors");
+
+        let subscriberRunner: CliRunner | null = null;
+        let cursorRunner: CliRunner | null = null;
+
+        try {
+          // The Spaces SDK only publishes cursor data when 2+ members are on the
+          // ::$cursors channel (CursorBatching.shouldSend optimization). Start a
+          // subscriber first so cursor set actually publishes to channel history.
+          subscriberRunner = await startSubscribeCommand(
+            [
+              "spaces",
+              "cursors",
+              "subscribe",
+              spaceName,
+              "--client-id",
+              `${clientId}-subscriber`,
+              "--duration",
+              "30",
+            ],
+            /Listening|listening/i,
+            {
+              env: { ABLY_API_KEY: E2E_API_KEY || "" },
+              timeoutMs: 30000,
+            },
+          );
+
+          // Wait for subscriber's presence to propagate on the cursors channel
+          await new Promise((resolve) => setTimeout(resolve, 2000));
+
+          // Set cursor with --simulate for continuous publishes (resilient against
+          // brief race between presence callback and first cursor.set call)
+          cursorRunner = await startPresenceCommand(
+            [
+              "spaces",
+              "cursors",
+              "set",
+              spaceName,
+              "--simulate",
+              "--x",
+              "10",
+              "--y",
+              "20",
+              "--client-id",
+              clientId,
+              "--duration",
+              "15",
+            ],
+            /Holding|Simulating|cursor/i,
+            {
+              env: { ABLY_API_KEY: E2E_API_KEY || "" },
+              timeoutMs: 30000,
+            },
+          );
+
+          // Wait for simulated cursor data to be published to channel history
+          await new Promise((resolve) => setTimeout(resolve, 3000));
+
+          // Get cursors
+          const getResult = await runCommand(
+            ["spaces", "cursors", "get", spaceName, "--json"],
+            {
+              env: { ABLY_API_KEY: E2E_API_KEY || "" },
+              timeoutMs: 15000,
+            },
+          );
+
+          expect(getResult.exitCode).toBe(0);
+        } finally {
+          const runners: CliRunner[] = [];
+          if (subscriberRunner) runners.push(subscriberRunner);
+          if (cursorRunner) runners.push(cursorRunner);
+          if (runners.length > 0) await cleanupRunners(runners);
+        }
+      });
+    });
+
+    describe("spaces locks", () => {
+      it(
+        "should acquire a lock and get locks",
+        { timeout: 60000 },
+        async () => {
+          setupTestFailureHandler("should acquire a lock and get locks");
+
+          let lockRunner: CliRunner | null = null;
+
+          try {
+            // Acquire a lock (long-running hold command)
+            lockRunner = await startPresenceCommand(
+              [
+                "spaces",
+                "locks",
+                "acquire",
+                spaceName,
+                "test-lock-1",
+                "--client-id",
+                clientId,
+                "--duration",
+                "15",
+              ],
+              /Holding|Acquired|lock/i,
+              {
+                env: { ABLY_API_KEY: E2E_API_KEY || "" },
+                timeoutMs: 30000,
+              },
+            );
+
+            // Wait for lock to propagate
+            await new Promise((resolve) => setTimeout(resolve, 2000));
+
+            // Get locks
+            const getResult = await runCommand(
+              ["spaces", "locks", "get", spaceName, "--json"],
+              {
+                env: { ABLY_API_KEY: E2E_API_KEY || "" },
+                timeoutMs: 15000,
+              },
+            );
+
+            expect(getResult.exitCode).toBe(0);
+          } finally {
+            if (lockRunner) {
+              await cleanupRunners([lockRunner]);
+            }
+          }
+        },
+      );
+    });
+  },
+);

--- a/test/e2e/spaces/spaces-locations-e2e.test.ts
+++ b/test/e2e/spaces/spaces-locations-e2e.test.ts
@@ -67,7 +67,6 @@ describe.skipIf(SHOULD_SKIP_E2E)(
                 "locations",
                 "set",
                 spaceName,
-                "--location",
                 '{"slide":1}',
                 "--client-id",
                 clientId,

--- a/test/e2e/spaces/spaces-occupancy-e2e.test.ts
+++ b/test/e2e/spaces/spaces-occupancy-e2e.test.ts
@@ -1,0 +1,95 @@
+import {
+  describe,
+  it,
+  beforeEach,
+  afterEach,
+  beforeAll,
+  afterAll,
+  expect,
+} from "vitest";
+import {
+  E2E_API_KEY,
+  SHOULD_SKIP_E2E,
+  getUniqueChannelName,
+  getUniqueClientId,
+  forceExit,
+  cleanupTrackedResources,
+  setupTestFailureHandler,
+  resetTestTracking,
+} from "../../helpers/e2e-test-helper.js";
+import {
+  runCommand,
+  startPresenceCommand,
+  cleanupRunners,
+} from "../../helpers/command-helpers.js";
+import type { CliRunner } from "../../helpers/cli-runner.js";
+
+describe.skipIf(SHOULD_SKIP_E2E)("Spaces Occupancy E2E Tests", () => {
+  beforeAll(() => {
+    process.on("SIGINT", forceExit);
+  });
+
+  afterAll(() => {
+    process.removeListener("SIGINT", forceExit);
+  });
+
+  let spaceName: string;
+  let clientId: string;
+
+  beforeEach(() => {
+    resetTestTracking();
+    spaceName = getUniqueChannelName("space-occ");
+    clientId = getUniqueClientId("occ-client");
+  });
+
+  afterEach(async () => {
+    await cleanupTrackedResources();
+  });
+
+  describe("spaces occupancy get", () => {
+    it("should get space occupancy", { timeout: 60000 }, async () => {
+      setupTestFailureHandler("should get space occupancy");
+
+      let memberRunner: CliRunner | null = null;
+
+      try {
+        // Enter a member into the space to ensure non-zero occupancy
+        memberRunner = await startPresenceCommand(
+          [
+            "spaces",
+            "members",
+            "enter",
+            spaceName,
+            "--client-id",
+            clientId,
+            "--duration",
+            "15",
+          ],
+          /Entered|Holding|member/i,
+          {
+            env: { ABLY_API_KEY: E2E_API_KEY || "" },
+            timeoutMs: 30000,
+          },
+        );
+
+        // Wait for member to propagate
+        await new Promise((resolve) => setTimeout(resolve, 2000));
+
+        // Get occupancy
+        const result = await runCommand(
+          ["spaces", "occupancy", "get", spaceName, "--json"],
+          {
+            env: { ABLY_API_KEY: E2E_API_KEY || "" },
+            timeoutMs: 15000,
+          },
+        );
+
+        expect(result.exitCode).toBe(0);
+      } finally {
+        if (memberRunner) {
+          await cleanupRunners([memberRunner]);
+        }
+      }
+    });
+  });
+});

--- a/test/e2e/spaces/spaces-occupancy-e2e.test.ts
+++ b/test/e2e/spaces/spaces-occupancy-e2e.test.ts
@@ -23,6 +23,7 @@ import {
   cleanupRunners,
 } from "../../helpers/command-helpers.js";
 import type { CliRunner } from "../../helpers/cli-runner.js";
+import { parseNdjsonLines } from "../../helpers/ndjson.js";
 
 describe.skipIf(SHOULD_SKIP_E2E)("Spaces Occupancy E2E Tests", () => {
   beforeAll(() => {
@@ -85,6 +86,20 @@ describe.skipIf(SHOULD_SKIP_E2E)("Spaces Occupancy E2E Tests", () => {
         );
 
         expect(result.exitCode).toBe(0);
+
+        const records = parseNdjsonLines(result.stdout);
+        const resultRecord = records.find((r) => r.type === "result");
+        expect(resultRecord).toBeDefined();
+        expect(resultRecord!.success).toBe(true);
+        const occupancy = resultRecord!.occupancy as {
+          spaceName: string;
+          metrics: { connections: number; presenceMembers: number };
+        };
+        expect(occupancy).toBeDefined();
+        expect(occupancy.spaceName).toBe(spaceName);
+        expect(occupancy.metrics).toBeDefined();
+        expect(typeof occupancy.metrics.connections).toBe("number");
+        expect(typeof occupancy.metrics.presenceMembers).toBe("number");
       } finally {
         if (memberRunner) {
           await cleanupRunners([memberRunner]);

--- a/test/e2e/spaces/spaces-occupancy-e2e.test.ts
+++ b/test/e2e/spaces/spaces-occupancy-e2e.test.ts
@@ -1,18 +1,9 @@
-import {
-  describe,
-  it,
-  beforeEach,
-  afterEach,
-  beforeAll,
-  afterAll,
-  expect,
-} from "vitest";
+import { describe, it, beforeEach, afterEach, expect } from "vitest";
 import {
   E2E_API_KEY,
   SHOULD_SKIP_E2E,
   getUniqueChannelName,
   getUniqueClientId,
-  forceExit,
   cleanupTrackedResources,
   setupTestFailureHandler,
   resetTestTracking,
@@ -26,14 +17,6 @@ import type { CliRunner } from "../../helpers/cli-runner.js";
 import { parseNdjsonLines } from "../../helpers/ndjson.js";
 
 describe.skipIf(SHOULD_SKIP_E2E)("Spaces Occupancy E2E Tests", () => {
-  beforeAll(() => {
-    process.on("SIGINT", forceExit);
-  });
-
-  afterAll(() => {
-    process.removeListener("SIGINT", forceExit);
-  });
-
   let spaceName: string;
   let clientId: string;
 

--- a/test/e2e/spaces/spaces-subscribe-e2e.test.ts
+++ b/test/e2e/spaces/spaces-subscribe-e2e.test.ts
@@ -1,18 +1,9 @@
-import {
-  describe,
-  it,
-  beforeEach,
-  afterEach,
-  beforeAll,
-  afterAll,
-  expect,
-} from "vitest";
+import { describe, it, beforeEach, afterEach, expect } from "vitest";
 import {
   E2E_API_KEY,
   SHOULD_SKIP_E2E,
   getUniqueChannelName,
   getUniqueClientId,
-  forceExit,
   cleanupTrackedResources,
   setupTestFailureHandler,
   resetTestTracking,
@@ -27,14 +18,6 @@ import type { CliRunner } from "../../helpers/cli-runner.js";
 
 describe.skipIf(SHOULD_SKIP_E2E)("Spaces Subscribe E2E Tests", () => {
   const runners: CliRunner[] = [];
-
-  beforeAll(() => {
-    process.on("SIGINT", forceExit);
-  });
-
-  afterAll(() => {
-    process.removeListener("SIGINT", forceExit);
-  });
 
   beforeEach(() => {
     resetTestTracking();

--- a/test/e2e/spaces/spaces-subscribe-e2e.test.ts
+++ b/test/e2e/spaces/spaces-subscribe-e2e.test.ts
@@ -1,0 +1,106 @@
+import {
+  describe,
+  it,
+  beforeEach,
+  afterEach,
+  beforeAll,
+  afterAll,
+  expect,
+} from "vitest";
+import {
+  E2E_API_KEY,
+  SHOULD_SKIP_E2E,
+  getUniqueChannelName,
+  getUniqueClientId,
+  forceExit,
+  cleanupTrackedResources,
+  setupTestFailureHandler,
+  resetTestTracking,
+} from "../../helpers/e2e-test-helper.js";
+import {
+  startSubscribeCommand,
+  startPresenceCommand,
+  waitForOutput,
+  cleanupRunners,
+} from "../../helpers/command-helpers.js";
+import type { CliRunner } from "../../helpers/cli-runner.js";
+
+describe.skipIf(SHOULD_SKIP_E2E)("Spaces Subscribe E2E Tests", () => {
+  const runners: CliRunner[] = [];
+
+  beforeAll(() => {
+    process.on("SIGINT", forceExit);
+  });
+
+  afterAll(() => {
+    process.removeListener("SIGINT", forceExit);
+  });
+
+  beforeEach(() => {
+    resetTestTracking();
+  });
+
+  afterEach(async () => {
+    await cleanupRunners(runners);
+    runners.length = 0;
+    await cleanupTrackedResources();
+  });
+
+  it("should receive member events when a member enters a space", async () => {
+    setupTestFailureHandler(
+      "should receive member events when a member enters a space",
+    );
+
+    const spaceName = getUniqueChannelName("space-sub");
+    const subClientId = getUniqueClientId("space-sub-client");
+    const enterClientId = getUniqueClientId("space-enter-client");
+
+    // Start the space subscriber
+    const subscriber = await startSubscribeCommand(
+      [
+        "spaces",
+        "subscribe",
+        spaceName,
+        "--client-id",
+        subClientId,
+        "--duration",
+        "30",
+      ],
+      /Listening for space|Subscribed to space/i,
+      {
+        env: { ABLY_API_KEY: E2E_API_KEY || "" },
+        timeoutMs: 30000,
+      },
+    );
+    runners.push(subscriber);
+
+    // Wait for subscription to be established
+    await new Promise((resolve) => setTimeout(resolve, 3000));
+
+    // Enter the space with a different client to trigger a member event
+    const enterer = await startPresenceCommand(
+      [
+        "spaces",
+        "members",
+        "enter",
+        spaceName,
+        "--client-id",
+        enterClientId,
+        "--duration",
+        "15",
+      ],
+      /Entered space|Holding|entering/i,
+      {
+        env: { ABLY_API_KEY: E2E_API_KEY || "" },
+        timeoutMs: 30000,
+      },
+    );
+    runners.push(enterer);
+
+    // Wait for the subscriber to receive the member event
+    await waitForOutput(subscriber, enterClientId, 15000);
+
+    // Verify the member event appeared in subscriber output
+    expect(subscriber.combined()).toContain(enterClientId);
+  }, 60000);
+});

--- a/test/e2e/stats/stats.test.ts
+++ b/test/e2e/stats/stats.test.ts
@@ -1,16 +1,7 @@
-import {
-  describe,
-  it,
-  beforeEach,
-  afterEach,
-  beforeAll,
-  afterAll,
-  expect,
-} from "vitest";
+import { describe, it, beforeEach, afterEach, expect } from "vitest";
 import {
   E2E_API_KEY,
   SHOULD_SKIP_E2E,
-  forceExit,
   cleanupTrackedResources,
   setupTestFailureHandler,
   resetTestTracking,
@@ -36,14 +27,6 @@ function parseJsonLines(stdout: string): Record<string, unknown>[] {
 describe.skipIf(SHOULD_SKIP_E2E || SKIP_ACCOUNT_STATS)(
   "Stats E2E Tests",
   () => {
-    beforeAll(() => {
-      process.on("SIGINT", forceExit);
-    });
-
-    afterAll(() => {
-      process.removeListener("SIGINT", forceExit);
-    });
-
     beforeEach(() => {
       resetTestTracking();
     });

--- a/test/e2e/stats/stats.test.ts
+++ b/test/e2e/stats/stats.test.ts
@@ -12,8 +12,6 @@ import {
   SHOULD_SKIP_E2E,
   forceExit,
   cleanupTrackedResources,
-  testOutputFiles,
-  testCommands,
   setupTestFailureHandler,
   resetTestTracking,
 } from "../../helpers/e2e-test-helper.js";
@@ -48,8 +46,6 @@ describe.skipIf(SHOULD_SKIP_E2E || SKIP_ACCOUNT_STATS)(
 
     beforeEach(() => {
       resetTestTracking();
-      testOutputFiles.clear();
-      testCommands.length = 0;
     });
 
     afterEach(async () => {

--- a/test/e2e/status/status-e2e.test.ts
+++ b/test/e2e/status/status-e2e.test.ts
@@ -1,14 +1,5 @@
+import { describe, it, beforeEach, afterEach, expect } from "vitest";
 import {
-  describe,
-  it,
-  beforeEach,
-  afterEach,
-  beforeAll,
-  afterAll,
-  expect,
-} from "vitest";
-import {
-  forceExit,
   cleanupTrackedResources,
   setupTestFailureHandler,
   resetTestTracking,
@@ -16,14 +7,6 @@ import {
 import { runCommand } from "../../helpers/command-helpers.js";
 
 describe("Status E2E Tests", () => {
-  beforeAll(() => {
-    process.on("SIGINT", forceExit);
-  });
-
-  afterAll(() => {
-    process.removeListener("SIGINT", forceExit);
-  });
-
   beforeEach(() => {
     resetTestTracking();
   });

--- a/test/e2e/status/status-e2e.test.ts
+++ b/test/e2e/status/status-e2e.test.ts
@@ -1,0 +1,68 @@
+import {
+  describe,
+  it,
+  beforeEach,
+  afterEach,
+  beforeAll,
+  afterAll,
+  expect,
+} from "vitest";
+import {
+  forceExit,
+  cleanupTrackedResources,
+  setupTestFailureHandler,
+  resetTestTracking,
+} from "../../helpers/e2e-test-helper.js";
+import { runCommand } from "../../helpers/command-helpers.js";
+
+describe("Status E2E Tests", () => {
+  beforeAll(() => {
+    process.on("SIGINT", forceExit);
+  });
+
+  afterAll(() => {
+    process.removeListener("SIGINT", forceExit);
+  });
+
+  beforeEach(() => {
+    resetTestTracking();
+  });
+
+  afterEach(async () => {
+    await cleanupTrackedResources();
+  });
+
+  describe("status", () => {
+    it("should check Ably service status", async () => {
+      setupTestFailureHandler("should check Ably service status");
+
+      const result = await runCommand(["status"], {
+        env: { NODE_OPTIONS: "", ABLY_CLI_NON_INTERACTIVE: "true" },
+        timeoutMs: 15000,
+      });
+
+      expect(result.exitCode).toBe(0);
+      // Status output should contain some indication of service health
+      const combined = result.stdout + result.stderr;
+      expect(combined).toMatch(/status|operational|ok|healthy|incident/i);
+    });
+
+    it("should output status as JSON", async () => {
+      setupTestFailureHandler("should output status as JSON");
+
+      const result = await runCommand(["status", "--json"], {
+        env: { NODE_OPTIONS: "", ABLY_CLI_NON_INTERACTIVE: "true" },
+        timeoutMs: 15000,
+      });
+
+      expect(result.exitCode).toBe(0);
+      const lines = result.stdout
+        .trim()
+        .split("\n")
+        .filter((l) => l.trim().startsWith("{"));
+      expect(lines.length).toBeGreaterThan(0);
+      const json = JSON.parse(lines[0]);
+      expect(json).toHaveProperty("type");
+    });
+  });
+});

--- a/test/e2e/support/support-e2e.test.ts
+++ b/test/e2e/support/support-e2e.test.ts
@@ -1,0 +1,48 @@
+import {
+  describe,
+  it,
+  beforeEach,
+  afterEach,
+  beforeAll,
+  afterAll,
+  expect,
+} from "vitest";
+import {
+  forceExit,
+  cleanupTrackedResources,
+  setupTestFailureHandler,
+  resetTestTracking,
+} from "../../helpers/e2e-test-helper.js";
+import { runCommand } from "../../helpers/command-helpers.js";
+
+describe("Support E2E Tests", () => {
+  beforeAll(() => {
+    process.on("SIGINT", forceExit);
+  });
+
+  afterAll(() => {
+    process.removeListener("SIGINT", forceExit);
+  });
+
+  beforeEach(() => {
+    resetTestTracking();
+  });
+
+  afterEach(async () => {
+    await cleanupTrackedResources();
+  });
+
+  describe("support contact", () => {
+    it("should show support contact help", async () => {
+      setupTestFailureHandler("should show support contact help");
+
+      const result = await runCommand(["support", "contact", "--help"], {
+        env: { NODE_OPTIONS: "", ABLY_CLI_NON_INTERACTIVE: "true" },
+        timeoutMs: 10000,
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toMatch(/contact|support|ably/i);
+    });
+  });
+});

--- a/test/e2e/support/support-e2e.test.ts
+++ b/test/e2e/support/support-e2e.test.ts
@@ -1,14 +1,5 @@
+import { describe, it, beforeEach, afterEach, expect } from "vitest";
 import {
-  describe,
-  it,
-  beforeEach,
-  afterEach,
-  beforeAll,
-  afterAll,
-  expect,
-} from "vitest";
-import {
-  forceExit,
   cleanupTrackedResources,
   setupTestFailureHandler,
   resetTestTracking,
@@ -16,14 +7,6 @@ import {
 import { runCommand } from "../../helpers/command-helpers.js";
 
 describe("Support E2E Tests", () => {
-  beforeAll(() => {
-    process.on("SIGINT", forceExit);
-  });
-
-  afterAll(() => {
-    process.removeListener("SIGINT", forceExit);
-  });
-
   beforeEach(() => {
     resetTestTracking();
   });

--- a/test/e2e/web-cli/terminal-ui.test.ts
+++ b/test/e2e/web-cli/terminal-ui.test.ts
@@ -215,8 +215,8 @@ test.describe("Web CLI Terminal UI Tests", () => {
         page.locator('[data-testid="terminal-container-secondary"]'),
       ).toBeVisible();
 
-      // Wait a bit for both terminals to initialize
-      await page.waitForTimeout(2000);
+      // Wait for both terminals to initialize (needs extra time to avoid server-side rate limiting)
+      await page.waitForTimeout(5000);
 
       // Type in the first terminal
       const primaryTerminal = page.locator(

--- a/test/helpers/cli-runner.ts
+++ b/test/helpers/cli-runner.ts
@@ -170,7 +170,11 @@ export class CliRunner extends EventTarget {
       // Running in E2E mode - use real Ably connections
       // Remove test mode to allow real Ably connections
       delete env.ABLY_CLI_TEST_MODE;
-      env.ABLY_API_KEY = process.env.E2E_ABLY_API_KEY;
+      // Only fall back to the full-access E2E key if the caller hasn't
+      // explicitly provided one (e.g. a scoped or revoked key under test).
+      if (!this.opts.env?.ABLY_API_KEY) {
+        env.ABLY_API_KEY = process.env.E2E_ABLY_API_KEY;
+      }
       env.ABLY_E2E_TEST = "true";
     }
 

--- a/test/helpers/e2e-mutable-messages.ts
+++ b/test/helpers/e2e-mutable-messages.ts
@@ -1,0 +1,125 @@
+import { runCommand } from "./command-helpers.js";
+import { parseNdjsonLines } from "./ndjson.js";
+import { E2E_API_KEY, getUniqueChannelName } from "./e2e-test-helper.js";
+
+/**
+ * Probe whether the E2E test app supports mutable messages by attempting
+ * a message update on a temporary channel. Returns false if error 93002
+ * (mutableMessages not enabled) is returned.
+ */
+export async function checkMutableMessagesSupport(): Promise<boolean> {
+  const probeChannel = getUniqueChannelName("mutable-probe");
+
+  // Publish a message first
+  const pubResult = await runCommand(
+    ["channels", "publish", probeChannel, "probe", "--json"],
+    {
+      env: { ABLY_API_KEY: E2E_API_KEY || "" },
+      timeoutMs: 15000,
+    },
+  );
+  if (pubResult.exitCode !== 0) return false;
+
+  // Get the serial from history
+  for (let attempt = 0; attempt < 5; attempt++) {
+    const histResult = await runCommand(
+      ["channels", "history", probeChannel, "--json", "--limit", "1"],
+      {
+        env: { ABLY_API_KEY: E2E_API_KEY || "" },
+        timeoutMs: 15000,
+      },
+    );
+    if (histResult.exitCode !== 0) {
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+      continue;
+    }
+
+    const records = parseNdjsonLines(histResult.stdout);
+    const result = records.find((r) => r.type === "result");
+    const messages = result?.messages as Array<{ serial?: string }> | undefined;
+    if (!messages?.[0]?.serial) {
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+      continue;
+    }
+
+    // Try to update the message — if it fails with 93002, mutable messages isn't enabled
+    const updateResult = await runCommand(
+      [
+        "channels",
+        "update",
+        probeChannel,
+        messages[0].serial,
+        "updated-probe",
+        "--json",
+      ],
+      {
+        env: { ABLY_API_KEY: E2E_API_KEY || "" },
+        timeoutMs: 15000,
+      },
+    );
+
+    if (updateResult.exitCode === 0) return true;
+
+    // Check for error code 93002
+    const errorRecords = parseNdjsonLines(updateResult.stdout);
+    const errorRecord = errorRecords.find((r) => r.type === "error");
+    const error = errorRecord?.error as { code?: number } | undefined;
+    if (error?.code === 93002) {
+      return false;
+    }
+
+    // Some other error — assume not supported
+    return false;
+  }
+
+  return false;
+}
+
+/**
+ * Publish a message via CLI with --json, then get the serial from history --json.
+ * Uses retry logic to handle eventual consistency.
+ */
+export async function publishAndGetSerial(
+  channelName: string,
+  messageText: string,
+): Promise<string> {
+  const publishResult = await runCommand(
+    ["channels", "publish", channelName, messageText, "--json"],
+    {
+      env: { ABLY_API_KEY: E2E_API_KEY || "" },
+      timeoutMs: 30000,
+    },
+  );
+  if (publishResult.exitCode !== 0) {
+    throw new Error(
+      `Publish failed: exitCode=${publishResult.exitCode}, stderr=${publishResult.stderr}`,
+    );
+  }
+
+  // Retry history until the message is available (eventually consistent)
+  for (let attempt = 0; attempt < 10; attempt++) {
+    const historyResult = await runCommand(
+      ["channels", "history", channelName, "--json", "--limit", "1"],
+      {
+        env: { ABLY_API_KEY: E2E_API_KEY || "" },
+        timeoutMs: 30000,
+      },
+    );
+    if (historyResult.exitCode !== 0) {
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+      continue;
+    }
+
+    const records = parseNdjsonLines(historyResult.stdout);
+    const result = records.find((r) => r.type === "result");
+    const messages = result?.messages as Array<{ serial?: string }> | undefined;
+    if (messages && messages.length > 0 && messages[0].serial) {
+      return messages[0].serial;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+  }
+
+  throw new Error(
+    `No message serial found in history after retries for channel: ${channelName}`,
+  );
+}

--- a/test/helpers/e2e-mutable-messages.ts
+++ b/test/helpers/e2e-mutable-messages.ts
@@ -7,7 +7,12 @@ export { SHOULD_SKIP_CONTROL_E2E as SHOULD_SKIP_MUTABLE_TESTS } from "./e2e-test
 /** Namespace prefix for mutable message test channels. */
 export const MUTABLE_NAMESPACE = "e2e-mutable";
 
-/** Track whether the rule was created so teardown knows whether to clean up. */
+// The module-level ruleCreated flag and the shared MUTABLE_NAMESPACE channel
+// rule assume e2e files run serially. Vitest's e2e project sets
+// `fileParallelism: false` (see vitest.config.ts), so only one file uses this
+// helper at a time. If that config ever changes, switch to a per-caller
+// cleanup-token pattern to avoid one file's teardown deleting the rule while
+// another is still publishing.
 let ruleCreated = false;
 
 function getAppId(): string {

--- a/test/helpers/e2e-mutable-messages.ts
+++ b/test/helpers/e2e-mutable-messages.ts
@@ -1,78 +1,115 @@
+import { randomUUID } from "node:crypto";
 import { runCommand } from "./command-helpers.js";
 import { parseNdjsonLines } from "./ndjson.js";
-import { E2E_API_KEY, getUniqueChannelName } from "./e2e-test-helper.js";
+import { E2E_API_KEY, E2E_ACCESS_TOKEN } from "./e2e-test-helper.js";
+export { SHOULD_SKIP_CONTROL_E2E as SHOULD_SKIP_MUTABLE_TESTS } from "./e2e-test-helper.js";
+
+/** Namespace prefix for mutable message test channels. */
+export const MUTABLE_NAMESPACE = "e2e-mutable";
+
+/** Track whether the rule was created so teardown knows whether to clean up. */
+let ruleCreated = false;
+
+function getAppId(): string {
+  if (!E2E_API_KEY) throw new Error("E2E_API_KEY is not set");
+  return E2E_API_KEY.split(".")[0] || "";
+}
 
 /**
- * Probe whether the E2E test app supports mutable messages by attempting
- * a message update on a temporary channel. Returns false if error 93002
- * (mutableMessages not enabled) is returned.
+ * Create a channel rule (namespace) with mutableMessages enabled.
+ * Call in beforeAll. Handles "already exists" gracefully.
  */
-export async function checkMutableMessagesSupport(): Promise<boolean> {
-  const probeChannel = getUniqueChannelName("mutable-probe");
+export async function setupMutableMessagesRule(): Promise<void> {
+  const appId = getAppId();
 
-  // Publish a message first
-  const pubResult = await runCommand(
-    ["channels", "publish", probeChannel, "probe", "--json"],
+  const result = await runCommand(
+    [
+      "apps",
+      "rules",
+      "create",
+      "--name",
+      MUTABLE_NAMESPACE,
+      "--mutable-messages",
+      "--app",
+      appId,
+      "--json",
+    ],
     {
-      env: { ABLY_API_KEY: E2E_API_KEY || "" },
-      timeoutMs: 15000,
+      env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN || "" },
+      timeoutMs: 30000,
     },
   );
-  if (pubResult.exitCode !== 0) return false;
 
-  // Get the serial from history
-  for (let attempt = 0; attempt < 5; attempt++) {
-    const histResult = await runCommand(
-      ["channels", "history", probeChannel, "--json", "--limit", "1"],
+  if (result.exitCode === 0) {
+    ruleCreated = true;
+  } else {
+    // Rule may already exist from a previous run — try to verify
+    const listResult = await runCommand(
+      ["apps", "rules", "list", "--app", appId, "--json"],
       {
-        env: { ABLY_API_KEY: E2E_API_KEY || "" },
-        timeoutMs: 15000,
-      },
-    );
-    if (histResult.exitCode !== 0) {
-      await new Promise((resolve) => setTimeout(resolve, 1000));
-      continue;
-    }
-
-    const records = parseNdjsonLines(histResult.stdout);
-    const result = records.find((r) => r.type === "result");
-    const messages = result?.messages as Array<{ serial?: string }> | undefined;
-    if (!messages?.[0]?.serial) {
-      await new Promise((resolve) => setTimeout(resolve, 1000));
-      continue;
-    }
-
-    // Try to update the message — if it fails with 93002, mutable messages isn't enabled
-    const updateResult = await runCommand(
-      [
-        "channels",
-        "update",
-        probeChannel,
-        messages[0].serial,
-        "updated-probe",
-        "--json",
-      ],
-      {
-        env: { ABLY_API_KEY: E2E_API_KEY || "" },
-        timeoutMs: 15000,
+        env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN || "" },
+        timeoutMs: 30000,
       },
     );
 
-    if (updateResult.exitCode === 0) return true;
+    const records = parseNdjsonLines(listResult.stdout);
+    const resultRecord = records.find((r) => r.type === "result");
+    const rules = (resultRecord?.rules ?? []) as Array<{
+      id?: string;
+      mutableMessages?: boolean;
+    }>;
+    const existing = rules.find(
+      (r) => r.id === MUTABLE_NAMESPACE && r.mutableMessages === true,
+    );
 
-    // Check for error code 93002
-    const errorRecords = parseNdjsonLines(updateResult.stdout);
-    const errorRecord = errorRecords.find((r) => r.type === "error");
-    const error = errorRecord?.error as { code?: number } | undefined;
-    if (error?.code === 93002) {
-      return false;
+    if (existing) {
+      ruleCreated = true;
+    } else {
+      throw new Error(
+        `Failed to create mutable messages rule: exitCode=${result.exitCode}, stderr=${result.stderr}`,
+      );
     }
-
-    // Some other error — assume not supported
-    return false;
   }
 
-  return false;
+  // Brief delay for rule propagation
+  await new Promise((resolve) => setTimeout(resolve, 2000));
+}
+
+/**
+ * Delete the channel rule created by setupMutableMessagesRule().
+ * Call in afterAll. Ignores "not found" errors.
+ */
+export async function teardownMutableMessagesRule(): Promise<void> {
+  if (!ruleCreated) return;
+
+  const appId = getAppId();
+
+  await runCommand(
+    [
+      "apps",
+      "rules",
+      "delete",
+      MUTABLE_NAMESPACE,
+      "--app",
+      appId,
+      "--force",
+      "--json",
+    ],
+    {
+      env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN || "" },
+      timeoutMs: 30000,
+    },
+  );
+
+  ruleCreated = false;
+}
+
+/**
+ * Generate a channel name under the mutable namespace.
+ * Format: "e2e-mutable:<suffix>-<uuid>" — matches the namespace rule.
+ */
+export function getMutableChannelName(suffix: string): string {
+  return `${MUTABLE_NAMESPACE}:${suffix}-${randomUUID().slice(0, 8)}`;
 }
 
 /**

--- a/test/helpers/e2e-mutable-messages.ts
+++ b/test/helpers/e2e-mutable-messages.ts
@@ -32,7 +32,6 @@ export async function setupMutableMessagesRule(): Promise<void> {
       "apps",
       "rules",
       "create",
-      "--name",
       MUTABLE_NAMESPACE,
       "--mutable-messages",
       "--app",

--- a/test/helpers/e2e-test-app.ts
+++ b/test/helpers/e2e-test-app.ts
@@ -1,0 +1,57 @@
+import { runCommand } from "./command-helpers.js";
+import { E2E_ACCESS_TOKEN } from "./e2e-test-helper.js";
+import { parseNdjsonLines } from "./ndjson.js";
+
+export interface TestAppHandle {
+  appId: string;
+  teardown: () => Promise<void>;
+}
+
+/**
+ * Create a disposable test app via `ably apps create` for E2E tests and return
+ * the app ID plus a `teardown` function that deletes the app.
+ *
+ * Typical use:
+ * ```ts
+ * let handle: TestAppHandle;
+ * beforeAll(async () => { handle = await createTestApp("e2e-mytest"); });
+ * afterAll(async () => { await handle.teardown(); });
+ * ```
+ */
+export async function createTestApp(
+  namePrefix: string,
+): Promise<TestAppHandle> {
+  const createResult = await runCommand(
+    ["apps", "create", `${namePrefix}-${Date.now()}`, "--json"],
+    { env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN || "" } },
+  );
+  if (createResult.exitCode !== 0) {
+    throw new Error(`Failed to create test app: ${createResult.stderr}`);
+  }
+  const result = parseNdjsonLines(createResult.stdout).find(
+    (r) => r.type === "result",
+  );
+  if (!result) {
+    throw new Error(
+      `No result record in apps create output: ${createResult.stdout}`,
+    );
+  }
+  const app = result.app as Record<string, unknown> | undefined;
+  const appId = (app?.id ?? app?.appId) as string | undefined;
+  if (!appId) {
+    throw new Error(`No app ID found in result: ${JSON.stringify(result)}`);
+  }
+
+  return {
+    appId,
+    teardown: async () => {
+      try {
+        await runCommand(["apps", "delete", appId, "--force"], {
+          env: { ABLY_ACCESS_TOKEN: E2E_ACCESS_TOKEN || "" },
+        });
+      } catch {
+        // Ignore cleanup errors — app may already be deleted
+      }
+    },
+  };
+}

--- a/test/helpers/e2e-test-helper.ts
+++ b/test/helpers/e2e-test-helper.ts
@@ -17,6 +17,8 @@ import { onTestFailed } from "vitest";
 export const E2E_API_KEY = process.env.E2E_ABLY_API_KEY;
 export const SHOULD_SKIP_E2E =
   !E2E_API_KEY || process.env.SKIP_E2E_TESTS === "true";
+export const E2E_ACCESS_TOKEN = process.env.E2E_ABLY_ACCESS_TOKEN;
+export const SHOULD_SKIP_CONTROL_E2E = SHOULD_SKIP_E2E || !E2E_ACCESS_TOKEN;
 
 // Store active background processes and temp files for cleanup
 const activeProcesses: Map<string, ChildProcess> = new Map();

--- a/test/unit/base/base-command.test.ts
+++ b/test/unit/base/base-command.test.ts
@@ -590,16 +590,16 @@ describe("AblyBaseCommand", function () {
     it("should use ABLY_API_KEY environment variable if available", async function () {
       const flags: BaseFlags = {};
 
-      // Reset relevant stubs — no config available
+      // Reset relevant stubs — no app in config, but getApiKey falls back to env var
       configManagerStub.getCurrentAppId.mockReturnValue();
-      configManagerStub.getApiKey.mockReturnValue();
+      configManagerStub.getApiKey.mockReturnValue("envApp.keyId:keySecret");
 
-      // Set environment variable
+      // Set environment variable (getApiKey reads this internally)
       process.env.ABLY_API_KEY = "envApp.keyId:keySecret";
 
       const result = await command.testEnsureAppAndKey(flags);
 
-      // Should return the env var directly without interactive selection
+      // Should extract appId from the key and return without interactive selection
       expect(result).not.toBeNull();
       expect(result?.appId).toBe("envApp");
       expect(result?.apiKey).toBe("envApp.keyId:keySecret");

--- a/test/unit/base/base-command.test.ts
+++ b/test/unit/base/base-command.test.ts
@@ -590,35 +590,19 @@ describe("AblyBaseCommand", function () {
     it("should use ABLY_API_KEY environment variable if available", async function () {
       const flags: BaseFlags = {};
 
-      // Reset relevant stubs
+      // Reset relevant stubs — no config available
       configManagerStub.getCurrentAppId.mockReturnValue();
       configManagerStub.getApiKey.mockReturnValue();
-      // Set access token to ensure the control API path is followed
-      configManagerStub.getAccessToken.mockReturnValue("test-token");
 
-      // Set up interactive helper to simulate user selecting an app and key
-      const mockApp = { id: "envApp", name: "Test App" };
-      const mockKey = {
-        id: "keyId",
-        name: "Test Key",
-        key: "envApp.keyId:keySecret",
-      };
-
-      interactiveHelperStub.selectApp.mockResolvedValue(mockApp);
-      interactiveHelperStub.selectKey.mockResolvedValue(mockKey);
-
-      // Set environment variable but it will be used in getClientOptions, not directly in this test path
+      // Set environment variable
       process.env.ABLY_API_KEY = "envApp.keyId:keySecret";
 
       const result = await command.testEnsureAppAndKey(flags);
 
+      // Should return the env var directly without interactive selection
       expect(result).not.toBeNull();
       expect(result?.appId).toBe("envApp");
       expect(result?.apiKey).toBe("envApp.keyId:keySecret");
-      expect(interactiveHelperStub.selectKey).toHaveBeenCalledWith(
-        expect.anything(),
-        "envApp",
-      );
     });
 
     it("should handle web CLI mode appropriately", async function () {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -68,6 +68,7 @@ export default defineConfig({
             "**/dist/**",
             "test/e2e/web-cli/**/*.test.ts",
           ],
+          setupFiles: ["./test/setup.ts", "./test/e2e/setup.ts"],
           env: {
             ABLY_API_KEY: undefined,
           },


### PR DESCRIPTION
## Summary

Adds 28 new E2E test files and updates the E2E test helper, covering commands across channels, rooms, spaces, auth, logs, config, integrations, and more. In addition to happy-path coverage, this PR also exercises a set of cross-cutting concerns: capability-scoped auth (negative paths), revoked-key usability, CLI→CLI pub/sub round-trips, `--pretty-json` output shape, and error envelope/error-hint consistency.

### New test files (28)
- **Channels:** annotations CRUD, batch-publish, message-ops (update/append/delete), occupancy get, presence subscribe
- **Rooms:** list, messages (send/history/update/delete), messages subscribe, message reactions (send/subscribe/remove), reactions (send/subscribe), typing, presence (enter/get/subscribe), occupancy (get/subscribe)
- **Spaces:** CRUD (create/list/get), locations/cursors/locks, occupancy, subscribe
- **Auth:** keys (list/create/get/update/revoke), tokens (issue ably/jwt, revoke), capability scoping (negative paths)
- **Output:** `--pretty-json` shape, error envelope consistency, error hint wiring
- **Other:** accounts, integrations, logs (history + subscribe variants), config (show), status, support

### Cross-cutting coverage added in this PR
- **Revoke endpoint correctness** (covers the fix in #335): CLI `auth keys revoke` is exercised via the corrected `POST /apps/{app_id}/keys/{key_id}/revoke` path, asserting the success envelope.
- **Revoked key is actually unusable**: publishes work with a new key pre-revocation and are rejected post-revocation.
- **Wildcard capabilities**: explicit tests for channels-only (`{"*":["*"]}`) and channels-and-queues (`{"[*]*":["*"]}`) keys, asserting capability round-trips.
- **Capability-scoped auth (negative)**: a key scoped to `{"allowed-*":["publish"]}` can publish to matching channels, is rejected on non-matching channels, and is rejected on `history` (lacks the op).
- **CLI→CLI pub/sub round-trip**: both subscribe and publish run as CLI subprocesses (prior round-trip test published via the SDK), catching regressions in the CLI publish path.
- **`--pretty-json` output shape**: asserts multi-line indented output, parseable JSON, and envelope-field parity with `--json`.
- **Error envelope consistency**: every failure path emits `type:error`, `success:false`, nested `error.message`, and a trailing `status:completed` with `exitCode:1`.
- **Error hint wiring**: triggers Ably error 40160 via a scoped key and asserts `error.hint` surfaces the registered CLI hint from `src/utils/errors.ts`.

### Current E2E coverage after this PR

| Category      | Covered | Total Leaf Commands | Coverage |
|---------------|---------|---------------------|----------|
| Accounts      | 2       | 5                   | 40%      |
| Apps          | 8       | 10                  | 80%      |
| Auth          | 8       | 10                  | 80%      |
| Bench         | 2       | 2                   | 100%     |
| Channels      | 15      | 16                  | 94%      |
| Config        | 2       | 2                   | 100%     |
| Connections   | 1       | 1                   | 100%     |
| Integrations  | 5       | 5                   | 100%     |
| Logs          | 5       | 7                   | 71%      |
| Push          | 13      | 17                  | 76%      |
| Queues        | 3       | 3                   | 100%     |
| Rooms         | 18      | 18                  | 100%     |
| Spaces        | 12      | 17                  | 71%      |
| Stats         | 2       | 2                   | 100%     |
| Other         | 5       | 8                   | 63%      |
| **Total**     | **101** | **123**             | **~82%** |

Remaining gaps are mostly commands requiring interactive OAuth / account config (`accounts login/switch`, `apps current/switch`, `auth keys current/switch`, `channels inspect`), subscribe variants for spaces sub-resources, and some push channel subscription CRUD.

> **Note:** The majority of new tests are happy-path; this PR additionally covers selected negative paths (capability scoping, revoked keys, invalid auth, non-existent resources) and cross-cutting concerns (`--pretty-json` shape, error envelope, error hints). Broader error-path and flag-variation coverage remains in unit tests.

## Test plan
- [x] `pnpm exec eslint test/e2e/` passes with 0 errors
- [x] New test files follow existing E2E patterns (env var auth, unique resource names, proper cleanup)
- [x] `pnpm test:e2e` passes against real Ably infrastructure

🤖 Generated with [Claude Code](https://claude.com/claude-code)
