### PR TITLE
Fix e2e helper false-matching 401/403 inside random UUIDs

### DIFF
--- a/test/helpers/e2e-test-helper.ts
+++ b/test/helpers/e2e-test-helper.ts
@@ -425,11 +425,13 @@ async function attemptProcessStart(
           // Also check for common error patterns that indicate immediate failure
           // Note: We need to be careful about false positives. The channel subscribe command
           // outputs legitimate error messages like "✗ Failed to attach to channel" during
-          // normal operation when testing error scenarios.
-          const criticalErrors = [
+          // normal operation when testing error scenarios. Numeric HTTP status codes use
+          // word boundaries so they don't false-match substrings inside random UUIDs
+          // (e.g. a channel name like "subscribe-test-...ee745401c274" contains "401").
+          const criticalErrors: (string | RegExp)[] = [
             "authentication failed",
-            "401",
-            "403",
+            /\b401\b/,
+            /\b403\b/,
             "Command failed",
             "ENOENT",
             "Cannot find module",
@@ -440,8 +442,10 @@ async function attemptProcessStart(
           ];
 
           // Check for critical errors that indicate the process can't continue
-          const hasCriticalError = criticalErrors.some((error) =>
-            output.includes(error),
+          const hasCriticalError = criticalErrors.some((pattern) =>
+            typeof pattern === "string"
+              ? output.includes(pattern)
+              : pattern.test(output),
           );
 
           // For generic "Error:" or "error:", only fail if we haven't seen the ready signal yet


### PR DESCRIPTION
## Summary

`attemptProcessStart` in `test/helpers/e2e-test-helper.ts` polls the started process's output for critical error substrings, including the bare strings `"401"` and `"403"` (intended to catch HTTP Unauthorized / Forbidden). The check was `output.includes(...)`, so any randomly-generated UUID containing `401` or `403` as a substring tripped a false positive and the helper aborted the start-up with `"failed with error pattern in output"`.

Example failure on `channel-subscribe-e2e`:

```
Failed to start process after 2 attempts. Last error: Process bin/run.js
channels subscribe subscribe-test-899305ef-bbbe-41c8-a831-ee745401c274
failed with error pattern in output. Full Output:
Attaching to channel: subscribe-test-899305ef-bbbe-41c8-a831-ee745401c274...
```

The UUID contained `...ee745401c274` — the `401` inside the hex is what tripped the check.

## Change

Replaced the two offending entries with regexes that use word boundaries:

```diff
-  "401",
-  "403",
+  /\b401\b/,
+  /\b403\b/,
```

and updated the `.some()` caller to handle both strings and regex patterns.

Verified behaviour:

| input | matches? |
|---|---|
| `subscribe-test-...ee745401c274...` | false |
| `status 401 Unauthorized` | true |
| `(401,` | true |
| ` 401 ` | true |

## Test plan

- [x] `pnpm exec eslint test/helpers/e2e-test-helper.ts` — clean
- [x] Node check: `\b401\b` does not match hex-embedded `401` but matches real error text
- [ ] CI: e2e suite that previously flaked on UUID-containing-`401`/`403` should now pass stably