### PR TITLE
Fix Claude action input: direct_prompt → prompt

### DIFF
--- a/.github/workflows/dependabot-lockfile.yml
+++ b/.github/workflows/dependabot-lockfile.yml
@@ -161,7 +161,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ steps.generate-token.outputs.token }}
-          direct_prompt: |
+          prompt: |
             This is a Dependabot PR that bumps dependencies. The lockfile has been
             regenerated but the build, lint, or tests are failing.
 


### PR DESCRIPTION
## Summary

`direct_prompt` is not a valid input for `anthropics/claude-code-action@v1`. The action silently ignored it, found no trigger, and skipped — which is why Claude never actually ran on PR #326 despite the workflow succeeding.

The correct input is `prompt`, which enables automation mode (runs immediately without needing an `@claude` mention).

## Test plan

- [ ] Merge this PR
- [ ] Comment `@dependabot recreate` on #326
- [ ] Verify Claude actually executes and attempts to fix the test failures