### PR TITLE
Support account alias argument for `stats account`

### DIFF
--- a/src/commands/stats/account.ts
+++ b/src/commands/stats/account.ts
@@ -1,14 +1,29 @@
+import { Args } from "@oclif/core";
+
 import { StatsBaseCommand } from "../../stats-base-command.js";
 import type { StatsDisplayData } from "../../services/stats-display.js";
 import type { BaseFlags } from "../../types/cli.js";
-import type { ControlApi } from "../../services/control-api.js";
+import { ControlApi } from "../../services/control-api.js";
 import { formatResource } from "../../utils/output.js";
 
 export default class StatsAccountCommand extends StatsBaseCommand {
+  static args = {
+    accountAliasOrId: Args.string({
+      description:
+        "Account alias or ID to get stats for (uses current account if not provided)",
+      required: false,
+    }),
+  };
+
   static description = "Get account stats with optional live updates";
 
   static examples = [
     "$ ably stats account",
+    "$ ably stats account mycompany",
+    "$ ably stats account VgQpOZ",
+    "$ ably stats account mycompany --start 1h",
+    "$ ably stats account mycompany --json",
+    "$ ably stats account mycompany --live",
     "$ ably stats account --unit hour",
     '$ ably stats account --start "2023-01-01T00:00:00Z" --end "2023-01-02T00:00:00Z"',
     "$ ably stats account --start 1h",
@@ -47,9 +62,32 @@ export default class StatsAccountCommand extends StatsBaseCommand {
   }
 
   async run(): Promise<void> {
-    const { flags } = await this.parse(StatsAccountCommand);
+    const { args, flags } = await this.parse(StatsAccountCommand);
+
+    let controlApi: ControlApi;
+
+    if (args.accountAliasOrId) {
+      const resolvedAlias = this.resolveAccountAlias(
+        args.accountAliasOrId,
+        flags,
+      );
+      const accessToken = this.configManager.getAccessToken(resolvedAlias);
+      if (!accessToken) {
+        this.fail(
+          `No access token found for account "${resolvedAlias}". Please log in again with "ably accounts login".`,
+          flags,
+          "statsAccount",
+        );
+      }
+      controlApi = new ControlApi({
+        accessToken,
+        controlHost: flags["control-host"],
+      });
+    } else {
+      controlApi = this.createControlApi(flags);
+    }
+
     try {
-      const controlApi = this.createControlApi(flags);
       await this.runStats(flags, controlApi);
     } catch (error) {
       this.fail(error, flags, "statsAccount");

--- a/test/unit/commands/stats/account.test.ts
+++ b/test/unit/commands/stats/account.test.ts
@@ -4,12 +4,14 @@ import {
   controlApiCleanup,
 } from "../../../helpers/control-api-test-helpers.js";
 import { runCommand } from "@oclif/test";
+import { getMockConfigManager } from "../../../helpers/mock-config-manager.js";
 import {
   standardHelpTests,
   standardArgValidationTests,
   standardFlagTests,
   standardControlApiErrorTests,
 } from "../../../helpers/standard-tests.js";
+import { parseNdjsonLines } from "../../../helpers/ndjson.js";
 import { mockStats as mockStatsFactory } from "../../../fixtures/control-api.js";
 
 describe("stats:account command", () => {
@@ -138,6 +140,115 @@ describe("stats:account command", () => {
           scope.reply(500, { error: "Internal Server Error" });
         else scope.replyWithError("Network error");
       },
+    });
+  });
+
+  describe("querying stats for a specific account", () => {
+    const altAlias = "altaccount";
+    const altAccountId = "alt-account-id";
+    const altAccountName = "Alt Account";
+    const altToken = "alt_access_token";
+
+    beforeEach(() => {
+      // Do NOT set ABLY_ACCESS_TOKEN — it overrides config-based tokens
+      delete process.env.ABLY_ACCESS_TOKEN;
+      controlApiCleanup();
+      getMockConfigManager().storeAccount(altToken, altAlias, {
+        accountId: altAccountId,
+        accountName: altAccountName,
+        userEmail: "alt@example.com",
+      });
+    });
+
+    afterEach(() => {
+      controlApiCleanup();
+    });
+
+    it("should query stats for a specific account by alias", async () => {
+      // getStatsLabel + getAccountStats both call /v1/me
+      nockControl()
+        .get("/v1/me")
+        .times(2)
+        .reply(200, {
+          account: { id: altAccountId, name: altAccountName },
+          user: { email: "alt@example.com" },
+        });
+
+      const scope = nockControl()
+        .get(`/v1/accounts/${altAccountId}/stats`)
+        .query(true)
+        .reply(200, mockStatsData);
+
+      const { stdout, error } = await runCommand(
+        ["stats:account", altAlias, "--start", "1h"],
+        import.meta.url,
+      );
+
+      expect(error).toBeUndefined();
+      expect(scope.isDone()).toBe(true);
+      expect(stdout).toContain("2023-01-01");
+    });
+
+    it("should query stats for a specific account by account ID", async () => {
+      nockControl()
+        .get("/v1/me")
+        .times(2)
+        .reply(200, {
+          account: { id: altAccountId, name: altAccountName },
+          user: { email: "alt@example.com" },
+        });
+
+      const scope = nockControl()
+        .get(`/v1/accounts/${altAccountId}/stats`)
+        .query(true)
+        .reply(200, mockStatsData);
+
+      const { stdout, error } = await runCommand(
+        ["stats:account", altAccountId, "--start", "1h"],
+        import.meta.url,
+      );
+
+      expect(error).toBeUndefined();
+      expect(scope.isDone()).toBe(true);
+      expect(stdout).toContain("2023-01-01");
+    });
+
+    it("should error when account not found", async () => {
+      const { stdout } = await runCommand(
+        ["stats:account", "nonexistent", "--json"],
+        import.meta.url,
+      );
+
+      const result = parseNdjsonLines(stdout).find(
+        (r) => r.type === "result" || r.type === "error",
+      )!;
+      expect(result).toHaveProperty("success", false);
+      expect(result.error.message).toContain("not found");
+    });
+
+    it("should error when account has no access token", async () => {
+      getMockConfigManager().setConfig({
+        current: { account: altAlias },
+        accounts: {
+          [altAlias]: {
+            accessToken: "",
+            accountId: altAccountId,
+            accountName: altAccountName,
+            userEmail: "alt@example.com",
+          },
+        },
+      });
+
+      const { stdout } = await runCommand(
+        ["stats:account", altAlias, "--json"],
+        import.meta.url,
+      );
+
+      const result = parseNdjsonLines(stdout).find(
+        (r) => r.type === "result" || r.type === "error",
+      )!;
+      expect(result).toHaveProperty("success", false);
+      expect(result.error.message).toContain("No access token");
     });
   });
 });


### PR DESCRIPTION
## Problem
                                                                                                                    
- `ably stats app [APP_NAME_OR_ID]` accepts an optional app identifier — users can query stats for any app by name or ID directly. 
- But `ably stats account` accepts no argument — users can only query stats for the *current* account. 
- To query a different account's stats, they must first run `ably accounts switch other-account`.                       
                                                                                                                  
**This is an inconsistency in the CLI's UX.**                                                    
 
## Implementation                                                                                                         
                                                                                                                  
Add an optional `accountAliasOrId` positional argument to `ably stats account`, similar to `ably stats apps`

```
ably stats account [ACCOUNT_ALIAS_OR_ID]
``` 

## Changes                                                                                                          
                                                                                                                  
- Add optional `ACCOUNT_ALIAS_OR_ID` positional argument to `stats account`                                         
- Resolve alias or account ID via `resolveAccountAlias()` (from #369), then use that account's stored access token
to construct a `ControlApi` for the stats query                                                                     
- When no argument is provided, existing behavior is preserved (uses current account)

TODO

- [ ] Need to check if explicit login required for getting `access-token` for different account.
- [ ] Test multiple account stats
- [ ]  Shouldn't log `full key` anywhere in commands ( security )