### PR TITLE
[VUL-471] Fix arbitrary file read vulnerability in web CLI push config commands

### DIFF
--- a/.claude/skills/ably-new-command/SKILL.md
+++ b/.claude/skills/ably-new-command/SKILL.md
@@ -429,6 +429,8 @@ If the new command shouldn't be available in the web CLI, add it to the appropri
 - `WEB_CLI_ANONYMOUS_RESTRICTED_COMMANDS` — for commands that expose account/app data
 - `INTERACTIVE_UNSUITABLE_COMMANDS` — for commands that don't work in interactive mode
 
+**Security rule:** Any command that reads or uploads files from the filesystem (e.g., certificate uploads, key file imports) **must** be added to `WEB_CLI_RESTRICTED_COMMANDS`. The web CLI runs on a server — file-reading commands would read from the server's filesystem, not the user's local machine, which could expose server contents. There is no file upload mechanism in the web CLI to transfer local files.
+
 ## Step 6: Validate
 
 After creating command and test files, always run:

--- a/src/base-command.ts
+++ b/src/base-command.ts
@@ -57,6 +57,10 @@ export const WEB_CLI_RESTRICTED_COMMANDS = [
 
   // config only applicable to local env
   "config*",
+
+  // File-reading commands can expose server filesystem contents in web CLI mode
+  "push:config:set-apns",
+  "push:config:set-fcm",
 ];
 
 /* Additional restricted commands when running in anonymous web CLI mode */

--- a/src/commands/push/config/set-apns.ts
+++ b/src/commands/push/config/set-apns.ts
@@ -64,6 +64,15 @@ export default class PushConfigSetApns extends ControlBaseCommand {
 
         if (flags.certificate) {
           const certPath = path.resolve(flags.certificate);
+          const certExt = path.extname(certPath).toLowerCase();
+          if (certExt !== ".p12" && certExt !== ".pfx") {
+            this.fail(
+              `Invalid certificate file type: expected a .p12 or .pfx file, got "${certExt || "(no extension)"}".`,
+              flags,
+              "pushConfigSetApns",
+            );
+          }
+
           if (!fs.existsSync(certPath)) {
             this.fail(
               `Certificate file not found: ${certPath}`,
@@ -123,6 +132,15 @@ export default class PushConfigSetApns extends ControlBaseCommand {
           }
 
           const keyPath = path.resolve(flags["key-file"]);
+          const keyExt = path.extname(keyPath).toLowerCase();
+          if (keyExt !== ".p8") {
+            this.fail(
+              `Invalid key file type: expected a .p8 file, got "${keyExt || "(no extension)"}".`,
+              flags,
+              "pushConfigSetApns",
+            );
+          }
+
           if (!fs.existsSync(keyPath)) {
             this.fail(
               `Key file not found: ${keyPath}`,

--- a/src/commands/push/config/set-fcm.ts
+++ b/src/commands/push/config/set-fcm.ts
@@ -33,6 +33,14 @@ export default class PushConfigSetFcm extends ControlBaseCommand {
       async (controlApi) => {
         const appId = await this.requireAppId(flags);
         const filePath = path.resolve(flags["service-account"]);
+        const ext = path.extname(filePath).toLowerCase();
+        if (ext !== ".json") {
+          this.fail(
+            `Invalid service account file type: expected a .json file, got "${ext || "(no extension)"}".`,
+            flags,
+            "pushConfigSetFcm",
+          );
+        }
 
         if (!fs.existsSync(filePath)) {
           this.fail(

--- a/src/control-base-command.ts
+++ b/src/control-base-command.ts
@@ -3,6 +3,7 @@ import { controlApiFlags } from "./flags.js";
 import { ControlApi, App } from "./services/control-api.js";
 import { BaseFlags } from "./types/cli.js";
 import { errorMessage } from "./utils/errors.js";
+import isWebCliMode from "./utils/web-mode.js";
 
 export abstract class ControlBaseCommand extends AblyBaseCommand {
   // Control API commands get core + hidden control API flags
@@ -30,6 +31,14 @@ export abstract class ControlBaseCommand extends AblyBaseCommand {
     if (!accessToken) {
       this.fail(
         `No access token provided. Please set the ABLY_ACCESS_TOKEN environment variable or configure an account with "ably accounts login".`,
+        flags,
+        "auth",
+      );
+    }
+
+    if (isWebCliMode() && flags["control-host"]) {
+      this.fail(
+        "The --control-host flag is not available in web CLI mode.",
         flags,
         "auth",
       );

--- a/test/fixtures/push/test-apns-cert.p12
+++ b/test/fixtures/push/test-apns-cert.p12
@@ -1,0 +1,1 @@
+fake-p12-certificate-data

--- a/test/unit/commands/push/config/set-apns.test.ts
+++ b/test/unit/commands/push/config/set-apns.test.ts
@@ -17,6 +17,7 @@ import { parseJsonOutput } from "../../../../helpers/ndjson.js";
 describe("push:config:set-apns command", () => {
   let appId: string;
   const p8FixturePath = resolve("test/fixtures/push/test-apns-key.p8");
+  const p12FixturePath = resolve("test/fixtures/push/test-apns-cert.p12");
 
   beforeEach(() => {
     const ctx = getControlApiContext();
@@ -67,7 +68,7 @@ describe("push:config:set-apns command", () => {
         .reply(200, { id: "cert-123" });
 
       const { stderr } = await runCommand(
-        ["push:config:set-apns", "--certificate", p8FixturePath],
+        ["push:config:set-apns", "--certificate", p12FixturePath],
         import.meta.url,
       );
 
@@ -107,7 +108,7 @@ describe("push:config:set-apns command", () => {
         .reply(200, { id: "cert-123" });
 
       const { stdout } = await runCommand(
-        ["push:config:set-apns", "--certificate", p8FixturePath, "--json"],
+        ["push:config:set-apns", "--certificate", p12FixturePath, "--json"],
         import.meta.url,
       );
 
@@ -206,7 +207,7 @@ describe("push:config:set-apns command", () => {
         .reply(200, { id: appId, apnsUseSandboxEndpoint: true });
 
       const { stderr } = await runCommand(
-        ["push:config:set-apns", "--certificate", p8FixturePath, "--sandbox"],
+        ["push:config:set-apns", "--certificate", p12FixturePath, "--sandbox"],
         import.meta.url,
       );
 
@@ -220,6 +221,84 @@ describe("push:config:set-apns command", () => {
       );
 
       expect(error).toBeDefined();
+    });
+  });
+
+  describe("file extension validation", () => {
+    it("should reject certificate files without .p12 or .pfx extension", async () => {
+      const { error } = await runCommand(
+        ["push:config:set-apns", "--certificate", "/etc/passwd"],
+        import.meta.url,
+      );
+
+      expect(error).toBeDefined();
+      expect(error?.message).toContain("Invalid certificate file type");
+      expect(error?.message).toContain(".p12 or .pfx");
+    });
+
+    it("should reject key files without .p8 extension", async () => {
+      const { error } = await runCommand(
+        [
+          "push:config:set-apns",
+          "--key-file",
+          "/some/file.txt",
+          "--key-id",
+          "KEY123",
+          "--team-id",
+          "TEAM456",
+          "--topic",
+          "com.example.app",
+        ],
+        import.meta.url,
+      );
+
+      expect(error).toBeDefined();
+      expect(error?.message).toContain("Invalid key file type");
+      expect(error?.message).toContain(".p8");
+    });
+
+    it("should accept .pfx certificate files", async () => {
+      nockControl()
+        .post(`/v1/apps/${appId}/pkcs12`)
+        .reply(200, { id: "cert-123" });
+
+      // The file won't exist, but extension validation should pass
+      const { error } = await runCommand(
+        ["push:config:set-apns", "--certificate", "/nonexistent/cert.pfx"],
+        import.meta.url,
+      );
+
+      // Should fail with "not found", not "invalid file type"
+      expect(error).toBeDefined();
+      expect(error?.message).toContain("not found");
+    });
+  });
+
+  describe("web CLI restrictions", () => {
+    let originalWebCliMode: string | undefined;
+
+    beforeEach(() => {
+      originalWebCliMode = process.env.ABLY_WEB_CLI_MODE;
+    });
+
+    afterEach(() => {
+      if (originalWebCliMode === undefined) {
+        delete process.env.ABLY_WEB_CLI_MODE;
+      } else {
+        process.env.ABLY_WEB_CLI_MODE = originalWebCliMode;
+      }
+    });
+
+    it("should be restricted in web CLI mode", async () => {
+      process.env.ABLY_WEB_CLI_MODE = "true";
+
+      const { error } = await runCommand(
+        ["push:config:set-apns", "--certificate", p12FixturePath],
+        import.meta.url,
+      );
+
+      expect(error).toBeDefined();
+      expect(error?.message).toContain("not available in the web CLI");
     });
   });
 

--- a/test/unit/commands/push/config/set-fcm.test.ts
+++ b/test/unit/commands/push/config/set-fcm.test.ts
@@ -84,13 +84,20 @@ describe("push:config:set-fcm command", () => {
     });
 
     it("should fail when service account file is not valid JSON", async () => {
-      const invalidPath = resolve("test/fixtures/push/test-apns-key.p8");
-      const { error } = await runCommand(
-        ["push:config:set-fcm", "--service-account", invalidPath],
-        import.meta.url,
-      );
-
-      expect(error).toBeDefined();
+      const tempDir = mkdtempSync(join(tmpdir(), "ably-cli-test-"));
+      const tempPath = join(tempDir, "invalid.json");
+      writeFileSync(tempPath, "not valid json content");
+      try {
+        const { error } = await runCommand(
+          ["push:config:set-fcm", "--service-account", tempPath],
+          import.meta.url,
+        );
+        expect(error).toBeDefined();
+        expect(error?.message).toContain("not valid JSON");
+      } finally {
+        unlinkSync(tempPath);
+        rmdirSync(tempDir);
+      }
     });
 
     it("should require service-account flag", async () => {
@@ -135,6 +142,47 @@ describe("push:config:set-fcm command", () => {
         unlinkSync(tempPath);
         rmdirSync(tempDir);
       }
+    });
+  });
+
+  describe("file extension validation", () => {
+    it("should reject service account files without .json extension", async () => {
+      const { error } = await runCommand(
+        ["push:config:set-fcm", "--service-account", "/etc/passwd"],
+        import.meta.url,
+      );
+
+      expect(error).toBeDefined();
+      expect(error?.message).toContain("Invalid service account file type");
+      expect(error?.message).toContain(".json");
+    });
+  });
+
+  describe("web CLI restrictions", () => {
+    let originalWebCliMode: string | undefined;
+
+    beforeEach(() => {
+      originalWebCliMode = process.env.ABLY_WEB_CLI_MODE;
+    });
+
+    afterEach(() => {
+      if (originalWebCliMode === undefined) {
+        delete process.env.ABLY_WEB_CLI_MODE;
+      } else {
+        process.env.ABLY_WEB_CLI_MODE = originalWebCliMode;
+      }
+    });
+
+    it("should be restricted in web CLI mode", async () => {
+      process.env.ABLY_WEB_CLI_MODE = "true";
+
+      const { error } = await runCommand(
+        ["push:config:set-fcm", "--service-account", fcmFixturePath],
+        import.meta.url,
+      );
+
+      expect(error).toBeDefined();
+      expect(error?.message).toContain("not available in the web CLI");
     });
   });
 

--- a/test/unit/commands/push/config/show.test.ts
+++ b/test/unit/commands/push/config/show.test.ts
@@ -177,6 +177,36 @@ describe("push:config:show command", () => {
     });
   });
 
+  describe("--control-host web CLI restriction", () => {
+    let originalWebCliMode: string | undefined;
+
+    beforeEach(() => {
+      originalWebCliMode = process.env.ABLY_WEB_CLI_MODE;
+    });
+
+    afterEach(() => {
+      if (originalWebCliMode === undefined) {
+        delete process.env.ABLY_WEB_CLI_MODE;
+      } else {
+        process.env.ABLY_WEB_CLI_MODE = originalWebCliMode;
+      }
+    });
+
+    it("should reject --control-host in web CLI mode", async () => {
+      process.env.ABLY_WEB_CLI_MODE = "true";
+
+      const { error } = await runCommand(
+        ["push:config:show", "--control-host", "attacker.com"],
+        import.meta.url,
+      );
+
+      expect(error).toBeDefined();
+      expect(error?.message).toContain(
+        "--control-host flag is not available in web CLI mode",
+      );
+    });
+  });
+
   describe("error handling", () => {
     standardControlApiErrorTests({
       commandArgs: ["push:config:show"],


### PR DESCRIPTION
## Summary

- Block `push:config:set-apns` and `push:config:set-fcm` in web CLI mode — these commands read files from the server filesystem (not the user's local machine) and have no legitimate web CLI use case since there's no file upload mechanism
- Block `--control-host` flag in web CLI mode to prevent redirecting API requests (and file contents) to attacker-controlled servers
- Add file extension validation (`.p12`/`.pfx` for certificates, `.p8` for keys) as defense in depth against arbitrary file reads

**Context:** A security researcher demonstrated that an authenticated web CLI user could read arbitrary server container files (e.g., `/etc/passwd`) via `--certificate /etc/passwd` and exfiltrate them using `--control-host https://attacker.com`. The local CLI is not affected — local users already have full filesystem access.

## Test plan

- [x] `pnpm prepare` passes
- [x] `pnpm exec eslint .` — 0 errors
- [x] `pnpm test:unit` — 2258 tests pass
- [ ] Verify `push:config:set-apns` is rejected in web CLI mode (`ABLY_WEB_CLI_MODE=true`)
- [ ] Verify `--control-host` is rejected for any control API command in web CLI mode
- [ ] Verify invalid file extensions are rejected (e.g., `--certificate /etc/passwd`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)