### PR TITLE
fix(push publish): parse --message as a full Ably message shape

### DIFF
--- a/src/commands/push/publish.ts
+++ b/src/commands/push/publish.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 import { AblyBaseCommand } from "../../base-command.js";
 import { forceFlag, productApiFlags } from "../../flags.js";
 import { BaseFlags } from "../../types/cli.js";
+import { prepareMessageFromInput } from "../../utils/message.js";
 import { formatResource } from "../../utils/output.js";
 import { promptForConfirmation } from "../../utils/prompt-confirmation.js";
 
@@ -25,6 +26,7 @@ export default class PushPublish extends AblyBaseCommand {
     "<%= config.bin %> <%= command.id %> --channel my-channel --payload ./notification.json",
     "<%= config.bin %> <%= command.id %> --channel my-channel --title Hello --body World --message 'Hello from push'",
     '<%= config.bin %> <%= command.id %> --channel my-channel --title Hello --body World --message \'{"event":"push","text":"Hello"}\'',
+    '<%= config.bin %> <%= command.id %> --channel my-channel --title Hello --body World --message \'{"name":"alert","data":"Server down"}\'',
     '<%= config.bin %> <%= command.id %> --recipient \'{"transportType":"apns","deviceToken":"token123"}\' --title Hello --body World',
     "<%= config.bin %> <%= command.id %> --device-id device-123 --title Hello --body World --json",
   ];
@@ -49,7 +51,7 @@ export default class PushPublish extends AblyBaseCommand {
     }),
     message: Flags.string({
       description:
-        "Realtime message data to include alongside the push notification (only applies when publishing via --channel)",
+        'Realtime message to include alongside the push notification. Accepts plain text, JSON data, or a full message object ({"name":...,"data":...,"extras":...}). Only applies when publishing via --channel.',
     }),
     title: Flags.string({
       description: "Notification title",
@@ -277,16 +279,31 @@ export default class PushPublish extends AblyBaseCommand {
           }
         }
 
-        const publishMessage: Record<string, unknown> = {
-          extras: { push: payload },
-        };
+        const publishMessage: Record<string, unknown> = {};
+        let userExtras: Record<string, unknown> | undefined;
+
         if (flags.message) {
-          try {
-            publishMessage.data = JSON.parse(flags.message);
-          } catch {
-            publishMessage.data = flags.message;
+          const parsed = prepareMessageFromInput(flags.message, flags);
+          if (
+            parsed.extras &&
+            (parsed.extras as Record<string, unknown>).push !== undefined
+          ) {
+            this.fail(
+              "--message must not include extras.push; use the push flags (--title/--body/--payload/etc.) to specify push content",
+              flags as BaseFlags,
+              "pushPublish",
+            );
+          }
+          if (parsed.name !== undefined) publishMessage.name = parsed.name;
+          if (parsed.data !== undefined) publishMessage.data = parsed.data;
+          if (parsed.extras) {
+            userExtras = parsed.extras as Record<string, unknown>;
           }
         }
+
+        publishMessage.extras = userExtras
+          ? { ...userExtras, push: payload }
+          : { push: payload };
 
         await rest.channels.get(channelName).publish(publishMessage);
 
@@ -296,7 +313,12 @@ export default class PushPublish extends AblyBaseCommand {
               notification: {
                 published: true,
                 channel: channelName,
-                ...(flags.message ? { messageData: publishMessage.data } : {}),
+                ...(publishMessage.data === undefined
+                  ? {}
+                  : { messageData: publishMessage.data }),
+                ...(publishMessage.name === undefined
+                  ? {}
+                  : { messageName: publishMessage.name }),
               },
             },
             flags,

--- a/src/commands/push/publish.ts
+++ b/src/commands/push/publish.ts
@@ -26,7 +26,7 @@ export default class PushPublish extends AblyBaseCommand {
     "<%= config.bin %> <%= command.id %> --channel my-channel --payload ./notification.json",
     "<%= config.bin %> <%= command.id %> --channel my-channel --title Hello --body World --message 'Hello from push'",
     '<%= config.bin %> <%= command.id %> --channel my-channel --title Hello --body World --message \'{"event":"push","text":"Hello"}\'',
-    '<%= config.bin %> <%= command.id %> --channel my-channel --title Hello --body World --message \'{"name":"alert","data":"Server down"}\'',
+    '<%= config.bin %> <%= command.id %> --channel my-channel --title Hello --body World --message \'{"name":"greeting","data":"Welcome back"}\'',
     '<%= config.bin %> <%= command.id %> --recipient \'{"transportType":"apns","deviceToken":"token123"}\' --title Hello --body World',
     "<%= config.bin %> <%= command.id %> --device-id device-123 --title Hello --body World --json",
   ];

--- a/test/unit/commands/push/publish.test.ts
+++ b/test/unit/commands/push/publish.test.ts
@@ -257,6 +257,29 @@ describe("push:publish command", () => {
       );
     });
 
+    it("should unwrap the inner value when --message has a top-level data key", async () => {
+      const mock = getMockAblyRest();
+      const channel = mock.channels._getChannel("my-channel");
+
+      await runCommand(
+        [
+          "push:publish",
+          "--channel",
+          "my-channel",
+          "--title",
+          "Hi",
+          "--message",
+          '{"data":"extracted"}',
+          "--force",
+        ],
+        import.meta.url,
+      );
+
+      expect(channel.publish).toHaveBeenCalledWith(
+        expect.objectContaining({ data: "extracted" }),
+      );
+    });
+
     it("should ignore --message when direct recipient overrides --channel", async () => {
       const mock = getMockAblyRest();
 

--- a/test/unit/commands/push/publish.test.ts
+++ b/test/unit/commands/push/publish.test.ts
@@ -304,6 +304,86 @@ describe("push:publish command", () => {
       expect(result.notification).toHaveProperty("channel", "my-channel");
       expect(result.notification).toHaveProperty("messageData", "hello");
     });
+
+    it("should set message name and data when --message is a full message object", async () => {
+      const mock = getMockAblyRest();
+      const channel = mock.channels._getChannel("my-channel");
+
+      await runCommand(
+        [
+          "push:publish",
+          "--channel",
+          "my-channel",
+          "--title",
+          "Hi",
+          "--message",
+          '{"name":"alert","data":"Server down"}',
+          "--force",
+        ],
+        import.meta.url,
+      );
+
+      expect(channel.publish).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: "alert",
+          data: "Server down",
+          extras: expect.objectContaining({
+            push: expect.objectContaining({
+              notification: expect.objectContaining({ title: "Hi" }),
+            }),
+          }),
+        }),
+      );
+    });
+
+    it("should merge user-provided extras with push extras", async () => {
+      const mock = getMockAblyRest();
+      const channel = mock.channels._getChannel("my-channel");
+
+      await runCommand(
+        [
+          "push:publish",
+          "--channel",
+          "my-channel",
+          "--title",
+          "Hi",
+          "--message",
+          '{"data":"payload","extras":{"headers":{"x-trace":"abc"}}}',
+          "--force",
+        ],
+        import.meta.url,
+      );
+
+      const call = channel.publish.mock.calls[0][0];
+      expect(call.data).toBe("payload");
+      expect(call.extras).toEqual({
+        headers: { "x-trace": "abc" },
+        push: expect.objectContaining({
+          notification: expect.objectContaining({ title: "Hi" }),
+        }),
+      });
+    });
+
+    it("should include messageName and messageData in JSON output for full message object", async () => {
+      const { stdout } = await runCommand(
+        [
+          "push:publish",
+          "--channel",
+          "my-channel",
+          "--title",
+          "Hi",
+          "--message",
+          '{"name":"alert","data":"hi"}',
+          "--json",
+          "--force",
+        ],
+        import.meta.url,
+      );
+
+      const result = parseJsonOutput(stdout);
+      expect(result.notification).toHaveProperty("messageName", "alert");
+      expect(result.notification).toHaveProperty("messageData", "hi");
+    });
   });
 
   describe("error handling", () => {
@@ -317,6 +397,31 @@ describe("push:publish command", () => {
       expect(error?.message).toContain(
         "--message can only be used with --channel",
       );
+    });
+
+    it("should fail when --message includes extras.push", async () => {
+      const mock = getMockAblyRest();
+      const channel = mock.channels._getChannel("my-channel");
+
+      const { error } = await runCommand(
+        [
+          "push:publish",
+          "--channel",
+          "my-channel",
+          "--title",
+          "Hi",
+          "--message",
+          '{"extras":{"push":{"notification":{"title":"x"}}}}',
+          "--force",
+        ],
+        import.meta.url,
+      );
+
+      expect(error).toBeDefined();
+      expect(error?.message).toContain(
+        "--message must not include extras.push",
+      );
+      expect(channel.publish).not.toHaveBeenCalled();
     });
 
     it("should handle API errors", async () => {


### PR DESCRIPTION
## Summary

- `ably push publish --message` now parses JSON input as a full Ably message (`name`, `data`, `extras`) instead of always stuffing the parsed value into `data`. This matches the semantics of `ably channels publish` and makes it possible to set the realtime message's `name`.
- Reuses the existing `prepareMessageFromInput()` helper in `src/utils/message.ts` — no new utility.
- The CLI-built push payload is still attached as `extras.push` on the published message; any user-supplied `extras` keys are merged alongside it.
- If `--message` already contains `extras.push`, the command fails with a clear error (the CLI owns that field via `--title` / `--body` / `--payload` / etc.).
- JSON output (`--json`) now includes `messageName` and `messageData` when present, making the result self-describing (replaces the previous `messageData: true` boolean sentinel).

Follow-up to #310 (addresses the reviewer comment that `--message` couldn't set the message name).

### Behaviour change ⚠️

Moving to `prepareMessageFromInput` means any JSON object that already contains top-level `name`, `data`, or `extras` keys is now treated as a full Ably message shape. This is the point of the change, but two cases are worth calling out explicitly:

| `--message` input | Before | After |
|---|---|---|
| `'hello'` (plain string) | `data: "hello"` | `data: "hello"` — unchanged |
| `'{"key":"val"}'` (object, no reserved keys) | `data: { key: "val" }` | `data: { key: "val" }` — unchanged |
| `'{"name":"alert","data":"hi"}'` | `data: { name: "alert", data: "hi" }` | **`name: "alert"`, `data: "hi"`** — new capability |
| `'{"data":"hi"}'` | `data: { data: "hi" }` | **`data: "hi"`** — inner value unwrapped |
| `'{"extras":{"headers":{...}}}'` | `data: { extras: {...} }` | **`extras: { headers: {...}, push: ... }`** — merged |
| `'{"extras":{"push":{...}}}'` | `data: { extras: { push: {...} } }` | **Error** — CLI owns `extras.push` |

Callers who relied on the previous (arguably incorrect) behaviour where `{"data":"x"}` was stored as `data: { data: "x" }` will see the inner value unwrapped instead. The new shape matches `channels publish` and how a plain Ably realtime subscriber expects messages.

## Test plan

- [x] `pnpm prepare` (build + manifest) succeeds
- [x] `pnpm exec eslint src/commands/push/publish.ts test/unit/commands/push/publish.test.ts` — 0 errors
- [x] `pnpm test test/unit/commands/push/publish.test.ts` — 32/32 pass, including:
  - full message object sets `name` and `data`
  - bare object without reserved keys stays wrapped as `data`
  - top-level `data` key is unwrapped (behaviour-change assertion)
  - user `extras` merged with `push`
  - `extras.push` collision fails with clear error, publish is not called
  - JSON output surfaces `messageName` + `messageData`
- [x] `pnpm test:unit` — full suite green
- [ ] Manual smoke against a real Ably app (recommended before merge):
  - `ably push publish --channel demo --title Hi --message '{"name":"alert","data":"hi"}' --force` — verify a realtime subscriber sees `name === "alert"` and `data === "hi"`.
  - `ably push publish --channel demo --title Hi --message '{"extras":{"push":{"notification":{"title":"x"}}}}' --force` — verify the collision error and non-zero exit.