### PR TITLE
chore(release): v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2026-05-12
+
+### Added
+
+- **`ably init`** — single-command onboarding for AI-powered development. Install the Ably CLI, authenticate, and install the Ably Agent Skills into your AI coding tools all in one command (`npx @ably/cli init`). Detects installed tools (Claude Code, Cursor, VS Code, Windsurf) and installs via the appropriate mechanism (Claude Code plugin or file copy). Verifies SLSA provenance attestations on downloaded skill bundles before installing.
+- **`ably skills install`** — install or update the Ably Agent Skills into AI coding tools independently of `ably init`. Same tool detection, install mechanisms, and SLSA attestation verification.
+- **`ably channels get-message`** — retrieve the latest version of a message on a channel by its serial (requires `mutableMessages` enabled on the channel rule).
+
 ## [1.0.0] - 2026-05-01
 
 First stable release. This is a large release that overhauls authentication, command argument conventions, output formatting, and adds several new command groups. Key user-facing changes are summarised below; review the migration notes before upgrading.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ably/cli",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Ably CLI for Pub/Sub, Chat and Spaces",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Release v1.1.0 — adds AI coding tool onboarding (`ably init` / `ably skills install`) and get-message.

See CHANGELOG.md for full details.

### Highlights

- **`ably init`** — single-command onboarding: install CLI, authenticate, and install Ably Agent Skills into detected AI coding tools (Claude Code, Cursor, VS Code, Windsurf) in one go. Verifies SLSA provenance attestations on downloaded skill bundles.
- **`ably skills install`** — install/update Ably Agent Skills independently of `ably init`.
- **`ably channels get-message`** — retrieve the latest version of a message on a channel by its serial 

## Test plan

- [ ] `pnpm prepare` succeeds
- [ ] `pnpm exec eslint .` shows 0 errors
- [ ] `pnpm test:unit` passes
- [ ] `pnpm test:e2e` passes (skills install end-to-end)
- [ ] Smoke test `npx @ably/cli@1.1.0 init` post-release

🤖 Generated with [Claude Code](https://claude.com/claude-code)