### PR TITLE
Fix status in `integration update` and incorrect examples/description

### DIFF
--- a/src/commands/apps/rules/update.ts
+++ b/src/commands/apps/rules/update.ts
@@ -18,6 +18,7 @@ export default class RulesUpdateCommand extends ControlBaseCommand {
     "$ ably apps rules update chat --persisted",
     "$ ably apps rules update chat --mutable-messages",
     "$ ably apps rules update events --push-enabled=false",
+    "$ ably apps rules update events --no-push-enabled",
     '$ ably apps rules update notifications --persisted --push-enabled --app "My App"',
     "$ ably apps rules update chat --persisted --json",
   ];

--- a/src/commands/auth/keys/create.ts
+++ b/src/commands/auth/keys/create.ts
@@ -14,9 +14,8 @@ export default class KeysCreateCommand extends ControlBaseCommand {
     `$ ably auth keys create --name "My New Key" --capabilities '{"channel1":["publish","subscribe"],"channel2":["history"]}'`,
     `$ ably auth keys create --name "My New Key" --json`,
     `$ ably auth keys create --name "My New Key" --pretty-json`,
-    `$ ably auth keys create --app <appId> --name "MyKey" --capabilities '{"channel:*":["publish"]}'`,
-    `$ ably auth keys create --app <appId> --name "MyOtherKey" --capabilities '{"channel:chat-*":["subscribe"],"channel:updates":["publish"]}' --ttl 86400`,
-    `$ ably auth keys create --name "My New Key" --capabilities '{"channel1":["publish","subscribe"],"channel2":["history"]}'`,
+    `$ ably auth keys create --app APP_ID --name "MyKey" --capabilities '{"channel:*":["publish"]}'`,
+    `$ ably auth keys create --app APP_ID --name "MyOtherKey" --capabilities '{"channel:chat-*":["subscribe"],"channel:updates":["publish"]}'`,
   ];
 
   static flags = {

--- a/src/commands/channels/presence/enter.ts
+++ b/src/commands/channels/presence/enter.ts
@@ -22,7 +22,7 @@ export default class ChannelsPresenceEnter extends AblyBaseCommand {
   };
 
   static override description =
-    "Enter presence on a channel and remains present until terminated.";
+    "Enter presence on a channel and remain present until terminated";
 
   static override examples = [
     "$ ably channels presence enter my-channel",

--- a/src/commands/channels/presence/subscribe.ts
+++ b/src/commands/channels/presence/subscribe.ts
@@ -21,7 +21,7 @@ export default class ChannelsPresenceSubscribe extends AblyBaseCommand {
 
   static override examples = [
     "$ ably channels presence subscribe my-channel",
-    '$ ably channels presence subscribe my-channel --client-id "filter123"',
+    '$ ably channels presence subscribe my-channel --client-id "my-client"',
     "$ ably channels presence subscribe my-channel --json",
     "$ ably channels presence subscribe my-channel --pretty-json",
     "$ ably channels presence subscribe my-channel --duration 30",

--- a/src/commands/integrations/update.ts
+++ b/src/commands/integrations/update.ts
@@ -73,7 +73,10 @@ export default class IntegrationsUpdateCommand extends ControlBaseCommand {
       const existingRule = await controlApi.getRule(appId, args.ruleId);
 
       // Prepare update data - explicitly typed
-      const updatePayload: Partial<Omit<PartialRuleData, "status">> = {
+      const updatePayload: Partial<PartialRuleData> = {
+        ...(flags.status && {
+          status: flags.status === "enabled" ? "enabled" : "disabled",
+        }),
         ...(flags["request-mode"] && { requestMode: flags["request-mode"] }),
         ...(flags.source && {
           source: JSON.parse(flags.source) as Record<string, unknown>,

--- a/src/commands/logs/channel-lifecycle/index.ts
+++ b/src/commands/logs/channel-lifecycle/index.ts
@@ -8,7 +8,7 @@ export default class LogsChannelLifecycleIndexCommand extends BaseTopicCommand {
     "Stream logs from [meta]channel.lifecycle meta channel";
 
   static override examples = [
-    "ably logs channel-lifecycle subscribe",
-    "ably logs channel-lifecycle subscribe --rewind 10",
+    "$ ably logs channel-lifecycle subscribe",
+    "$ ably logs channel-lifecycle subscribe --rewind 10",
   ];
 }

--- a/src/commands/logs/connection-lifecycle/index.ts
+++ b/src/commands/logs/connection-lifecycle/index.ts
@@ -8,7 +8,7 @@ export default class LogsConnectionLifecycleIndexCommand extends BaseTopicComman
     "Stream logs from [meta]connection.lifecycle meta channel";
 
   static override examples = [
-    "ably logs connection-lifecycle subscribe",
-    "ably logs connection-lifecycle subscribe --rewind 10",
+    "$ ably logs connection-lifecycle subscribe",
+    "$ ably logs connection-lifecycle subscribe --rewind 10",
   ];
 }

--- a/src/commands/rooms/presence/enter.ts
+++ b/src/commands/rooms/presence/enter.ts
@@ -22,7 +22,7 @@ export default class RoomsPresenceEnter extends ChatBaseCommand {
   };
 
   static override description =
-    "Enter presence in a chat room and remain present until terminated.";
+    "Enter presence in a chat room and remain present until terminated";
 
   static override examples = [
     "$ ably rooms presence enter my-room",


### PR DESCRIPTION
- Remove non-existent --ttl flag from auth keys create example (causes runtime error)
- Added missing `flags.status` payload param to `integrations update`
- Remove duplicate example in auth keys create
- Replace <appId> placeholders with APP_ID for consistency
- Other examples related updates