### PR TITLE
fix(ci): add ci-lockfile-regen bot to allowed_bots

### DIFF
--- a/.github/workflows/dependabot-lockfile.yml
+++ b/.github/workflows/dependabot-lockfile.yml
@@ -296,7 +296,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ steps.generate-token.outputs.token }}
-          allowed_bots: "dependabot[bot]"
+          allowed_bots: "dependabot[bot],ci-lockfile-regen[bot]"
           prompt: |
             You are fixing a Dependabot PR where CI checks are failing after a dependency
             bump. The lockfile has already been regenerated. Your job is to understand what


### PR DESCRIPTION
## Summary

- Adds `ci-lockfile-regen[bot]` to the `allowed_bots` list in the Claude Code Action step
- When the GitHub App pushes a lockfile commit, the workflow re-triggers with `ci-lockfile-regen[bot]` as the actor, causing Claude Code Action to reject it with: `Workflow initiated by non-human actor: ci-lockfile-regen (type: Bot)`

## Test plan

- [ ] Trigger a dependabot PR that needs a lockfile regen and verify the `fix-failures` job's Claude step no longer fails with the bot actor error