### PR TITLE
Stop duplicating "Press Ctrl+C to exit." in holding messages

### DIFF
--- a/src/commands/channels/presence/enter.ts
+++ b/src/commands/channels/presence/enter.ts
@@ -193,12 +193,9 @@ export default class ChannelsPresenceEnter extends AblyBaseCommand {
         }
       }
       if (flags["show-others"]) {
-        this.logListening(
-          "Listening for presence events. Press Ctrl+C to exit.",
-          flags,
-        );
+        this.logListening("Listening for presence events.", flags);
       } else {
-        this.logHolding("Holding presence. Press Ctrl+C to exit.", flags);
+        this.logHolding("Holding presence.", flags);
       }
 
       // Wait until the user interrupts or the optional duration elapses

--- a/src/commands/rooms/presence/enter.ts
+++ b/src/commands/rooms/presence/enter.ts
@@ -197,7 +197,7 @@ export default class RoomsPresenceEnter extends ChatBaseCommand {
       if (flags["show-others"]) {
         this.logListening("Listening for presence events.", flags);
       } else {
-        this.logHolding("Holding presence. Press Ctrl+C to exit.", flags);
+        this.logHolding("Holding presence.", flags);
       }
 
       // Wait until the user interrupts or the optional duration elapses

--- a/src/commands/spaces/cursors/set.ts
+++ b/src/commands/spaces/cursors/set.ts
@@ -273,9 +273,7 @@ export default class SpacesCursorsSet extends SpacesBaseCommand {
 
       // Hold in both simulate and non-simulate modes
       this.logHolding(
-        flags.simulate
-          ? "Simulating cursor movement. Press Ctrl+C to exit."
-          : "Holding cursor. Press Ctrl+C to exit.",
+        flags.simulate ? "Simulating cursor movement." : "Holding cursor.",
         flags,
       );
 

--- a/src/commands/spaces/locations/set.ts
+++ b/src/commands/spaces/locations/set.ts
@@ -70,7 +70,7 @@ export default class SpacesLocationsSet extends SpacesBaseCommand {
         );
         this.log(`${formatLabel("Location")} ${JSON.stringify(location)}`);
       }
-      this.logHolding("Holding location. Press Ctrl+C to exit.", flags);
+      this.logHolding("Holding location.", flags);
 
       await this.waitAndTrackCleanup(flags, "location", flags.duration);
     } catch (error) {

--- a/src/commands/spaces/locks/acquire.ts
+++ b/src/commands/spaces/locks/acquire.ts
@@ -123,7 +123,7 @@ export default class SpacesLocksAcquire extends SpacesBaseCommand {
           );
           this.log(formatLockBlock(lock));
         }
-        this.logHolding("Holding lock. Press Ctrl+C to exit.", flags);
+        this.logHolding("Holding lock.", flags);
       } catch (error) {
         this.fail(error, flags, "lockAcquire", {
           lockId,

--- a/src/commands/spaces/members/enter.ts
+++ b/src/commands/spaces/members/enter.ts
@@ -86,7 +86,7 @@ export default class SpacesMembersEnter extends SpacesBaseCommand {
           this.log(`${formatLabel("Profile")} ${JSON.stringify(profileData)}`);
         }
       }
-      this.logHolding("Holding presence. Press Ctrl+C to exit.", flags);
+      this.logHolding("Holding presence.", flags);
 
       // Wait until the user interrupts or the optional duration elapses
       await this.waitAndTrackCleanup(flags, "member", flags.duration);


### PR DESCRIPTION
## Summary
- `formatListening` (`src/utils/output.ts:18`) auto-appends "Press Ctrl+C to exit." to the message it gets, and `logHolding`/`logListening` (`src/base-command.ts`) both route through it.
- Every `logHolding` call site — and one `logListening` site in `channels/presence/enter` — passed a message that already ended with the same phrase, so the rendered output doubled it: `Holding presence. Press Ctrl+C to exit. Press Ctrl+C to exit.`
- Stripped the manual suffix from the six affected call sites. The helper still appends it once, and the holding-style sites now match the convention `logListening` callers already follow elsewhere (e.g. `"Listening for messages."`).

## Test plan
- [x] `pnpm prepare` builds clean
- [x] `pnpm exec eslint .` — 0 errors
- [x] `pnpm test:unit` — 2295 passed, 1 skipped, 1 todo
- [ ] Manual: run `ably rooms presence enter chat` and confirm the holding line reads `Holding presence. Press Ctrl+C to exit.` (single suffix)