### PR TITLE
refactor(interactive): remove dead __dirname/__filename after wrapper retirement

### DIFF
--- a/src/commands/interactive.ts
+++ b/src/commands/interactive.ts
@@ -2,7 +2,6 @@ import { Command } from "@oclif/core";
 import * as readline from "node:readline";
 import * as path from "node:path";
 import * as fs from "node:fs";
-import { fileURLToPath } from "node:url";
 import chalk from "chalk";
 import { HistoryManager } from "../services/history-manager.js";
 import { displayLogo } from "../utils/logo.js";
@@ -15,9 +14,6 @@ import { TerminalDiagnostics } from "../utils/terminal-diagnostics.js";
 import { formatWarning } from "../utils/output.js";
 import "../utils/sigint-exit.js";
 import isWebCliMode from "../utils/web-mode.js";
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
 
 interface HistorySearchState {
   active: boolean;


### PR DESCRIPTION
Small follow-up to [#419](https://github.com/ably/ably-cli/pull/419).

When the `ably-interactive` wrapper was retired, the `__filename` / `__dirname` constants it relied on in `src/commands/interactive.ts` were left behind, along with the now-unused `fileURLToPath` import. They were dead code.

This removes all three lines. `path` and `fs` are kept — they're still used for the oclif manifest lookup later in the file.

ESLint did not flag these (so `main` stays green), but they're genuine leftovers, so worth tidying.

## Validation
- `pnpm prepare` — build + manifest OK
- `pnpm exec eslint src/commands/interactive.ts` — clean
- `pnpm test test/unit/commands/interactive.test.ts` — 7 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
