### PR TITLE
chore(release): v1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1] - 2026-06-30
+
+### Fixed
+
+- `npx @ably/cli <command>` now runs without a redundant `ably` token, so `npx @ably/cli init` works as expected. The package previously shipped two binaries, which stopped npx from auto-selecting one. It now ships a single `ably` binary. The older forms (`npx -p @ably/cli ably <command>`, `npx @ably/cli ably <command>`, and `npm install -g @ably/cli`) all still work.
+
+### Changed
+
+- The standalone `ably-interactive` binary is no longer installed as a separate global command. Interactive mode now handles Ctrl+C in-process. This is an internal change for most users; the terminal server consumes it through a companion update.
+
 ## [1.2.0] - 2026-06-04
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ably/cli",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Ably CLI for Pub/Sub, Chat and Spaces",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Prepares the **v1.2.1** release.

## What's in this release

The only user-facing change since v1.2.0 is [#419](https://github.com/ably/ably-cli/pull/419). The other 7 commits on `main` are internal CI hardening and are not changelog-worthy.

### Fixed
- `npx @ably/cli <command>` now runs without a redundant `ably` token, so `npx @ably/cli init` works as expected. The package previously shipped two binaries, which stopped npx auto-selecting one; it now ships a single `ably` binary.

### Changed
- The standalone `ably-interactive` global binary is no longer installed as a separate command. Interactive mode handles Ctrl+C in-process. The terminal server consumes this through a companion Dockerfile change (already merged).

## This PR
- Bumps `package.json` `1.2.0` → `1.2.1`
- Adds the `1.2.1` CHANGELOG entry

(`packages/react-web-cli` is versioned independently and unaffected, so it is not bumped — consistent with the v1.2.0 release.)

## Validation
- `pnpm prepare` — build + manifest OK
- `pnpm exec eslint .` — 0 errors
- `pnpm test:unit` — 2534 passed, 1 skipped, 1 todo

## After merge
Tag the merge commit on `main` to trigger the npm publish workflow:

```bash
git tag -a v1.2.1 -m "Release v1.2.1"
git push origin v1.2.1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
