### PR TITLE
[DX-1135] Fix arg names not converting to snake_case in error output

### DIFF
--- a/src/hooks/init/patch-arg-names.ts
+++ b/src/hooks/init/patch-arg-names.ts
@@ -3,18 +3,18 @@ import { Hook } from "@oclif/core";
 import { camelToSnake } from "../../help.js";
 
 /**
- * When generating docs (GENERATING_DOC=true), patch camelCase arg names to
- * snake_case so oclif's toUpperCase() produces UPPER_SNAKE_CASE in headings/TOC.
+ * oclif init hook (registered in package.json under oclif.hooks.init).
+ * Runs on every CLI invocation after loading the manifest, before command execution.
  *
- * This complements the same patch in CustomHelp.formatCommand() (src/help.ts),
- * which only covers the help body. The readme generator's commandUsage() has its
- * own toUpperCase() call that runs before formatCommand, so we patch here — in
- * the init hook — to cover all code paths.
+ * Converts camelCase arg names to snake_case on config.commands metadata
+ * (e.g., keyName → key_name) so oclif renders UPPER_SNAKE_CASE in USAGE and
+ * ARGUMENTS sections. This covers missing-arg error output and doc generation
+ * (`pnpm generate-doc`), both of which use the base Help class and bypass our
+ * CustomHelp. CustomHelp.formatCommand() applies the same idempotent transform
+ * for the --help path.
  */
 // eslint-disable-next-line @typescript-eslint/require-await -- oclif Hook type requires async
 const hook: Hook<"init"> = async function ({ config }) {
-  if (process.env.GENERATING_DOC !== "true") return;
-
   for (const command of config.commands) {
     for (const arg of Object.values(command.args)) {
       arg.name = camelToSnake(arg.name);


### PR DESCRIPTION
- Fixes https://ably.atlassian.net/browse/DX-1135
- Fixes `camelCase` arg names appearing in error output when required args are missing.
- Following is BEFORE/AFTER output for `pnpm cli auth keys create` without explicit `--help` flag

**Before:**
```
> bin/run.js auth keys create

 ›   Error: Missing 1 required arg:
 ›   keyName  Name of the key
 ›   See more help with --help

USAGE
  $ ably auth keys create KEYNAME [-v] [--json | --pretty-json] [--app <value>]
    [--capabilities <value>]

ARGUMENTS
  KEYNAME  Name of the key
```

**After:**
```
> bin/run.js auth keys create

 ›   Error: Missing 1 required arg:
 ›   keyName  Name of the key
 ›   See more help with --help

USAGE
  $ ably auth keys create KEY_NAME [-v] [--json | --pretty-json] [--app <value>]
    [--capabilities <value>]

ARGUMENTS
  KEY_NAME  Name of the key
```

- Now it renders `KEY_NAME` properly in `snake_case`.
- The init hook that patches arg names to snake_case was gated behind `GENERATING_DOC=true`, so it only ran during doc generation — not during normal CLI usage.

## Context

oclif's error handler creates a base `Help` instance (not our `CustomHelp`)
to render USAGE/ARGUMENTS sections alongside missing-arg errors. Since it reads
from `config.commands`, the init hook is the right place to patch arg names
for this code path.

The existing `camelToSnake` patch in `CustomHelp.formatCommand()` is retained
as defense in depth — `camelToSnake` is idempotent so the double-patch is harmless.