### PR TITLE
[DX-1101] Fix keys revoke to use correct Control API endpoint

### DIFF
--- a/src/services/control-api.ts
+++ b/src/services/control-api.ts
@@ -423,7 +423,7 @@ export class ControlApi {
 
   // Revoke a key
   async revokeKey(appId: string, keyId: string): Promise<void> {
-    return this.request<void>(`/apps/${appId}/keys/${keyId}`, "DELETE");
+    return this.request<void>(`/apps/${appId}/keys/${keyId}/revoke`, "POST");
   }
 
   // Update an app
@@ -588,6 +588,11 @@ export class ControlApi {
       return {} as T;
     }
 
-    return (await response.json()) as T;
+    const text = await response.text();
+    if (!text) {
+      return {} as T;
+    }
+
+    return JSON.parse(text) as T;
   }
 }

--- a/test/unit/commands/auth/keys/revoke.test.ts
+++ b/test/unit/commands/auth/keys/revoke.test.ts
@@ -37,7 +37,7 @@ describe("auth:keys:revoke command", () => {
 
       // Mock revoke key
       nockControl()
-        .delete(`/v1/apps/${appId}/keys/${mockKeyId}`)
+        .post(`/v1/apps/${appId}/keys/${mockKeyId}/revoke`)
         .reply(200, {});
 
       const { stdout } = await runCommand(
@@ -59,7 +59,7 @@ describe("auth:keys:revoke command", () => {
       ]);
 
       nockControl()
-        .delete(`/v1/apps/${appId}/keys/${mockKeyId}`)
+        .post(`/v1/apps/${appId}/keys/${mockKeyId}/revoke`)
         .reply(200, {});
 
       const { stdout } = await runCommand(
@@ -76,7 +76,7 @@ describe("auth:keys:revoke command", () => {
       mockKeysList(appId, [buildMockKey(appId, mockKeyId)]);
 
       nockControl()
-        .delete(`/v1/apps/${appId}/keys/${mockKeyId}`)
+        .post(`/v1/apps/${appId}/keys/${mockKeyId}/revoke`)
         .reply(200, {});
 
       const { stdout } = await runCommand(

--- a/test/unit/services/control-api.test.ts
+++ b/test/unit/services/control-api.test.ts
@@ -362,7 +362,7 @@ describe("ControlApi", function () {
 
       // Set up nock to intercept request
       nock(`https://${controlHost}`)
-        .delete(`/v1/apps/${appId}/keys/${keyId}`)
+        .post(`/v1/apps/${appId}/keys/${keyId}/revoke`)
         .reply(500, { message: "Failed to revoke key" });
 
       // Intercept any calls to /me


### PR DESCRIPTION
- Fixes https://ably.atlassian.net/browse/DX-1101
- Fixed `revokeKey` to use `POST /apps/{app_id}/keys/{key_id}/revoke` instead of                                    
  `DELETE /apps/{app_id}/keys/{key_id}`, matching the actual Control API spec                                     
- Handle empty 200 response body from the revoke endpoint (`head :ok`)                                              
- Updated unit test mocks to match the corrected endpoint
- Seems E2E test for this will be addressed as a part of https://github.com/ably/ably-cli/pull/250