### PR TITLE
[DX-1042] Fix ably-interactive MODULE_NOT_FOUND when installed globally

### DIFF
--- a/bin/ably-interactive
+++ b/bin/ably-interactive
@@ -5,7 +5,13 @@
 # restarting the CLI when it exits due to SIGINT
 
 # Configuration
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SOURCE="${BASH_SOURCE[0]}"
+while [ -L "$SOURCE" ]; do
+  DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
 ABLY_BIN="$SCRIPT_DIR/run.js"
 ABLY_CONFIG_DIR="$HOME/.ably"
 HISTORY_FILE="$ABLY_CONFIG_DIR/history"

--- a/bin/ably-interactive.ps1
+++ b/bin/ably-interactive.ps1
@@ -5,7 +5,7 @@
 $ErrorActionPreference = "Stop"
 
 # Configuration
-$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$ScriptDir = Split-Path -Parent (Resolve-Path $MyInvocation.MyCommand.Path).Path
 $AblyBin = Join-Path $ScriptDir "run.cmd"
 $AblyConfigDir = Join-Path $env:USERPROFILE ".ably"
 $HistoryFile = Join-Path $AblyConfigDir "history"


### PR DESCRIPTION
## Summary

- **What:** `ably-interactive` throws `MODULE_NOT_FOUND` for `run.js` when installed globally (e.g., via `npm install -g`)
- **Why:** The bash wrapper uses `${BASH_SOURCE[0]}` to locate `run.js`, but when npm symlinks the script into the global bin directory, `dirname` resolves to the **symlink's parent** (the Node/mise bin directory) — not the package's `bin/` directory. The main `ably` command doesn't have this issue because `bin/run.js` uses `import.meta.url`, which always resolves to the real file.
- **How:** Replace the single-line `SCRIPT_DIR` assignment with a portable symlink resolution loop that follows the symlink chain to the real script location before deriving the directory. This is the standard pattern used by nvm, sdkman, and other bash tools. Also added defensive `Resolve-Path` in the PowerShell wrapper.

## Error reproduced

```
Error: Cannot find module '/Users/andyford/.local/share/mise/installs/node/24.9.0/bin/run.js'
```

## Verified

Old behavior via symlink → resolves to wrong directory, `run.js` NOT found:
```
SCRIPT_DIR=/tmp/test-bin
ABLY_BIN=/tmp/test-bin/run.js
run.js exists: NO
```

New behavior via symlink → resolves to package directory, `run.js` found:
```
SCRIPT_DIR=/Users/umair/Git/ably-cli/bin
ABLY_BIN=/Users/umair/Git/ably-cli/bin/run.js
run.js exists: YES
```

All 2253 unit tests pass.

## Test plan

- [x] Verified old code fails when invoked via symlink
- [x] Verified new code resolves correctly via symlink
- [x] `pnpm exec eslint .` — 0 errors
- [x] `pnpm test:unit` — 2253 passed