### PR TITLE
ci: surface dependabot fix workflow in PR checks list

### DIFF
--- a/.github/workflows/dependabot-claude-fix.yml
+++ b/.github/workflows/dependabot-claude-fix.yml
@@ -23,7 +23,7 @@ on:
 
 permissions:
   actions: read
-  checks: read
+  checks: write
   contents: write
   pull-requests: write
 
@@ -258,6 +258,32 @@ jobs:
             echo "${delim_l}"
           } >> "$GITHUB_OUTPUT"
 
+      # Create a check run on the PR's HEAD SHA so the fix job is visible in
+      # the PR checks list. workflow_run-triggered runs are otherwise attached
+      # to the default branch, not the PR, so nothing shows up in the PR UI
+      # until we emit an explicit check run.
+      - name: Open in-progress check on PR head SHA
+        id: check-run
+        if: steps.gate.outputs.proceed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          FAILED_SUMMARY: ${{ steps.gate.outputs.failure_summary }}
+        run: |
+          set -euo pipefail
+          CHECK_ID=$(gh api -X POST "repos/$REPO/check-runs" \
+            -f name="Fix Dependabot PRs" \
+            -f head_sha="$HEAD_SHA" \
+            -f status=in_progress \
+            -f details_url="$RUN_URL" \
+            -f "output[title]=Analysing CI failures and preparing fix" \
+            -f "output[summary]=${FAILED_SUMMARY:-Gathering failure logs...}" \
+            --jq '.id')
+          echo "id=$CHECK_ID" >> "$GITHUB_OUTPUT"
+          echo "Opened check run $CHECK_ID on $HEAD_SHA"
+
       - name: Generate App Token
         if: steps.gate.outputs.proceed == 'true'
         id: generate-token
@@ -290,6 +316,7 @@ jobs:
         run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Fix failures with Claude
+        id: claude
         if: steps.gate.outputs.proceed == 'true'
         uses: anthropics/claude-code-action@v1
         with:
@@ -475,3 +502,51 @@ jobs:
             --max-turns 50
             --model claude-sonnet-4-6
             --allowedTools "Bash,Read,Write,Edit,Glob,Grep,WebSearch,WebFetch"
+
+      # Close out the check run we opened above. Runs even if a prior step
+      # failed or the job was cancelled, so the PR's checks list never shows
+      # a perpetually-in-progress row.
+      - name: Close check run
+        if: always() && steps.check-run.outputs.id != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          CHECK_ID: ${{ steps.check-run.outputs.id }}
+          CLAUDE_OUTCOME: ${{ steps.claude.outcome }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          case "$CLAUDE_OUTCOME" in
+            success)
+              CONCLUSION=success
+              TITLE="Claude finished"
+              SUMMARY="See the PR comment for the fix assessment, or the [run logs]($RUN_URL) for full detail."
+              ;;
+            failure)
+              CONCLUSION=failure
+              TITLE="Fix step errored"
+              SUMMARY="The Claude step failed. Check the [run logs]($RUN_URL)."
+              ;;
+            cancelled)
+              CONCLUSION=cancelled
+              TITLE="Cancelled"
+              SUMMARY="The fix run was cancelled, usually because a newer workflow_run event superseded it."
+              ;;
+            *)
+              # Any other state (e.g. skipped because the Claude step's own
+              # `if:` evaluated to false) shouldn't really happen once the
+              # gate proceeded, but emit a neutral conclusion to keep the
+              # check row meaningful.
+              CONCLUSION=neutral
+              TITLE="No fix applied"
+              SUMMARY="Gate opened but the Claude step did not run. See [run logs]($RUN_URL)."
+              ;;
+          esac
+
+          gh api -X PATCH "repos/$REPO/check-runs/$CHECK_ID" \
+            -f status=completed \
+            -f conclusion="$CONCLUSION" \
+            -f "output[title]=$TITLE" \
+            -f "output[summary]=$SUMMARY" \
+            > /dev/null
+          echo "Closed check $CHECK_ID with conclusion=$CONCLUSION"


### PR DESCRIPTION
## Summary

Make the `Fix Dependabot PRs` workflow visible in the PR's checks list while it's running, via an explicit Checks-API check run on the PR's HEAD SHA.

## Motivation

The fix job in `dependabot-claude-fix.yml` is triggered by `workflow_run`. For GitHub that means the run is attached to the **default branch**, not the PR — its `head_sha` is `main`'s HEAD, not the PR's latest commit. GitHub's PR checks list only shows runs whose `head_sha` matches the PR branch, so while Claude is investigating and fixing a dependabot PR there is no visible indicator on the PR itself. The only way to see what's happening is to dig into the Actions tab and find the run manually.

Tested live against PR #349: the fix ran end-to-end and Claude pushed a working fix commit, but the only sign of it on the PR was the assessment comment posted at the very end — no live "in progress" signal, no clickable link to the logs.

## Change

Two new steps wrapped around the existing Claude step:

1. **`Open in-progress check on PR head SHA`** (after gate passes, before App token generation): `POST /repos/:r/check-runs` with `head_sha` = the upstream workflow's head SHA, `status: in_progress`, a `details_url` pointing to the workflow run, and a summary seeded from the gate step's failure list. Captures the returned check-run id as a step output.
2. **`Close check run`** (final step, `if: always()` so it runs even on error/cancel): `PATCH /repos/:r/check-runs/:id` with `status: completed` and a conclusion mapped from `steps.claude.outcome`:

   | `claude.outcome` | check conclusion |
   |---|---|
   | `success` | `success` |
   | `failure` | `failure` |
   | `cancelled` | `cancelled` |
   | (anything else) | `neutral` |

   The `always()` gate guarantees the row never sticks as perpetually `in_progress` — even a cancelled-by-concurrency run closes its check out cleanly.

Required permission bump: `checks: read` → `checks: write` on the workflow's top-level `permissions` block. Uses the default `GITHUB_TOKEN`; `workflow_run` runs in the trusted default-branch context, so the token picks up `checks: write` without needing the App token.

## What the user sees

Once merged, the next dependabot PR that has failing CI gets:
- A **`Fix Dependabot PRs` row in the PR's checks list** the moment the gate opens, with status "in progress".
- **Clickable `Details` link** on that row, pointing straight at the workflow run logs.
- A **final ✅ / ❌ / ⚪ / 🟡 conclusion** when the run finishes, with a short title (`Claude finished` / `Fix step errored` / `Cancelled` / `No fix applied`) and a one-line summary linking back to the run.

## Test plan

- [ ] On the next failing dependabot PR, confirm a `Fix Dependabot PRs` row appears in the checks list as soon as the gate proceeds (not only after Claude finishes).
- [ ] Confirm the row's `Details` link opens the workflow run directly.
- [ ] Confirm the row transitions to a conclusion (✅ / ❌ / ⚪) when the run finishes, matching the Claude step's outcome.
- [ ] Cancel a running fix (via concurrency, by pushing a new commit) → confirm the check closes as `cancelled` rather than hanging.