### PR TITLE
fix(ci): allow dependabot bot in Claude Code Action

### DIFF
--- a/.github/workflows/dependabot-lockfile.yml
+++ b/.github/workflows/dependabot-lockfile.yml
@@ -161,6 +161,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ steps.generate-token.outputs.token }}
+          allowed_bots: "dependabot[bot]"
           prompt: |
             This is a Dependabot PR that bumps dependencies. The lockfile has been
             regenerated but the build, lint, or tests are failing.


### PR DESCRIPTION
## Summary
- Adds `allowed_bots: "dependabot[bot]"` to the Claude Code Action step in the Fix Dependabot PRs workflow
- The action was rejecting runs triggered by dependabot because bot actors must be explicitly allowlisted
- This was causing PR #314 (and likely other dependabot PRs) to fail the `fix-dependabot` check

## Test plan
- [ ] Re-run the `fix-dependabot` workflow on an existing dependabot PR and verify the Claude Code Action step no longer fails with "non-human actor" error