### PR TITLE
chore(release): v1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - 2026-05-13
+
+### Added
+
+- **`ably init` now completes the one-command onboarding flow by installing `@ably/cli` globally.** Run `npx @ably/cli init` once and the `ably` command is available in every shell from then on — no separate `npm install -g` needed. At-the-keyboard users get a single yes/no prompt (default Yes); `--json` mode runs the install silently for AI agents. Add `--no-install` to opt out. The install step is non-blocking — if it can't complete (e.g. `EACCES` on a system-wide Node install), init carries on with authentication and skills installation and tells the user how to install manually.
+
 ## [1.1.0] - 2026-05-12
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ably/cli",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Ably CLI for Pub/Sub, Chat and Spaces",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Draft release PR for v1.1.1. **Blocked on #394 merging to main first.** This branch is currently stacked on `feature/init-global-install` — once that lands on main, rebase this onto main and the diff will become clean.

## Changes vs v1.1.0

- **`ably init` now globally installs `@ably/cli` when launched via `npx`** (#394) — fixes the v1.1.0 onboarding gap where `npx @ably/cli init` left the user without a persistent `ably` command after init exited.
- `package.json` bumped `1.1.0` → `1.1.1`.
- `CHANGELOG.md` updated with the v1.1.1 entry.

## Release checklist

- [ ] #394 (`feature/init-global-install`) is merged to main
- [ ] This branch rebased onto the updated `main`
- [ ] CI green on this branch
- [ ] Mark this PR ready for review (remove draft)
- [ ] Merge to main
- [ ] Tag `v1.1.1` and publish to npm
- [ ] Confirm `npx @ably/cli init` actually installs globally on a fresh machine
- [ ] Confirm `npx @ably/cli init --json` produces clean NDJSON (no npm output leakage)
- [ ] Confirm `npx @ably/cli init --no-install` skips install and continues

🤖 Generated with [Claude Code](https://claude.com/claude-code)