### PR TITLE
[DX-1097] Fixed capability flag inconsistency for keys create/update

### DIFF
--- a/src/commands/auth/keys/create.ts
+++ b/src/commands/auth/keys/create.ts
@@ -2,6 +2,7 @@ import { Flags } from "@oclif/core";
 
 import { ControlBaseCommand } from "../../../control-base-command.js";
 import { formatCapabilities } from "../../../utils/key-display.js";
+import { parseCapabilities } from "../../../utils/key-parsing.js";
 import { formatLabel, formatResource } from "../../../utils/output.js";
 
 export default class KeysCreateCommand extends ControlBaseCommand {
@@ -12,6 +13,7 @@ export default class KeysCreateCommand extends ControlBaseCommand {
     `$ ably auth keys create --name "My New Key" --app APP_ID`,
     `$ ably auth keys create --name "My New Key" --capabilities '{"*":["*"]}'`,
     `$ ably auth keys create --name "My New Key" --capabilities '{"channel1":["publish","subscribe"],"channel2":["history"]}'`,
+    `$ ably auth keys create --name "My New Key" --capabilities "publish,subscribe"`,
     `$ ably auth keys create --name "My New Key" --json`,
     `$ ably auth keys create --name "My New Key" --pretty-json`,
     `$ ably auth keys create --app APP_ID --name "MyKey" --capabilities '{"channel:*":["publish"]}'`,
@@ -26,7 +28,8 @@ export default class KeysCreateCommand extends ControlBaseCommand {
     }),
     capabilities: Flags.string({
       default: '{"*":["*"]}',
-      description: `Capability object as a JSON string. Example: '{"channel:*":["publish"]}'`,
+      description:
+        "Capabilities as JSON object (per-channel) or comma-separated list (all channels)",
     }),
     name: Flags.string({
       description: "Name of the key",
@@ -41,13 +44,9 @@ export default class KeysCreateCommand extends ControlBaseCommand {
 
     let capabilities: Record<string, string[]>;
     try {
-      capabilities = JSON.parse(flags.capabilities) as Record<string, string[]>;
-    } catch {
-      this.fail(
-        "Invalid capabilities JSON format. Please provide a valid JSON string.",
-        flags,
-        "keyCreate",
-      );
+      capabilities = parseCapabilities(flags.capabilities);
+    } catch (error) {
+      this.fail(error, flags, "keyCreate");
     }
 
     try {

--- a/src/commands/auth/keys/current.ts
+++ b/src/commands/auth/keys/current.ts
@@ -2,6 +2,7 @@ import { Flags } from "@oclif/core";
 import chalk from "chalk";
 
 import { ControlBaseCommand } from "../../../control-base-command.js";
+import { resolveCurrentKeyName } from "../../../utils/key-parsing.js";
 import { formatLabel } from "../../../utils/output.js";
 
 export default class KeysCurrentCommand extends ControlBaseCommand {
@@ -50,9 +51,7 @@ export default class KeysCurrentCommand extends ControlBaseCommand {
     const appName = this.configManager.getAppName(appId) || appId;
 
     // Format the full key name (app_id.key_id)
-    const keyName = keyId.includes(".")
-      ? keyId
-      : `${appId}.${keyId.split(".")[1] ?? keyId}`;
+    const keyName = resolveCurrentKeyName(appId, keyId) ?? keyId;
 
     if (this.shouldOutputJson(flags)) {
       this.logJsonResult(

--- a/src/commands/auth/keys/get.ts
+++ b/src/commands/auth/keys/get.ts
@@ -2,6 +2,7 @@ import { Args, Flags } from "@oclif/core";
 
 import { ControlBaseCommand } from "../../../control-base-command.js";
 import { formatCapabilities } from "../../../utils/key-display.js";
+import { resolveCurrentKeyName } from "../../../utils/key-parsing.js";
 import {
   formatHeading,
   formatLabel,
@@ -74,11 +75,7 @@ export default class KeysGetCommand extends ControlBaseCommand {
 
       // Check if env var overrides the current key
       const currentKeyId = this.configManager.getKeyId(appId);
-      const currentKeyName = currentKeyId?.includes(".")
-        ? currentKeyId
-        : currentKeyId
-          ? `${appId}.${currentKeyId}`
-          : undefined;
+      const currentKeyName = resolveCurrentKeyName(appId, currentKeyId);
       const envKey = process.env.ABLY_API_KEY;
       const envKeyPrefix = envKey ? envKey.split(":")[0] : undefined;
       const hasEnvOverride =

--- a/src/commands/auth/keys/index.ts
+++ b/src/commands/auth/keys/index.ts
@@ -11,7 +11,7 @@ export default class AuthKeys extends BaseTopicCommand {
     '$ ably auth keys create --name "My New Key"',
     "$ ably auth keys get KEY_ID",
     "$ ably auth keys revoke KEY_ID",
-    "$ ably auth keys update KEY_ID",
+    '$ ably auth keys update KEY_ID --name "New Name"',
     "$ ably auth keys switch KEY_ID",
   ];
 }

--- a/src/commands/auth/keys/list.ts
+++ b/src/commands/auth/keys/list.ts
@@ -3,6 +3,7 @@ import chalk from "chalk";
 
 import { ControlBaseCommand } from "../../../control-base-command.js";
 import { formatCapabilities } from "../../../utils/key-display.js";
+import { resolveCurrentKeyName } from "../../../utils/key-parsing.js";
 import {
   formatHeading,
   formatLabel,
@@ -51,12 +52,7 @@ export default class KeysListCommand extends ControlBaseCommand {
 
       // Get the current key name for highlighting (app_id.key_Id)
       const currentKeyId = this.configManager.getKeyId(appId);
-      const currentKeyName =
-        currentKeyId && currentKeyId.includes(".")
-          ? currentKeyId
-          : currentKeyId
-            ? `${appId}.${currentKeyId}`
-            : undefined;
+      const currentKeyName = resolveCurrentKeyName(appId, currentKeyId);
 
       if (this.shouldOutputJson(flags)) {
         // Add a "current" flag to the key if it's the currently selected one

--- a/src/commands/auth/keys/update.ts
+++ b/src/commands/auth/keys/update.ts
@@ -2,7 +2,10 @@ import { Args, Flags } from "@oclif/core";
 
 import { ControlBaseCommand } from "../../../control-base-command.js";
 import { formatCapabilityInline } from "../../../utils/key-display.js";
-import { parseKeyIdentifier } from "../../../utils/key-parsing.js";
+import {
+  parseCapabilities,
+  parseKeyIdentifier,
+} from "../../../utils/key-parsing.js";
 import { formatLabel, formatResource } from "../../../utils/output.js";
 
 export default class KeysUpdateCommand extends ControlBaseCommand {
@@ -19,6 +22,7 @@ export default class KeysUpdateCommand extends ControlBaseCommand {
     '$ ably auth keys update APP_ID.KEY_ID --name "New Name"',
     '$ ably auth keys update KEY_ID --app APP_ID --capabilities "publish,subscribe"',
     '$ ably auth keys update APP_ID.KEY_ID --name "New Name" --capabilities "publish,subscribe"',
+    `$ ably auth keys update APP_ID.KEY_ID --name "New Name" --capabilities '{"channel1":["publish"],"channel2":["subscribe"]}'`,
     '$ ably auth keys update APP_ID.KEY_ID --name "New Name" --json',
   ];
 
@@ -29,7 +33,8 @@ export default class KeysUpdateCommand extends ControlBaseCommand {
       env: "ABLY_APP_ID",
     }),
     capabilities: Flags.string({
-      description: "New capabilities for the key (comma-separated list)",
+      description:
+        "New capabilities as JSON object (per-channel) or comma-separated list (all channels)",
       required: false,
     }),
     name: Flags.string({
@@ -71,21 +76,10 @@ export default class KeysUpdateCommand extends ControlBaseCommand {
       }
 
       if (flags.capabilities) {
-        // Parse the capabilities string into the expected format
-        // The expected format is a Record<string, string[]> (channel => permissions)
         try {
-          // Split by commas to get individual capabilities
-          const capabilityArray = flags.capabilities
-            .split(",")
-            .map((cap) => cap.trim());
-          // Create capability object with "*" channel and array of capabilities
-          updateData.capability = {
-            "*": capabilityArray,
-          };
+          updateData.capability = parseCapabilities(flags.capabilities);
         } catch (error) {
-          this.fail(error, flags, "keyUpdate", {
-            context: "parsing capabilities",
-          });
+          this.fail(error, flags, "keyUpdate");
         }
       }
 

--- a/src/utils/key-parsing.ts
+++ b/src/utils/key-parsing.ts
@@ -15,3 +15,49 @@ export function parseKeyIdentifier(identifier: string): {
   }
   return { keyId: identifier };
 }
+
+/**
+ * Resolve a current key ID into a full key name (appId.keyId).
+ * Handles the case where keyId may already include the appId prefix.
+ * Returns undefined if keyId is not provided.
+ */
+export function resolveCurrentKeyName(
+  appId: string,
+  keyId?: string,
+): string | undefined {
+  if (!keyId) return undefined;
+  return keyId.includes(".") ? keyId : `${appId}.${keyId}`;
+}
+
+/**
+ * Parse a capabilities string that may be either:
+ * - JSON object: '{"channel1":["publish"],"channel2":["subscribe"]}'
+ * - Comma-separated list: "publish,subscribe" → {"*": ["publish","subscribe"]}
+ *
+ * Throws error on invalid JSON object or empty Capabilities array
+ */
+export function parseCapabilities(input: string): Record<string, string[]> {
+  if (input.trimStart().startsWith("{")) {
+    try {
+      return JSON.parse(input) as Record<string, string[]>;
+    } catch (error) {
+      throw new Error(
+        "Invalid capabilities JSON format. Please provide a valid JSON string.",
+        { cause: error },
+      );
+    }
+  }
+
+  const capabilityArray = input
+    .split(",")
+    .map((cap) => cap.trim())
+    .filter((cap) => cap.length > 0);
+
+  if (capabilityArray.length === 0) {
+    throw new Error(
+      "Capabilities must contain at least one non-empty capability.",
+    );
+  }
+
+  return { "*": capabilityArray };
+}

--- a/test/unit/commands/auth/keys/create.test.ts
+++ b/test/unit/commands/auth/keys/create.test.ts
@@ -63,6 +63,44 @@ describe("auth:keys:create command", () => {
       expect(stdout).toContain(mockKeyId);
     });
 
+    it("should create a key with comma-separated capabilities", async () => {
+      const appId = getMockConfigManager().getRegisteredAppId();
+      mockAppResolution(appId);
+      nockControl()
+        .post(`/v1/apps/${appId}/keys`, {
+          name: mockKeyName,
+          capability: { "*": ["publish", "subscribe"] },
+        })
+        .reply(201, {
+          id: mockKeyId,
+          appId,
+          name: mockKeyName,
+          key: `${appId}.${mockKeyId}:${mockKeySecret}`,
+          capability: { "*": ["publish", "subscribe"] },
+          created: Date.now(),
+          modified: Date.now(),
+          status: "enabled",
+          revocable: true,
+        });
+
+      const { stdout, stderr } = await runCommand(
+        [
+          "auth:keys:create",
+          "--name",
+          `"${mockKeyName}"`,
+          "--app",
+          appId,
+          "--capabilities",
+          "publish,subscribe",
+        ],
+        import.meta.url,
+      );
+
+      expect(stderr).toContain("Key created:");
+      expect(stdout).toContain("publish");
+      expect(stdout).toContain("subscribe");
+    });
+
     it("should create a key with custom capabilities", async () => {
       const appId = getMockConfigManager().getRegisteredAppId();
       mockAppResolution(appId);
@@ -236,10 +274,6 @@ describe("auth:keys:create command", () => {
     it("should handle invalid capabilities JSON", async () => {
       const appId = getMockConfigManager().getRegisteredAppId();
       mockAppResolution(appId);
-      // Mock the key creation endpoint with invalid capabilities
-      nockControl().post(`/v1/apps/${appId}/keys`).reply(400, {
-        error: "Invalid capabilities format",
-      });
 
       const { error } = await runCommand(
         [
@@ -249,12 +283,37 @@ describe("auth:keys:create command", () => {
           "--app",
           appId,
           "--capabilities",
-          "invalid-json",
+          "{invalid-json",
         ],
         import.meta.url,
       );
       expect(error).toBeDefined();
-      expect(error?.message).toMatch(/Invalid capabilities/);
+      expect(error?.message).toMatch(
+        /Invalid capabilities JSON format\. Please provide a valid JSON string\./,
+      );
+      expect(error?.oclif?.exit).toBeGreaterThan(0);
+    });
+
+    it("should handle empty capabilities", async () => {
+      const appId = getMockConfigManager().getRegisteredAppId();
+      mockAppResolution(appId);
+
+      const { error } = await runCommand(
+        [
+          "auth:keys:create",
+          "--name",
+          `"${mockKeyName}"`,
+          "--app",
+          appId,
+          "--capabilities",
+          ",,",
+        ],
+        import.meta.url,
+      );
+      expect(error).toBeDefined();
+      expect(error?.message).toMatch(
+        /Capabilities must contain at least one non-empty capability\./,
+      );
       expect(error?.oclif?.exit).toBeGreaterThan(0);
     });
   });

--- a/test/unit/commands/auth/keys/update.test.ts
+++ b/test/unit/commands/auth/keys/update.test.ts
@@ -89,6 +89,43 @@ describe("auth:keys:update command", () => {
       expect(stdout).toContain("* → subscribe");
     });
 
+    it("should update key capabilities with JSON object", async () => {
+      const appId = getMockConfigManager().getCurrentAppId()!;
+      mockKeysList(appId, [
+        buildMockKey(appId, mockKeyId, {
+          capability: { "*": ["publish", "subscribe"] },
+        }),
+      ]);
+
+      nockControl()
+        .patch(`/v1/apps/${appId}/keys/${mockKeyId}`)
+        .reply(200, {
+          id: mockKeyId,
+          appId,
+          name: "Test Key",
+          key: `${appId}.${mockKeyId}:secret`,
+          capability: {
+            channel1: ["publish"],
+            channel2: ["subscribe"],
+          },
+          created: Date.now(),
+          modified: Date.now(),
+        });
+
+      const { stdout } = await runCommand(
+        [
+          "auth:keys:update",
+          `${appId}.${mockKeyId}`,
+          "--capabilities",
+          '{"channel1":["publish"],"channel2":["subscribe"]}',
+        ],
+        import.meta.url,
+      );
+
+      expect(stdout).toContain(`Key Name: ${appId}.${mockKeyId}`);
+      expect(stdout).toContain("After:");
+    });
+
     it("should output JSON with nested key data when --json flag is used", async () => {
       const appId = getMockConfigManager().getCurrentAppId()!;
       mockKeysList(appId, [

--- a/test/unit/utils/key-parsing.test.ts
+++ b/test/unit/utils/key-parsing.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseKeyIdentifier,
+  resolveCurrentKeyName,
+  parseCapabilities,
+} from "../../../src/utils/key-parsing.js";
+
+describe("parseKeyIdentifier", () => {
+  it("should parse appId.keyId format", () => {
+    expect(parseKeyIdentifier("app123.key456")).toEqual({
+      appId: "app123",
+      keyId: "key456",
+    });
+  });
+
+  it("should return keyId only when no dot present", () => {
+    expect(parseKeyIdentifier("key456")).toEqual({ keyId: "key456" });
+  });
+
+  it("should return keyId only when identifier contains a colon", () => {
+    expect(parseKeyIdentifier("app123.key456:secret")).toEqual({
+      keyId: "app123.key456:secret",
+    });
+  });
+
+  it("should return keyId only when multiple dots present", () => {
+    expect(parseKeyIdentifier("a.b.c")).toEqual({ keyId: "a.b.c" });
+  });
+});
+
+describe("resolveCurrentKeyName", () => {
+  it("should prefix keyId with appId", () => {
+    expect(resolveCurrentKeyName("app123", "key456")).toBe("app123.key456");
+  });
+
+  it("should return as-is when keyId already includes appId", () => {
+    expect(resolveCurrentKeyName("app123", "app123.key456")).toBe(
+      "app123.key456",
+    );
+  });
+
+  it("should return undefined when keyId is not provided", () => {
+    expect(resolveCurrentKeyName("app123")).toBeUndefined();
+  });
+
+  it("should return undefined when keyId is empty string", () => {
+    expect(resolveCurrentKeyName("app123", "")).toBeUndefined();
+  });
+});
+
+describe("parseCapabilities", () => {
+  describe("JSON input", () => {
+    it("should parse a valid JSON capabilities object", () => {
+      const result = parseCapabilities(
+        '{"channel1":["publish"],"channel2":["subscribe"]}',
+      );
+      expect(result).toEqual({
+        channel1: ["publish"],
+        channel2: ["subscribe"],
+      });
+    });
+
+    it("should parse JSON with leading whitespace", () => {
+      const result = parseCapabilities('  {"*":["*"]}');
+      expect(result).toEqual({ "*": ["*"] });
+    });
+
+    it("should throw on invalid JSON", () => {
+      expect(() => parseCapabilities("{invalid-json")).toThrow(
+        "Invalid capabilities JSON format. Please provide a valid JSON string.",
+      );
+    });
+
+    it("should preserve the original parse error as cause", () => {
+      let thrown: Error | undefined;
+      try {
+        parseCapabilities("{invalid-json");
+      } catch (error) {
+        thrown = error as Error;
+      }
+      expect(thrown).toBeDefined();
+      expect(thrown!.cause).toBeInstanceOf(SyntaxError);
+    });
+  });
+
+  describe("comma-separated input", () => {
+    it("should parse a single capability", () => {
+      expect(parseCapabilities("publish")).toEqual({ "*": ["publish"] });
+    });
+
+    it("should parse multiple comma-separated capabilities", () => {
+      expect(parseCapabilities("publish,subscribe,history")).toEqual({
+        "*": ["publish", "subscribe", "history"],
+      });
+    });
+
+    it("should trim whitespace around capabilities", () => {
+      expect(parseCapabilities(" publish , subscribe ")).toEqual({
+        "*": ["publish", "subscribe"],
+      });
+    });
+
+    it("should filter out empty entries from extra commas", () => {
+      expect(parseCapabilities("publish,,subscribe")).toEqual({
+        "*": ["publish", "subscribe"],
+      });
+    });
+
+    it("should throw on empty capabilities", () => {
+      expect(() => parseCapabilities(",,")).toThrow(
+        "Capabilities must contain at least one non-empty capability.",
+      );
+    });
+
+    it("should throw on whitespace-only input", () => {
+      expect(() => parseCapabilities("  ")).toThrow(
+        "Capabilities must contain at least one non-empty capability.",
+      );
+    });
+  });
+});


### PR DESCRIPTION
- Fixes https://ably.atlassian.net/browse/DX-1097
- Earlier `keys create` supported `json capability` and `keys update` supported `comma-separated capability` individually.
- Now both commands support both`json` and `comma-separated` capability support