### PR TITLE
ci: skip PR overview for Dependabot

### DIFF
--- a/.github/workflows/pr-overview.yml
+++ b/.github/workflows/pr-overview.yml
@@ -12,7 +12,11 @@ permissions:
 jobs:
   generate-overview:
     name: Generate PR Overview
-    if: github.event.pull_request.draft == false
+    # Dependabot PRs don't have access to CLAUDE_APP_ID / CLAUDE_APP_PRIVATE_KEY
+    # (those secrets aren't mirrored into the Dependabot secret scope), so the
+    # job would always fail with "'client-id' input must be set to a non-empty
+    # string". A generated overview isn't useful for dependency bumps anyway.
+    if: github.event.pull_request.draft == false && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
## Summary

Failures seen on Dependabot PRs (e.g. #371).

**Fix 1 (code change in this PR):** the `Generate PR Overview` job now skips for Dependabot PRs.

The job uses `actions/create-github-app-token` with `CLAUDE_APP_ID` / `CLAUDE_APP_PRIVATE_KEY`, which are only set in the **Actions** secret scope. Dependabot has its own separate secret scope, and those two secrets aren't mirrored there — so on every Dependabot PR the step fails with `'client-id' input must be set to a non-empty string`. A generated PR overview isn't useful for dependency bumps, so skipping is the right call.


## Test plan

- [ ] Merge to main; next Dependabot PR should show `Generate PR Overview` as skipped (not failed)
- [ ] Confirm non-Dependabot PRs continue to run `Generate PR Overview` as before