### PR TITLE
Extend Dependabot workflow to auto-fix build, lint, and test failures

### DIFF
--- a/.github/workflows/dependabot-lockfile.yml
+++ b/.github/workflows/dependabot-lockfile.yml
@@ -11,11 +11,38 @@ permissions:
 jobs:
   fix-dependabot:
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]'
     timeout-minutes: 15
 
     steps:
+      - name: Check if Dependabot PR
+        id: guard
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_AUTHOR=$(gh pr view ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --json author --jq '.author.login')
+          if [[ "$PR_AUTHOR" != "app/dependabot" ]]; then
+            echo "Not a Dependabot PR (author: $PR_AUTHOR), nothing to do."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Prevent infinite loops: count how many times this workflow has already
+          # run successfully on this branch (max 2 attempts: initial + one retry)
+          RUN_COUNT=$(gh run list \
+            --workflow dependabot-lockfile.yml \
+            --branch "${{ github.event.pull_request.head.ref }}" \
+            --json conclusion \
+            --jq '[.[] | select(.conclusion == "success")] | length')
+          if [[ "$RUN_COUNT" -ge 2 ]]; then
+            echo "Already ran $RUN_COUNT times on this branch, skipping to prevent loop."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
       - name: Generate App Token
+        if: steps.guard.outputs.skip != 'true'
         id: generate-token
         uses: actions/create-github-app-token@v3
         with:
@@ -23,30 +50,36 @@ jobs:
           private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
 
       - name: Checkout Dependabot branch
+        if: steps.guard.outputs.skip != 'true'
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           token: ${{ steps.generate-token.outputs.token }}
 
       - name: Set up pnpm
+        if: steps.guard.outputs.skip != 'true'
         uses: pnpm/action-setup@v5
         with:
           version: 10
 
       - name: Set up Node.js
+        if: steps.guard.outputs.skip != 'true'
         uses: actions/setup-node@v6
         with:
           node-version: "22.x"
 
       - name: Configure git identity
+        if: steps.guard.outputs.skip != 'true'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Regenerate lockfile
+        if: steps.guard.outputs.skip != 'true'
         run: pnpm install --no-frozen-lockfile --ignore-scripts
 
       - name: Commit lockfile changes
+        if: steps.guard.outputs.skip != 'true'
         id: lockfile
         run: |
           if git diff --quiet pnpm-lock.yaml; then
@@ -59,6 +92,7 @@ jobs:
           fi
 
       - name: Try building
+        if: steps.guard.outputs.skip != 'true'
         id: build
         continue-on-error: true
         run: |
@@ -67,22 +101,26 @@ jobs:
           pnpm run build 2>&1 | tee /tmp/build-output.txt
 
       - name: Try linting
+        if: steps.guard.outputs.skip != 'true' && steps.build.outcome == 'success'
         id: lint
-        if: steps.build.outcome == 'success'
         continue-on-error: true
         run: |
           set -o pipefail
           pnpm exec eslint . 2>&1 | tee /tmp/lint-output.txt
 
       - name: Try testing
+        if: steps.guard.outputs.skip != 'true' && steps.build.outcome == 'success'
         id: test
-        if: steps.build.outcome == 'success'
         continue-on-error: true
         run: |
           set -o pipefail
-          pnpm test:unit 2>&1 | tee /tmp/test-output.txt
+          failed=0
+          pnpm test:unit 2>&1 | tee /tmp/test-output.txt || failed=1
+          pnpm --filter @ably/react-web-cli test 2>&1 | tee -a /tmp/test-output.txt || failed=1
+          exit $failed
 
       - name: Check if fixes needed
+        if: steps.guard.outputs.skip != 'true'
         id: needs-fix
         run: |
           if [[ "${{ steps.build.outcome }}" == "failure" || "${{ steps.lint.outcome }}" == "failure" || "${{ steps.test.outcome }}" == "failure" ]]; then


### PR DESCRIPTION
## Summary

- Adds build, lint, and test steps to the Dependabot workflow so Claude can diagnose and fix failures from dependency bumps (e.g. React 18→19 in #308)
- Checks PR author instead of triggering actor so the workflow re-runs after our bot pushes fixes (not just on the initial Dependabot push)
- Limits to 2 successful runs per branch to prevent infinite loops
- Job always runs (no job-level `if`) so the PR status shows green instead of "skipped"

## Test plan

- [ ] Merge this PR
- [ ] Comment `@dependabot recreate` on #308
- [ ] Verify the workflow detects test failures and invokes Claude to fix them