### PR TITLE
fix(rooms typing): don't emit status:"listening" for single-shot keystroke

### DIFF
--- a/src/commands/rooms/typing/keystroke.ts
+++ b/src/commands/rooms/typing/keystroke.ts
@@ -138,10 +138,9 @@ export default class TypingKeystroke extends ChatBaseCommand {
           "Will automatically remain typing until terminated.",
           flags,
         );
-      } else {
-        this.logListening(
+      } else if (!this.shouldOutputJson(flags)) {
+        this.log(
           "Sent a single typing indicator. Use --auto-type to keep typing automatically.",
-          flags,
         );
       }
 


### PR DESCRIPTION
## Summary

- The non-auto-type branch of `ably rooms typing keystroke` called `logListening`, which emits `status: "listening"` in JSON mode.
- But the command exits immediately after sending the single keystroke — so agent consumers were getting a false liveness signal.
- Swap `logListening` for a plain `this.log()` guarded by `!shouldOutputJson`, preserving the human-readable hint about `--auto-type` while letting the JSON envelope correctly represent a completed one-shot operation (via `success: true` and the auto-emitted `completed` status).

## Test plan

- [x] `pnpm prepare` succeeds
- [x] `pnpm exec eslint .` reports 0 errors
- [x] `pnpm test:unit` passes (2300 tests)
- [ ] Manual smoke: `ably rooms typing keystroke my-room --json | jq` no longer emits a `listening` status line for the single-shot case