### PR TITLE
feat: run the CLI against a local Ably server

### DIFF
--- a/docs/Environment-Variables/General-Usage.md
+++ b/docs/Environment-Variables/General-Usage.md
@@ -18,6 +18,7 @@ These environment variables are most commonly used during development as well as
 | `ABLY_HISTORY_FILE` | Configuration | Custom history file location | `~/.ably/history` |
 | `ABLY_CLI_DEFAULT_DURATION` | Behavior | Auto-exit long-running commands (seconds) | None (forever) |
 | `ABLY_CLI_NON_INTERACTIVE` | Behavior | Auto-confirm "Did you mean?" prompts | Not set |
-| `ABLY_ENDPOINT` | Host Override | Override Realtime/REST API endpoint | SDK default |
+| `ABLY_URL` | Host Override | Route Realtime/REST API calls to a URL | SDK default |
+| `ABLY_ENDPOINT` | Host Override | Override Realtime/REST API endpoint (host only) | SDK default |
 
 > For development, testing, debugging, and internal variables, see [Development Stage Usage](Development-Usage.md).

--- a/docs/Local-Server.md
+++ b/docs/Local-Server.md
@@ -49,6 +49,8 @@ Both `--url` and `--control-url` take a full URL. A missing scheme defaults to `
 
 The data plane URL must not include a path: Ably routes by hostname, so a path would be silently discarded. The control plane URL may include one — if it does, it is used verbatim as the API prefix; if it does not, `/v1` is appended (matching the dedicated Control API service).
 
+Embedded credentials, query strings and fragments are rejected for the same reason a path is: nothing downstream carries them, and dropping them silently would resurface later as an unrelated auth or routing error.
+
 Internally the data plane URL is decomposed into the SDK's `endpoint`, `port`/`tlsPort` and `tls` client options and stored on the account, which is why you do not need to repeat host or port flags on individual commands.
 
 ---
@@ -67,26 +69,52 @@ Running the control plane locally is optional. When you log in without `--contro
 
 ```
 Control API commands aren't available for local server "local" because it was configured without a control plane URL.
-Re-run "ably accounts login --local" with --control-url if you are running the control plane locally, or switch to a managed account with "ably accounts switch".
+Re-run "ably accounts login --local" with --control-url if you are running the control plane locally, set ABLY_CONTROL_HOST to send just this command to a hosted control plane, or switch to a managed account with "ably accounts switch".
 ```
 
 This is deliberate: without the guard those commands would silently query the managed Control API at `control.ably.net` while a local profile is selected.
 
-To add a control plane later, re-run `ably accounts login --local` with `--control-url`.
+To add a control plane later, re-run `ably accounts login --local` with `--control-url`. To reach a hosted control plane for a single command without leaving the local profile, set `ABLY_CONTROL_HOST` (with `ABLY_ACCESS_TOKEN` for a token it will accept).
+
+`ably accounts current` does not need a control plane: for a local profile without one it reports what is stored, rather than treating the absent control plane as an expired token.
 
 ---
 
 ## Knowing which server you are on
 
-The account name in the "Using:" banner is the profile's alias, so the banner names the server you are on the same way it names a managed account:
+Every command that talks to a non-default server says so in the "Using:" banner, as a URL:
 
 ```
-Using: Account=dev • App=Local App (localapp) • Key=Local Key (localapp.keyid)
+$ ably channels publish my-channel "hello"
+Using: Account=dev • Endpoint=http://localhost:8081 • App=localapp • Key=Local Key (localapp.keyid)
 ```
 
-The endpoint itself is not repeated on every command — it is part of the profile you deliberately configured. Run `ably accounts current` or `ably accounts list` to see the stored URL.
+The `Endpoint=` field is the server the command will actually reach, so a command run against localhost never looks identical to the same command run against production. It is omitted only for a managed account on Ably's own endpoints, where there is nothing to state. Control plane commands (`ably apps`, `ably auth keys`, …) show the control plane URL rather than the data plane one, since that is where their requests go.
 
-An `Endpoint=` field appears only when an environment variable redirects a command away from its profile, since that is ambient state you may have forgotten you exported:
+The same URL is reported by every command that describes an account:
+
+```
+$ ably accounts current
+Account: dev
+Endpoint: http://localhost:8081
+Control plane: http://localhost:8082
+Apps configured: 1
+Current App: localapp
+
+$ ably accounts list
+▶ Account: dev (current)
+  Endpoint: http://localhost:8081
+  Control plane: http://localhost:8082
+  Apps configured: 1
+  Current app: localapp (localapp)
+
+$ ably accounts switch dev
+✓ Switched to local server dev (http://localhost:8081).
+```
+
+With `--json`, the same routing is carried under a `dataPlane` object (`endpoint`, `port`, `tls`, `url`) alongside `controlUrl`, in the same shape from `accounts login --local`, `accounts current`, `accounts list` and `accounts switch`.
+
+An environment variable that redirects a command away from its profile shows up the same way, since the banner always names the effective target:
 
 ```
 $ export ABLY_ENDPOINT=other.example.com

--- a/docs/Local-Server.md
+++ b/docs/Local-Server.md
@@ -1,0 +1,145 @@
+# Local Servers
+
+The CLI can target a locally-running Ably server instead of the managed service. A local server is stored as an ordinary account profile, so `ably accounts list`, `ably accounts current` and `ably accounts switch` all work as usual and every data plane command runs unchanged.
+
+---
+
+## Getting started
+
+The guided flow prompts for everything it needs:
+
+```bash
+ably accounts login --local
+```
+
+It asks for:
+
+1. **Data plane URL** — defaults to `http://localhost:8081`
+2. **API key** — for a key you already hold on the server (input is masked)
+3. **Whether the control plane is also running locally** — and if so, its URL and a Control API access token
+
+The explicit form skips the prompts and is what you want in scripts:
+
+```bash
+# Data plane only
+ably accounts login --local --url http://localhost:8081
+
+# Data plane and control plane
+ably accounts login --local \
+  --url http://localhost:8081 \
+  --control-url http://localhost:8082
+```
+
+Passing `--url` disables the prompts for the data plane URL and the control plane question; the API key and Control API token still prompt unless supplied via the environment (see [Non-interactive use](#non-interactive-use)).
+
+Once logged in, everything works as it does against the managed service:
+
+```bash
+ably channels publish my-channel "hello"
+ably channels subscribe my-channel
+ably accounts switch production   # back to a managed account
+ably accounts switch local        # and back again
+```
+
+---
+
+## URLs
+
+Both `--url` and `--control-url` take a full URL. A missing scheme defaults to `http` for loopback hosts (`localhost`, `127.0.0.1`, `::1`) and `https` for everything else, so `--url localhost:8081` and `--url http://localhost:8081` are equivalent.
+
+The data plane URL must not include a path: Ably routes by hostname, so a path would be silently discarded. The control plane URL may include one — if it does, it is used verbatim as the API prefix; if it does not, `/v1` is appended (matching the dedicated Control API service).
+
+Internally the data plane URL is decomposed into the SDK's `endpoint`, `port`/`tlsPort` and `tls` client options and stored on the account, which is why you do not need to repeat host or port flags on individual commands.
+
+---
+
+## The API key is the only data plane credential
+
+There is no OAuth flow and no account directory on a local server. The app ID is read from the API key itself (`<appId>.<keyId>:<keySecret>`), so the key is the only thing you need to supply for the data plane to work.
+
+The key is validated for shape at login. A key without the `<appId>.<keyId>:<keySecret>` structure is rejected with a message rather than being stored and failing later.
+
+---
+
+## Running only the data plane
+
+Running the control plane locally is optional. When you log in without `--control-url`, control plane commands (`ably apps`, `ably auth keys`, `ably integrations`, `ably queues`, `ably stats`) fail immediately with:
+
+```
+Control API commands aren't available for local server "local" because it was configured without a control plane URL.
+Re-run "ably accounts login --local" with --control-url if you are running the control plane locally, or switch to a managed account with "ably accounts switch".
+```
+
+This is deliberate: without the guard those commands would silently query the managed Control API at `control.ably.net` while a local profile is selected.
+
+To add a control plane later, re-run `ably accounts login --local` with `--control-url`.
+
+---
+
+## Knowing which server you are on
+
+The account name in the "Using:" banner is the profile's alias, so the banner names the server you are on the same way it names a managed account:
+
+```
+Using: Account=dev • App=Local App (localapp) • Key=Local Key (localapp.keyid)
+```
+
+The endpoint itself is not repeated on every command — it is part of the profile you deliberately configured. Run `ably accounts current` or `ably accounts list` to see the stored URL.
+
+An `Endpoint=` field appears only when an environment variable redirects a command away from its profile, since that is ambient state you may have forgotten you exported:
+
+```
+$ export ABLY_ENDPOINT=other.example.com
+$ ably channels publish my-channel "hello"
+Using: Account=dev • Endpoint=http://other.example.com:8081 • App=…
+```
+
+Note that `ABLY_ENDPOINT` replaces only the host — the port and TLS setting still come from the profile, which is why the displayed URL is the combination that traffic will actually use. On control plane commands the equivalent override is `ABLY_CONTROL_HOST`.
+
+---
+
+## Aliases
+
+Local logins default to the alias `local`, and the alias becomes the profile's account name — a local server has no server-side identity to name it by. Re-running against a different URL updates that profile in place and warns you first. Use `--alias` to keep several servers side by side:
+
+```bash
+ably accounts login --local --url http://localhost:8081 --alias dev
+ably accounts login --local --url http://localhost:9091 --alias staging-local
+ably accounts switch dev
+```
+
+---
+
+## Non-interactive use
+
+With `--json` the CLI cannot prompt, so credentials must come from the environment and `--url` is required:
+
+```bash
+export ABLY_API_KEY="localapp.keyid:keysecret"
+export ABLY_ACCESS_TOKEN="local-control-token"   # only if using --control-url
+
+ably accounts login --local --url http://localhost:8081 --json
+```
+
+`ABLY_API_KEY` and `ABLY_ACCESS_TOKEN` are also used in place of the prompts in interactive mode when they are set.
+
+---
+
+## One-off overrides without a profile
+
+If you do not want to store a profile, the hidden dev flags still work and take precedence over stored values on the command they are passed to:
+
+```bash
+export ABLY_API_KEY="localapp.keyid:keysecret"
+export ABLY_ENDPOINT=localhost
+ably channels publish my-channel "hello" --tls=false --port 8081
+```
+
+Set `ABLY_SHOW_DEV_FLAGS=true` to un-hide `--port`, `--tls-port`, `--tls`, `--control-host` and `--endpoint` in `--help` output. Note that `ABLY_ENDPOINT` only sets the host — there is no environment variable for the port, which is the main reason to store a profile instead.
+
+---
+
+## Related
+
+- [Environment Variables — General Usage](Environment-Variables/General-Usage.md)
+- [Project Structure](Project-Structure.md)

--- a/docs/Local-Server.md
+++ b/docs/Local-Server.md
@@ -125,17 +125,37 @@ ably accounts login --local --url http://localhost:8081 --json
 
 ---
 
-## One-off overrides without a profile
+## Without a profile
 
-If you do not want to store a profile, the hidden dev flags still work and take precedence over stored values on the command they are passed to:
+If you do not want to store anything, two environment variables are enough:
 
 ```bash
-export ABLY_API_KEY="localapp.keyid:keysecret"
-export ABLY_ENDPOINT=localhost
-ably channels publish my-channel "hello" --tls=false --port 8081
+ABLY_URL=http://localhost:8081 \
+ABLY_API_KEY=appId.keyId:keySecret \
+  ably channels publish my-channel "hello"
 ```
 
-Set `ABLY_SHOW_DEV_FLAGS=true` to un-hide `--port`, `--tls-port`, `--tls`, `--control-host` and `--endpoint` in `--help` output. Note that `ABLY_ENDPOINT` only sets the host — there is no environment variable for the port, which is the main reason to store a profile instead.
+`ABLY_URL` sets host, port and TLS in one value. The scheme is optional for loopback hosts, so `ABLY_URL=localhost:8081` is equivalent. A path is rejected rather than silently discarded, since Ably routes by host.
+
+The same value is available as a flag, for a single command rather than a whole shell:
+
+```bash
+ably channels publish my-channel "hello" --url http://localhost:8081
+```
+
+### Precedence
+
+For the data plane, the first source that supplies routing wins:
+
+```
+--url  >  ABLY_URL  >  ABLY_ENDPOINT  >  profile  >  SDK default
+```
+
+`--port`, `--tls-port` and `--tls` are applied on top of whichever source won, so they can override a single field — `--url http://localhost:8081 --port 1234` targets `localhost:1234`.
+
+`ABLY_ENDPOINT` predates the URL forms and sets the **host only**, keeping the port and TLS setting from the profile. Prefer `ABLY_URL` unless you specifically want that behaviour.
+
+`--url`, `--port`, `--tls-port` and `--tls` are hidden from `--help` by default; set `ABLY_SHOW_DEV_FLAGS=true` to show them.
 
 ---
 

--- a/docs/Project-Structure.md
+++ b/docs/Project-Structure.md
@@ -73,6 +73,7 @@ This document outlines the directory structure of the Ably CLI project.
 │   └── utils/
 │       ├── channel-rule-display.ts # Channel rule human-readable display
 │       ├── chat-constants.ts       # Shared Chat SDK constants (REACTION_TYPE_MAP)
+│       ├── server-url.ts           # Local server URL parsing (parseServerUrl, formatServerUrl)
 │       ├── errors.ts               # Error utilities (errorMessage)
 │       ├── interrupt-feedback.ts   # Ctrl+C feedback messages
 │       ├── json-formatter.ts       # JSON output formatting (formatJson, formatMessageData)
@@ -86,6 +87,7 @@ This document outlines the directory structure of the Ably CLI project.
 │       ├── output.ts               # Output helpers (progress, success, resource, etc.)
 │       ├── pagination.ts           # Generic pagination utilities (collectPaginatedResults, collectFilteredPaginatedResults)
 │       ├── prompt-confirmation.ts  # Y/N confirmation prompts
+│       ├── prompt-value.ts         # Free-text and masked value prompts
 │       ├── readline-helper.ts      # Readline utilities for interactive mode
 │       ├── sigint-exit.ts          # SIGINT/Ctrl+C handling (exit code 130)
 │       ├── string-distance.ts      # Levenshtein distance for fuzzy matching
@@ -175,3 +177,4 @@ This document outlines the directory structure of the Ably CLI project.
 - [Debugging Guide](Debugging.md) — Debugging tips for CLI development
 - [Interactive REPL](Interactive-REPL.md) — Architecture of `src/commands/interactive.ts`
 - [Exit Codes](Exit-Codes.md) — Exit codes handled in `src/commands/interactive.ts` and `src/utils/sigint-exit.ts`
+- [Local Servers](Local-Server.md) — Pointing the CLI at a locally-running Ably server via `ably accounts login --local`

--- a/src/base-command.ts
+++ b/src/base-command.ts
@@ -638,15 +638,13 @@ export abstract class AblyBaseCommand extends InteractiveBaseCommand {
       if (appId) {
         let appName = this.configManager.getAppName(appId);
 
-        // If app name is missing, try to fetch it from the API and update config.
-        // Local server accounts with no control plane configured have nowhere
-        // to look it up, so skip straight to the fallback label.
+        // If the app name is missing, try to fetch it from the API and update
+        // config. Local server accounts with no control plane configured have
+        // nowhere to look it up, so skip the attempt entirely.
         const hasControlPlane =
           this.configManager.getAuthMethod() !== "apiKey" ||
           Boolean(this.configManager.getControlUrl());
-        if (!appName && !hasControlPlane) {
-          appName = "Unknown App";
-        } else if (!appName) {
+        if (!appName && hasControlPlane) {
           try {
             // Get access token for control API
             const accessToken =
@@ -659,7 +657,7 @@ export abstract class AblyBaseCommand extends InteractiveBaseCommand {
               // the user picked at login. Without the account fallback this
               // call silently targets control.ably.net even when the user
               // logged in against a review/staging deployment, the lookup
-              // 404s, and the banner downgrades to "Unknown App".
+              // 404s, and the banner degrades to showing the bare app ID.
               const account = this.configManager.getCurrentAccount();
               const controlApi = new ControlApi({
                 accessToken,
@@ -685,17 +683,18 @@ export abstract class AblyBaseCommand extends InteractiveBaseCommand {
                 // Even without an API key, persist the app name to avoid future lookups
                 this.configManager.storeAppInfo(appId, { appName: app.name });
               }
-            } else {
-              appName = "Unknown App";
             }
           } catch {
-            // If fetching fails, use fallback
-            appName = "Unknown App";
+            // Leave the name unresolved — the ID below still identifies the app.
           }
         }
 
+        // Only the name can be unknown; the ID always is known here. Showing
+        // it alone beats pairing a real ID with an invented "Unknown App".
         displayParts.push(
-          `${chalk.green("App=")}${chalk.green.bold(appName)} ${chalk.gray(`(${appId})`)}`,
+          appName
+            ? `${chalk.green("App=")}${chalk.green.bold(appName)} ${chalk.gray(`(${appId})`)}`
+            : `${chalk.green("App=")}${chalk.green.bold(appId)}`,
         );
 
         // Check auth method - token or API key

--- a/src/base-command.ts
+++ b/src/base-command.ts
@@ -14,6 +14,7 @@ import {
   extractKeyNameFromApiKey,
 } from "./utils/api-key.js";
 import { CommandError } from "./errors/command-error.js";
+import { formatServerUrl } from "./utils/server-url.js";
 import { getFriendlyAblyErrorHint } from "./utils/errors.js";
 import { coreGlobalFlags } from "./flags.js";
 import { InteractiveHelper } from "./services/interactive-helper.js";
@@ -619,6 +620,17 @@ export abstract class AblyBaseCommand extends InteractiveBaseCommand {
       );
     }
 
+    // Surface routing only when an environment variable overrides the profile.
+    // A profile's own endpoint is a deliberate, persistent choice that the
+    // account name already identifies — repeating it on every command is noise.
+    // An env var, by contrast, is ambient and easy to forget you exported.
+    const routingOverride = this.formatRoutingOverride(showAppInfo);
+    if (routingOverride) {
+      displayParts.push(
+        `${chalk.blue("Endpoint=")}${chalk.blue.bold(routingOverride)}`,
+      );
+    }
+
     // For data plane commands, show app and auth info
     if (showAppInfo) {
       // Get app info
@@ -626,8 +638,15 @@ export abstract class AblyBaseCommand extends InteractiveBaseCommand {
       if (appId) {
         let appName = this.configManager.getAppName(appId);
 
-        // If app name is missing, try to fetch it from the API and update config
-        if (!appName) {
+        // If app name is missing, try to fetch it from the API and update config.
+        // Local server accounts with no control plane configured have nowhere
+        // to look it up, so skip straight to the fallback label.
+        const hasControlPlane =
+          this.configManager.getAuthMethod() !== "apiKey" ||
+          Boolean(this.configManager.getControlUrl());
+        if (!appName && !hasControlPlane) {
+          appName = "Unknown App";
+        } else if (!appName) {
           try {
             // Get access token for control API
             const accessToken =
@@ -648,6 +667,7 @@ export abstract class AblyBaseCommand extends InteractiveBaseCommand {
                   flags["control-host"] ??
                   process.env.ABLY_CONTROL_HOST ??
                   account?.controlHost,
+                controlUrl: this.configManager.getControlUrl(),
               });
               const app = await controlApi.getApp(appId);
               appName = app.name;
@@ -717,6 +737,34 @@ export abstract class AblyBaseCommand extends InteractiveBaseCommand {
       );
       this.log(""); // Add blank line for readability
     }
+  }
+
+  /**
+   * Render the effective endpoint when an environment variable redirects the
+   * command away from what the current profile is configured with, or
+   * undefined when the profile's own routing is in force.
+   */
+  private formatRoutingOverride(showAppInfo: boolean): string | undefined {
+    if (!showAppInfo) {
+      // Control plane: ABLY_CONTROL_HOST is the only ambient override.
+      return process.env.ABLY_CONTROL_HOST;
+    }
+
+    const override = process.env.ABLY_ENDPOINT;
+    if (!override) return undefined;
+
+    const dataPlane = this.configManager.getDataPlane();
+    // Setting the env var to what the profile already says is not a redirect.
+    if (override === dataPlane?.endpoint) return undefined;
+
+    // ABLY_ENDPOINT only replaces the host; port and TLS still come from the
+    // profile, so show the combination that traffic will actually use.
+    return formatServerUrl({
+      host: override,
+      path: "",
+      port: dataPlane?.port,
+      tls: dataPlane?.tls ?? true,
+    });
   }
 
   /**
@@ -1067,23 +1115,37 @@ export abstract class AblyBaseCommand extends InteractiveBaseCommand {
       }
     }
 
-    // Endpoint resolution: ABLY_ENDPOINT env → account config
-    const endpoint =
-      process.env.ABLY_ENDPOINT || this.configManager.getEndpoint();
+    // Data plane routing: flags → env → account config. Local server accounts
+    // persist host, port and TLS together (see `ably accounts login --local`),
+    // so a stored profile targets localhost without repeating dev flags on
+    // every command. Explicit flags still win, for one-off overrides.
+    const dataPlane = this.configManager.getDataPlane();
+
+    const endpoint = process.env.ABLY_ENDPOINT || dataPlane?.endpoint;
     if (endpoint) {
       options.endpoint = endpoint;
     }
 
-    if (flags.port) {
-      options.port = flags.port;
-    }
-
-    if (flags["tls-port"]) {
-      options.tlsPort = flags["tls-port"];
-    }
-
-    if (flags.tls) {
+    if (flags.tls !== undefined) {
       options.tls = flags.tls === "true";
+    } else if (dataPlane?.tls !== undefined) {
+      options.tls = dataPlane.tls;
+    }
+
+    // The SDK reads `port` when TLS is off and `tlsPort` when it is on, so the
+    // single stored port has to be routed to whichever one is live.
+    const tlsEnabled = options.tls !== false;
+
+    if (flags.port !== undefined) {
+      options.port = flags.port;
+    } else if (dataPlane?.port !== undefined && !tlsEnabled) {
+      options.port = dataPlane.port;
+    }
+
+    if (flags["tls-port"] !== undefined) {
+      options.tlsPort = flags["tls-port"];
+    } else if (dataPlane?.port !== undefined && tlsEnabled) {
+      options.tlsPort = dataPlane.port;
     }
 
     // Always add a log handler to control SDK output formatting and destination

--- a/src/base-command.ts
+++ b/src/base-command.ts
@@ -9,14 +9,14 @@ import {
   createConfigManager,
   type DataPlaneConfig,
 } from "./services/config-manager.js";
-import { ControlApi } from "./services/control-api.js";
+import { ControlApi, controlHostScheme } from "./services/control-api.js";
 import {
   extractAppIdFromApiKey,
   extractKeyNameFromApiKey,
 } from "./utils/api-key.js";
 import { CommandError } from "./errors/command-error.js";
 import {
-  formatServerUrl,
+  formatEndpointUrl,
   parseServerUrl,
   type ServerUrl,
 } from "./utils/server-url.js";
@@ -625,14 +625,12 @@ export abstract class AblyBaseCommand extends InteractiveBaseCommand {
       );
     }
 
-    // Surface routing only when an environment variable overrides the profile.
-    // A profile's own endpoint is a deliberate, persistent choice that the
-    // account name already identifies — repeating it on every command is noise.
-    // An env var, by contrast, is ambient and easy to forget you exported.
-    const routingOverride = this.formatRoutingOverride(showAppInfo);
-    if (routingOverride) {
+    // Surface the server whenever it isn't Ably's default, so a command run
+    // against localhost never looks identical to one run against production.
+    const endpoint = this.formatBannerEndpoint(flags);
+    if (endpoint) {
       displayParts.push(
-        `${chalk.blue("Endpoint=")}${chalk.blue.bold(routingOverride)}`,
+        `${chalk.blue("Endpoint=")}${chalk.blue.bold(endpoint)}`,
       );
     }
 
@@ -806,39 +804,33 @@ export abstract class AblyBaseCommand extends InteractiveBaseCommand {
   }
 
   /**
-   * Render the effective endpoint when an environment variable redirects the
-   * command away from what the current profile is configured with, or
-   * undefined when the profile's own routing is in force. Flags are excluded
-   * deliberately: they are explicit on the command line and need no reminder.
+   * True for commands whose requests go to the Control API rather than to the
+   * data plane. Overridden in ControlBaseCommand, and used by the banner to
+   * name the server the command will actually talk to — `apps list` reaches a
+   * control plane even though it also reports app and key context.
    */
-  private formatRoutingOverride(showAppInfo: boolean): string | undefined {
-    if (!showAppInfo) {
-      // Control plane: ABLY_CONTROL_HOST is the only ambient override.
-      return process.env.ABLY_CONTROL_HOST;
+  protected get usesControlApi(): boolean {
+    return false;
+  }
+
+  /**
+   * Render the server this command will talk to, or undefined when it is
+   * Ably's default and so not worth stating. Whatever supplied the routing —
+   * flag, environment variable, or the selected profile — the value is a URL,
+   * so the banner reads the same for both planes and never hides a port.
+   */
+  private formatBannerEndpoint(flags: BaseFlags): string | undefined {
+    if (this.usesControlApi) {
+      // A locally-run control plane is stored as a full URL; a host override
+      // has to be given the scheme its requests will use.
+      const controlUrl = this.configManager.getControlUrl();
+      if (controlUrl) return controlUrl;
+
+      const host = flags["control-host"] ?? process.env.ABLY_CONTROL_HOST;
+      return host ? `${controlHostScheme(host)}://${host}` : undefined;
     }
 
-    if (!process.env.ABLY_URL && !process.env.ABLY_ENDPOINT) return undefined;
-
-    const effective = this.resolveDataPlaneRouting({});
-    if (!effective?.endpoint) return undefined;
-
-    // Setting the env var to what the profile already says is not a redirect.
-    const profile = this.configManager.getDataPlane();
-    if (
-      profile &&
-      effective.endpoint === profile.endpoint &&
-      effective.port === profile.port &&
-      effective.tls === profile.tls
-    ) {
-      return undefined;
-    }
-
-    return formatServerUrl({
-      host: effective.endpoint,
-      path: "",
-      port: effective.port,
-      tls: effective.tls ?? true,
-    });
+    return formatEndpointUrl(this.resolveDataPlaneRouting(flags));
   }
 
   /**

--- a/src/base-command.ts
+++ b/src/base-command.ts
@@ -7,6 +7,7 @@ import { randomUUID } from "node:crypto";
 import {
   ConfigManager,
   createConfigManager,
+  type DataPlaneConfig,
 } from "./services/config-manager.js";
 import { ControlApi } from "./services/control-api.js";
 import {
@@ -14,8 +15,12 @@ import {
   extractKeyNameFromApiKey,
 } from "./utils/api-key.js";
 import { CommandError } from "./errors/command-error.js";
-import { formatServerUrl } from "./utils/server-url.js";
-import { getFriendlyAblyErrorHint } from "./utils/errors.js";
+import {
+  formatServerUrl,
+  parseServerUrl,
+  type ServerUrl,
+} from "./utils/server-url.js";
+import { errorMessage, getFriendlyAblyErrorHint } from "./utils/errors.js";
 import { coreGlobalFlags } from "./flags.js";
 import { InteractiveHelper } from "./services/interactive-helper.js";
 import { promptForConfirmation } from "./utils/prompt-confirmation.js";
@@ -739,9 +744,72 @@ export abstract class AblyBaseCommand extends InteractiveBaseCommand {
   }
 
   /**
+   * Resolve host, port and TLS for the data plane from the first source that
+   * supplies them: `--url`, `ABLY_URL`, `ABLY_ENDPOINT`, then the account
+   * profile. The individual `--port`/`--tls-port`/`--tls` flags are applied by
+   * the caller on top, so they can override a single field.
+   *
+   * `ABLY_ENDPOINT` names a host only and predates the URL forms, so it keeps
+   * the profile's port and TLS rather than resetting them.
+   */
+  private resolveDataPlaneRouting(
+    flags: BaseFlags,
+  ): DataPlaneConfig | undefined {
+    if (flags.url) {
+      return this.routingFromUrl(flags.url, "--url", flags);
+    }
+
+    if (process.env.ABLY_URL) {
+      return this.routingFromUrl(process.env.ABLY_URL, "ABLY_URL", flags);
+    }
+
+    const profile = this.configManager.getDataPlane();
+
+    if (process.env.ABLY_ENDPOINT) {
+      return {
+        endpoint: process.env.ABLY_ENDPOINT,
+        port: profile?.port,
+        tls: profile?.tls,
+      };
+    }
+
+    return profile;
+  }
+
+  /** Parse a routing URL, failing the command with the source named. */
+  private routingFromUrl(
+    raw: string,
+    source: string,
+    flags: BaseFlags,
+  ): DataPlaneConfig {
+    let parsed: ServerUrl;
+    try {
+      parsed = parseServerUrl(raw);
+    } catch (error) {
+      this.fail(
+        `Invalid ${source} value: ${errorMessage(error)}`,
+        flags,
+        "routing",
+      );
+    }
+
+    // The SDK routes by hostname, so a path would be silently discarded.
+    if (parsed.path) {
+      this.fail(
+        `${source} must not include a path (got "${parsed.path}"). Ably routes by host, so use a value like http://localhost:8081.`,
+        flags,
+        "routing",
+      );
+    }
+
+    return { endpoint: parsed.host, port: parsed.port, tls: parsed.tls };
+  }
+
+  /**
    * Render the effective endpoint when an environment variable redirects the
    * command away from what the current profile is configured with, or
-   * undefined when the profile's own routing is in force.
+   * undefined when the profile's own routing is in force. Flags are excluded
+   * deliberately: they are explicit on the command line and need no reminder.
    */
   private formatRoutingOverride(showAppInfo: boolean): string | undefined {
     if (!showAppInfo) {
@@ -749,20 +817,27 @@ export abstract class AblyBaseCommand extends InteractiveBaseCommand {
       return process.env.ABLY_CONTROL_HOST;
     }
 
-    const override = process.env.ABLY_ENDPOINT;
-    if (!override) return undefined;
+    if (!process.env.ABLY_URL && !process.env.ABLY_ENDPOINT) return undefined;
 
-    const dataPlane = this.configManager.getDataPlane();
+    const effective = this.resolveDataPlaneRouting({});
+    if (!effective?.endpoint) return undefined;
+
     // Setting the env var to what the profile already says is not a redirect.
-    if (override === dataPlane?.endpoint) return undefined;
+    const profile = this.configManager.getDataPlane();
+    if (
+      profile &&
+      effective.endpoint === profile.endpoint &&
+      effective.port === profile.port &&
+      effective.tls === profile.tls
+    ) {
+      return undefined;
+    }
 
-    // ABLY_ENDPOINT only replaces the host; port and TLS still come from the
-    // profile, so show the combination that traffic will actually use.
     return formatServerUrl({
-      host: override,
+      host: effective.endpoint,
       path: "",
-      port: dataPlane?.port,
-      tls: dataPlane?.tls ?? true,
+      port: effective.port,
+      tls: effective.tls ?? true,
     });
   }
 
@@ -1114,15 +1189,14 @@ export abstract class AblyBaseCommand extends InteractiveBaseCommand {
       }
     }
 
-    // Data plane routing: flags → env → account config. Local server accounts
-    // persist host, port and TLS together (see `ably accounts login --local`),
-    // so a stored profile targets localhost without repeating dev flags on
-    // every command. Explicit flags still win, for one-off overrides.
-    const dataPlane = this.configManager.getDataPlane();
+    // Data plane routing: --url → ABLY_URL → ABLY_ENDPOINT → account config,
+    // with the individual --port/--tls-port/--tls flags overriding single
+    // fields on top. The URL forms set host, port and TLS together, which is
+    // what a local server needs; ABLY_ENDPOINT is host-only and predates them.
+    const dataPlane = this.resolveDataPlaneRouting(flags);
 
-    const endpoint = process.env.ABLY_ENDPOINT || dataPlane?.endpoint;
-    if (endpoint) {
-      options.endpoint = endpoint;
+    if (dataPlane?.endpoint) {
+      options.endpoint = dataPlane.endpoint;
     }
 
     if (flags.tls !== undefined) {
@@ -1132,7 +1206,7 @@ export abstract class AblyBaseCommand extends InteractiveBaseCommand {
     }
 
     // The SDK reads `port` when TLS is off and `tlsPort` when it is on, so the
-    // single stored port has to be routed to whichever one is live.
+    // single resolved port has to be routed to whichever one is live.
     const tlsEnabled = options.tls !== false;
 
     if (flags.port !== undefined) {

--- a/src/commands/accounts/current.ts
+++ b/src/commands/accounts/current.ts
@@ -1,12 +1,15 @@
 import chalk from "chalk";
 
 import { ControlBaseCommand } from "../../control-base-command.js";
+import type { AccountConfig } from "../../services/config-manager.js";
+import type { BaseFlags } from "../../types/cli.js";
 import {
   extractAppIdFromApiKey,
   extractKeyNameFromApiKey,
 } from "../../utils/api-key.js";
 import { errorMessage } from "../../utils/errors.js";
 import { formatLabel } from "../../utils/output.js";
+import { formatEndpointUrl } from "../../utils/server-url.js";
 
 export default class AccountsCurrent extends ControlBaseCommand {
   static override description = "Show the current Ably account";
@@ -41,6 +44,17 @@ export default class AccountsCurrent extends ControlBaseCommand {
       );
     }
 
+    // A local server account with no control plane has no /me endpoint to
+    // verify against. Report what is stored and stop, rather than letting the
+    // control-plane guard surface as an expired-token warning.
+    if (
+      currentAccount.authMethod === "apiKey" &&
+      !this.configManager.getControlUrl()
+    ) {
+      this.showLocalAccount(currentAlias, flags);
+      return;
+    }
+
     // Verify the account by making an API call to get up-to-date information.
     // Route through createControlApi so OAuth accounts get the same
     // TokenRefreshMiddleware used by every other control command.
@@ -54,30 +68,8 @@ export default class AccountsCurrent extends ControlBaseCommand {
         ? Object.keys(currentAccount.apps).length
         : 0;
 
-      // Show current app if one is selected
-      const currentAppId = this.configManager.getCurrentAppId();
-      let currentApp: { id: string; name: string } | null = null;
-      let currentKey: { id: string; label: string } | null = null;
-
-      if (currentAppId) {
-        const appName =
-          this.configManager.getAppName(currentAppId) || currentAppId;
-        currentApp = { id: currentAppId, name: appName };
-
-        // Show current key if one is selected
-        const apiKey = this.configManager.getApiKey(currentAppId);
-        if (apiKey) {
-          const keyId =
-            this.configManager.getKeyId(currentAppId) ||
-            extractKeyNameFromApiKey(apiKey);
-          const keyName =
-            this.configManager.getKeyName(currentAppId) || "Unnamed key";
-          const formattedKeyName = keyId.includes(".")
-            ? keyId
-            : `${currentAppId}.${keyId}`;
-          currentKey = { id: formattedKeyName, label: keyName };
-        }
-      }
+      const { currentApp, currentKey } = this.getCurrentAppAndKey();
+      const server = this.serverUrls();
 
       if (this.shouldOutputJson(flags)) {
         this.logJsonResult(
@@ -89,6 +81,7 @@ export default class AccountsCurrent extends ControlBaseCommand {
               appsConfigured: appCount,
               currentApp,
               currentKey,
+              ...server.json,
             },
           },
           flags,
@@ -98,6 +91,7 @@ export default class AccountsCurrent extends ControlBaseCommand {
           `${formatLabel("Account")} ${chalk.cyan.bold(account.name)} ${chalk.gray(`(${account.id})`)}`,
         );
         this.log(`${formatLabel("User")} ${chalk.cyan.bold(user.email)}`);
+        this.logServerUrls(server);
         this.log(
           `${formatLabel("Apps configured")} ${chalk.cyan.bold(appCount)}`,
         );
@@ -139,7 +133,7 @@ export default class AccountsCurrent extends ControlBaseCommand {
         );
         this.log(
           chalk.yellow(
-            `Consider logging in again with "ably accounts login --alias ${currentAlias}".`,
+            `Consider logging in again with "${this.reloginCommand(currentAlias, currentAccount)}".`,
           ),
         );
 
@@ -155,6 +149,156 @@ export default class AccountsCurrent extends ControlBaseCommand {
         }
       }
     }
+  }
+
+  /**
+   * Report a local server account from config alone.
+   *
+   * The alias, the server URL and the app read out of the API key are the whole
+   * of what a local server tells us — there is no account directory to query,
+   * so nothing here is unverified or stale.
+   */
+  private showLocalAccount(alias: string, flags: BaseFlags): void {
+    const account = this.configManager.getCurrentAccount()!;
+    const appCount = account.apps ? Object.keys(account.apps).length : 0;
+    const { currentApp, currentKey } = this.getCurrentAppAndKey();
+    const server = this.serverUrls();
+
+    if (this.shouldOutputJson(flags)) {
+      this.logJsonResult(
+        {
+          account: {
+            alias,
+            authMethod: "apiKey",
+            name: account.accountName || alias,
+            appsConfigured: appCount,
+            currentApp,
+            currentKey,
+            ...server.json,
+          },
+        },
+        flags,
+      );
+      return;
+    }
+
+    this.log(`${formatLabel("Account")} ${chalk.cyan.bold(alias)}`);
+    this.logServerUrls(server);
+    this.log(`${formatLabel("Apps configured")} ${chalk.cyan.bold(appCount)}`);
+
+    if (currentApp) {
+      // A local server has no control plane to resolve the name from, so the
+      // ID stands alone unless a name was cached at login.
+      this.log(
+        currentApp.name === currentApp.id
+          ? `${formatLabel("Current App")} ${chalk.green.bold(currentApp.id)}`
+          : `${formatLabel("Current App")} ${chalk.green.bold(currentApp.name)} ${chalk.gray(`(${currentApp.id})`)}`,
+      );
+
+      if (currentKey) {
+        this.log(
+          `${formatLabel("Current API Key")} ${chalk.yellow.bold(currentKey.id)}`,
+        );
+        this.log(
+          `${formatLabel("Key Label")} ${chalk.yellow.bold(currentKey.label)}`,
+        );
+      }
+    }
+
+    this.logToStderr(
+      "No control plane configured — app and key management commands are unavailable for this account.",
+    );
+  }
+
+  /**
+   * The current app and key as stored in config, shared by every output path.
+   */
+  private getCurrentAppAndKey(): {
+    currentApp: { id: string; name: string } | null;
+    currentKey: { id: string; label: string } | null;
+  } {
+    const currentAppId = this.configManager.getCurrentAppId();
+    if (!currentAppId) return { currentApp: null, currentKey: null };
+
+    const currentApp = {
+      id: currentAppId,
+      name: this.configManager.getAppName(currentAppId) || currentAppId,
+    };
+
+    const apiKey = this.configManager.getApiKey(currentAppId);
+    if (!apiKey) return { currentApp, currentKey: null };
+
+    const keyId =
+      this.configManager.getKeyId(currentAppId) ||
+      extractKeyNameFromApiKey(apiKey);
+    return {
+      currentApp,
+      currentKey: {
+        id: keyId.includes(".") ? keyId : `${currentAppId}.${keyId}`,
+        label: this.configManager.getKeyName(currentAppId) || "Unnamed key",
+      },
+    };
+  }
+
+  /**
+   * The servers this account is pointed at, as URLs — the same form used by
+   * `accounts list`, `accounts switch` and the "Using:" banner. Absent for a
+   * managed account on Ably's own endpoints, which need no stating.
+   */
+  private serverUrls(): {
+    controlUrl?: string;
+    endpoint?: string;
+    json: Record<string, unknown>;
+  } {
+    const dataPlane = this.configManager.getDataPlane();
+    const endpoint = formatEndpointUrl(dataPlane);
+    const controlUrl = this.configManager.getControlUrl();
+
+    return {
+      controlUrl,
+      endpoint,
+      // Same shape as `accounts login --local`, `accounts switch` and
+      // `accounts list` report.
+      json: {
+        ...(dataPlane ? { dataPlane: { ...dataPlane, url: endpoint } } : {}),
+        ...(controlUrl ? { controlUrl } : {}),
+      },
+    };
+  }
+
+  private logServerUrls(server: {
+    controlUrl?: string;
+    endpoint?: string;
+  }): void {
+    if (server.endpoint) {
+      this.log(
+        `${formatLabel("Endpoint")} ${chalk.blue.bold(server.endpoint)}`,
+      );
+    }
+
+    if (server.controlUrl) {
+      this.log(
+        `${formatLabel("Control plane")} ${chalk.blue.bold(server.controlUrl)}`,
+      );
+    }
+  }
+
+  /**
+   * The command that would re-establish this account's credentials. A local
+   * account has no OAuth flow, so pointing it at plain `accounts login` would
+   * open a browser to ably.com and abandon the local profile.
+   */
+  private reloginCommand(alias: string, account: AccountConfig): string {
+    if (account.authMethod !== "apiKey") {
+      return `ably accounts login --alias ${alias}`;
+    }
+
+    const parts = [`ably accounts login --local --alias ${alias}`];
+    const endpoint = formatEndpointUrl(account);
+    if (endpoint) parts.push(`--url ${endpoint}`);
+    const controlUrl = this.configManager.getControlUrl();
+    if (controlUrl) parts.push(`--control-url ${controlUrl}`);
+    return parts.join(" ");
   }
 
   /**

--- a/src/commands/accounts/current.ts
+++ b/src/commands/accounts/current.ts
@@ -145,7 +145,7 @@ export default class AccountsCurrent extends ControlBaseCommand {
 
         // Show cached information
         this.log(
-          `${formatLabel("Account (cached)")} ${chalk.cyan.bold(currentAccount.accountName)} ${chalk.gray(`(${currentAccount.accountId})`)}`,
+          `${formatLabel("Account (cached)")} ${chalk.cyan.bold(currentAccount.accountName)}${currentAccount.accountId ? ` ${chalk.gray(`(${currentAccount.accountId})`)}` : ""}`,
         );
 
         if (currentAccount.userEmail) {

--- a/src/commands/accounts/list.ts
+++ b/src/commands/accounts/list.ts
@@ -71,10 +71,16 @@ export default class AccountsList extends ControlBaseCommand {
           titleStyle(`Account: ${alias}`) +
           (isCurrent ? chalk.green(" (current)") : ""),
       );
-      this.log(
-        `  ${formatLabel("Name")} ${account.accountName} (${account.accountId})`,
-      );
-      this.log(`  ${formatLabel("User")} ${account.userEmail}`);
+      // A local server account is named after its alias and has no
+      // server-assigned ID, so the Name line would just repeat the heading.
+      if (account.accountName !== alias || account.accountId) {
+        this.log(
+          `  ${formatLabel("Name")} ${account.accountName}${account.accountId ? ` (${account.accountId})` : ""}`,
+        );
+      }
+      if (account.userEmail) {
+        this.log(`  ${formatLabel("User")} ${account.userEmail}`);
+      }
 
       // Count number of apps configured for this account
       const appCount = account.apps ? Object.keys(account.apps).length : 0;

--- a/src/commands/accounts/list.ts
+++ b/src/commands/accounts/list.ts
@@ -2,6 +2,7 @@ import chalk from "chalk";
 
 import { ControlBaseCommand } from "../../control-base-command.js";
 import { formatLabel } from "../../utils/output.js";
+import { formatEndpointUrl } from "../../utils/server-url.js";
 
 export default class AccountsList extends ControlBaseCommand {
   static override description = "List locally configured Ably accounts";
@@ -35,23 +36,43 @@ export default class AccountsList extends ControlBaseCommand {
     if (this.shouldOutputJson(flags)) {
       this.logJsonResult(
         {
-          accounts: accounts.map(({ account, alias }) => ({
-            alias,
-            appsConfigured: account.apps ? Object.keys(account.apps).length : 0,
-            currentApp:
-              alias === currentAlias && account.currentAppId
+          accounts: accounts.map(({ account, alias }) => {
+            const dataPlane = this.configManager.getDataPlane(alias);
+
+            return {
+              alias,
+              appsConfigured: account.apps
+                ? Object.keys(account.apps).length
+                : 0,
+              ...(account.authMethod ? { authMethod: account.authMethod } : {}),
+              ...(account.controlUrl ? { controlUrl: account.controlUrl } : {}),
+              currentApp:
+                alias === currentAlias && account.currentAppId
+                  ? {
+                      id: account.currentAppId,
+                      name:
+                        this.configManager.getAppName(account.currentAppId) ||
+                        account.currentAppId,
+                    }
+                  : undefined,
+              // Same shape as `accounts login --local` and `accounts switch`
+              // report, so the server can be read the same way everywhere.
+              ...(dataPlane
                 ? {
-                    id: account.currentAppId,
-                    name:
-                      this.configManager.getAppName(account.currentAppId) ||
-                      account.currentAppId,
+                    dataPlane: {
+                      ...dataPlane,
+                      url: formatEndpointUrl(dataPlane),
+                    },
                   }
-                : undefined,
-            id: account.accountId,
-            isCurrent: alias === currentAlias,
-            name: account.accountName,
-            user: account.userEmail,
-          })),
+                : {}),
+              // A local server assigns no account ID and knows no user, so
+              // those keys are omitted rather than emitted empty.
+              ...(account.accountId ? { id: account.accountId } : {}),
+              isCurrent: alias === currentAlias,
+              name: account.accountName,
+              ...(account.userEmail ? { user: account.userEmail } : {}),
+            };
+          }),
           currentAccount: currentAlias,
         },
         flags,
@@ -80,6 +101,21 @@ export default class AccountsList extends ControlBaseCommand {
       }
       if (account.userEmail) {
         this.log(`  ${formatLabel("User")} ${account.userEmail}`);
+      }
+
+      // The server is what distinguishes two local profiles from each other,
+      // so it is reported here as a URL — the same form used by the "Using:"
+      // banner, `accounts current` and `accounts switch`.
+      const endpoint = formatEndpointUrl(
+        this.configManager.getDataPlane(alias),
+      );
+      if (endpoint) {
+        this.log(`  ${formatLabel("Endpoint")} ${chalk.blue(endpoint)}`);
+      }
+      if (account.controlUrl) {
+        this.log(
+          `  ${formatLabel("Control plane")} ${chalk.blue(account.controlUrl)}`,
+        );
       }
 
       // Count number of apps configured for this account

--- a/src/commands/accounts/login.ts
+++ b/src/commands/accounts/login.ts
@@ -10,6 +10,7 @@ import { OAuthClient, type OAuthTokens } from "../../services/oauth-client.js";
 import { BaseFlags } from "../../types/cli.js";
 import { extractAppIdFromApiKey, isValidApiKey } from "../../utils/api-key.js";
 import {
+  formatEndpointUrl,
   formatServerUrl,
   parseServerUrl,
   type ServerUrl,
@@ -511,8 +512,12 @@ export default class AccountsLogin extends ControlBaseCommand {
         flags,
       );
       this.log(`Account ${formatResource(alias)} is now the current account`);
+      // Without a control plane there is no name to look up, and pairing the
+      // ID with itself in the parenthetical states nothing.
       this.logSuccessMessage(
-        `Using app ${formatResource(appName ?? appId)} (${appId}).`,
+        appName
+          ? `Using app ${formatResource(appName)} (${appId}).`
+          : `Using app ${formatResource(appId)}.`,
         flags,
       );
 
@@ -669,23 +674,24 @@ export default class AccountsLogin extends ControlBaseCommand {
     if (!existing) return;
 
     if (existing.account.authMethod !== "apiKey") {
+      // A managed account may have neither name nor ID cached yet, so name it
+      // only when there is something to name.
+      const identity =
+        existing.account.accountName || existing.account.accountId;
       this.logWarning(
-        `Alias "${alias}" is currently the managed account ${existing.account.accountName || existing.account.accountId} and will be replaced by this local server. Use --alias to keep both.`,
+        `Alias "${alias}" is currently ${identity ? `the managed account ${identity}` : "a managed account"} and will be replaced by this local server. Use --alias to keep both.`,
         flags,
       );
       return;
     }
 
-    const current = formatServerUrl({
-      host: existing.account.endpoint ?? "",
-      path: "",
-      port: existing.account.port,
-      tls: existing.account.tls ?? true,
-    });
+    const current = formatEndpointUrl(existing.account);
     const next = formatServerUrl(dataPlane);
     if (current !== next) {
       this.logWarning(
-        `Alias "${alias}" currently points at ${current} and will be updated to ${next}. Use --alias to keep both.`,
+        current
+          ? `Alias "${alias}" currently points at ${current} and will be updated to ${next}. Use --alias to keep both.`
+          : `Alias "${alias}" will be updated to point at ${next}. Use --alias to keep both.`,
         flags,
       );
     }

--- a/src/commands/accounts/login.ts
+++ b/src/commands/accounts/login.ts
@@ -4,16 +4,29 @@ import * as readline from "node:readline";
 import ora from "ora";
 
 import { ControlBaseCommand } from "../../control-base-command.js";
-import { endpointFlag } from "../../flags.js";
+import { endpointFlag, localServerFlags } from "../../flags.js";
 import { ControlApi } from "../../services/control-api.js";
 import { OAuthClient, type OAuthTokens } from "../../services/oauth-client.js";
 import { BaseFlags } from "../../types/cli.js";
+import { extractAppIdFromApiKey, isValidApiKey } from "../../utils/api-key.js";
+import {
+  formatServerUrl,
+  parseServerUrl,
+  type ServerUrl,
+} from "../../utils/server-url.js";
 import { errorMessage } from "../../utils/errors.js";
 import { displayLogo } from "../../utils/logo.js";
 import openUrl from "../../utils/open-url.js";
 import { formatResource } from "../../utils/output.js";
 import { promptForConfirmation } from "../../utils/prompt-confirmation.js";
+import { promptForValue } from "../../utils/prompt-value.js";
 import { pickUniqueAlias, slugifyAccountName } from "../../utils/slugify.js";
+
+/** Offered as the default when the guided local flow prompts for a URL. */
+const DEFAULT_LOCAL_URL = "http://localhost:8081";
+
+/** Alias used for a local server when --alias is not supplied. */
+const DEFAULT_LOCAL_ALIAS = "local";
 
 function validateAndGetAlias(
   input: string,
@@ -51,6 +64,9 @@ export default class AccountsLogin extends ControlBaseCommand {
     "<%= config.bin %> <%= command.id %>",
     "<%= config.bin %> <%= command.id %> --alias mycompany",
     "<%= config.bin %> <%= command.id %> --no-browser",
+    "<%= config.bin %> <%= command.id %> --local",
+    "<%= config.bin %> <%= command.id %> --local --url http://localhost:8081",
+    "<%= config.bin %> <%= command.id %> --local --url http://localhost:8081 --control-url http://localhost:8082",
     "<%= config.bin %> <%= command.id %> --json",
     "<%= config.bin %> <%= command.id %> --pretty-json",
   ];
@@ -58,6 +74,7 @@ export default class AccountsLogin extends ControlBaseCommand {
   static override flags = {
     ...ControlBaseCommand.globalFlags,
     ...endpointFlag,
+    ...localServerFlags,
     alias: Flags.string({
       char: "a",
       description: "Alias for this account (default account if not specified)",
@@ -85,6 +102,13 @@ export default class AccountsLogin extends ControlBaseCommand {
     // opted out (e.g. `ably init` already prints the logo and delegates here).
     if (!this.shouldOutputJson(flags) && !flags["skip-logo"]) {
       displayLogo(this.log.bind(this));
+    }
+
+    // A local server has no authorization server and no account directory, so
+    // it skips OAuth entirely and writes the profile from user-supplied values.
+    if (flags.local) {
+      await this.runLocalLogin(flags);
+      return;
     }
 
     let oauthTokens: OAuthTokens;
@@ -389,6 +413,303 @@ export default class AccountsLogin extends ControlBaseCommand {
       }
     } catch (error) {
       this.fail(error, flags, "accountLogin");
+    }
+  }
+
+  /**
+   * Log in to a locally-running server.
+   *
+   * There is no authorization server and no account directory to query, so the
+   * profile is assembled from the server URL and an API key the user already
+   * holds. The app ID is read out of the key, which makes the key the only
+   * credential needed for the data plane.
+   */
+  private async runLocalLogin(flags: BaseFlags): Promise<void> {
+    if (this.isWebCliMode) {
+      this.fail(
+        "The --local flag is not available in web CLI mode.",
+        flags,
+        "accountLogin",
+      );
+    }
+
+    const jsonMode = this.shouldOutputJson(flags);
+    // Passing --url signals the explicit, scriptable form; a bare
+    // `--local` walks through every prompt like the managed flow does.
+    const guided = !flags.url && !jsonMode;
+
+    const dataPlane = await this.resolveDataPlaneUrl(flags, guided);
+    const apiKey = await this.resolveLocalApiKey(flags, jsonMode);
+
+    if (!isValidApiKey(apiKey)) {
+      this.fail(
+        'Invalid API key — expected the form "<appId>.<keyId>:<keySecret>" so the app ID can be read from it.',
+        flags,
+        "accountLogin",
+      );
+    }
+    const appId = extractAppIdFromApiKey(apiKey);
+
+    const control = await this.resolveControlPlane(flags, guided, jsonMode);
+
+    const alias = (flags.alias as string | undefined) ?? DEFAULT_LOCAL_ALIAS;
+    this.warnOnLocalAliasRebind(alias, dataPlane, flags);
+
+    this.configManager.storeLocalAccount(alias, {
+      accessToken: control?.accessToken,
+      // A local server has no server-side identity to name it by, so the alias
+      // is the account name. That keeps several local profiles distinguishable
+      // in the "Using:" banner, exactly as managed accounts are by their name.
+      accountName: alias,
+      controlUrl: control?.url,
+      dataPlane: {
+        endpoint: dataPlane.host,
+        port: dataPlane.port,
+        tls: dataPlane.tls,
+      },
+    });
+    this.configManager.switchAccount(alias);
+    this.configManager.setCurrentApp(appId);
+    this.configManager.storeAppKey(appId, apiKey);
+
+    // Only a local control plane can resolve the app's name; without one the
+    // app ID from the key is all we have to show.
+    const appName = control
+      ? await this.lookupLocalAppName(appId, control, flags)
+      : undefined;
+    if (appName) {
+      this.configManager.storeAppInfo(appId, { appName });
+    }
+
+    const dataPlaneUrl = formatServerUrl(dataPlane);
+
+    if (jsonMode) {
+      this.logJsonResult(
+        {
+          account: {
+            alias,
+            app: {
+              id: appId,
+              ...(appName ? { name: appName } : {}),
+            },
+            authMethod: "apiKey",
+            ...(control ? { controlUrl: control.url } : {}),
+            dataPlane: {
+              endpoint: dataPlane.host,
+              port: dataPlane.port,
+              tls: dataPlane.tls,
+              url: dataPlaneUrl,
+            },
+            name: alias,
+          },
+        },
+        flags,
+      );
+    } else {
+      this.logSuccessMessage(
+        `Logged in to local server at ${formatResource(dataPlaneUrl)}.`,
+        flags,
+      );
+      this.log(`Account ${formatResource(alias)} is now the current account`);
+      this.logSuccessMessage(
+        `Using app ${formatResource(appName ?? appId)} (${appId}).`,
+        flags,
+      );
+
+      if (control) {
+        this.logSuccessMessage(
+          `Control plane configured at ${formatResource(control.url)}.`,
+          flags,
+        );
+      } else {
+        this.logToStderr(
+          "No control plane configured — app and key management commands are unavailable for this account.",
+        );
+      }
+    }
+  }
+
+  /** Resolve and validate the data plane URL for a local login. */
+  private async resolveDataPlaneUrl(
+    flags: BaseFlags,
+    guided: boolean,
+  ): Promise<ServerUrl> {
+    let raw = flags.url;
+
+    if (!raw) {
+      if (!guided) {
+        this.fail(
+          "The --url flag is required when using --local with --json.",
+          flags,
+          "accountLogin",
+        );
+      }
+
+      raw = await promptForValue("Data plane URL:", {
+        defaultValue: DEFAULT_LOCAL_URL,
+      });
+    }
+
+    const server = this.parseUrlOrFail(raw, "data plane", flags);
+
+    // The SDK routes by hostname, so a path would be silently discarded.
+    if (server.path) {
+      this.fail(
+        `The data plane URL must not include a path (got "${server.path}"). Ably routes by host, so use a value like ${DEFAULT_LOCAL_URL}.`,
+        flags,
+        "accountLogin",
+      );
+    }
+
+    return server;
+  }
+
+  /** Resolve the API key for a local login, from the environment or a prompt. */
+  private async resolveLocalApiKey(
+    flags: BaseFlags,
+    jsonMode: boolean,
+  ): Promise<string> {
+    const fromEnv = process.env.ABLY_API_KEY?.trim();
+    if (fromEnv) {
+      if (!jsonMode) {
+        this.log("Using API key from ABLY_API_KEY.");
+      }
+      return fromEnv;
+    }
+
+    if (jsonMode) {
+      this.fail(
+        "No API key available. Set ABLY_API_KEY when using --local with --json.",
+        flags,
+        "accountLogin",
+      );
+    }
+
+    return promptForValue("API key:", { secret: true });
+  }
+
+  /**
+   * Resolve the optional local control plane. Returns undefined when the user
+   * is only running the data plane, which leaves control commands disabled for
+   * the account.
+   */
+  private async resolveControlPlane(
+    flags: BaseFlags,
+    guided: boolean,
+    jsonMode: boolean,
+  ): Promise<undefined | { accessToken: string; url: string }> {
+    let raw = flags["control-url"];
+
+    if (!raw && guided) {
+      const runningLocally = await promptForConfirmation(
+        "Are you also running the control plane locally?",
+      );
+      if (runningLocally) {
+        raw = await promptForValue("Control plane URL:");
+      }
+    }
+
+    if (!raw) return undefined;
+
+    const url = formatServerUrl(
+      this.parseUrlOrFail(raw, "control plane", flags),
+    );
+
+    let accessToken = process.env.ABLY_ACCESS_TOKEN?.trim();
+    if (accessToken) {
+      if (!jsonMode) {
+        this.log("Using Control API access token from ABLY_ACCESS_TOKEN.");
+      }
+    } else {
+      if (jsonMode) {
+        this.fail(
+          "No Control API access token available. Set ABLY_ACCESS_TOKEN when using --control-url with --json.",
+          flags,
+          "accountLogin",
+        );
+      }
+
+      accessToken = await promptForValue("Control API access token:", {
+        secret: true,
+      });
+    }
+
+    return { accessToken, url };
+  }
+
+  private parseUrlOrFail(
+    raw: string,
+    label: string,
+    flags: BaseFlags,
+  ): ServerUrl {
+    try {
+      return parseServerUrl(raw);
+    } catch (error) {
+      this.fail(
+        `Invalid ${label} URL: ${errorMessage(error)}`,
+        flags,
+        "accountLogin",
+      );
+    }
+  }
+
+  /**
+   * Warn before an alias is repointed. Local logins default to a fixed alias,
+   * so re-running against a different server would otherwise silently rebind
+   * an existing profile.
+   */
+  private warnOnLocalAliasRebind(
+    alias: string,
+    dataPlane: ServerUrl,
+    flags: BaseFlags,
+  ): void {
+    const existing = this.configManager
+      .listAccounts()
+      .find((a) => a.alias === alias);
+    if (!existing) return;
+
+    if (existing.account.authMethod !== "apiKey") {
+      this.logWarning(
+        `Alias "${alias}" is currently the managed account ${existing.account.accountName || existing.account.accountId} and will be replaced by this local server. Use --alias to keep both.`,
+        flags,
+      );
+      return;
+    }
+
+    const current = formatServerUrl({
+      host: existing.account.endpoint ?? "",
+      path: "",
+      port: existing.account.port,
+      tls: existing.account.tls ?? true,
+    });
+    const next = formatServerUrl(dataPlane);
+    if (current !== next) {
+      this.logWarning(
+        `Alias "${alias}" currently points at ${current} and will be updated to ${next}. Use --alias to keep both.`,
+        flags,
+      );
+    }
+  }
+
+  /** Best-effort app name lookup against a local control plane. */
+  private async lookupLocalAppName(
+    appId: string,
+    control: { accessToken: string; url: string },
+    flags: BaseFlags,
+  ): Promise<string | undefined> {
+    try {
+      const controlApi = new ControlApi({
+        accessToken: control.accessToken,
+        controlUrl: control.url,
+      });
+      const app = await controlApi.getApp(appId);
+      return app.name;
+    } catch (error) {
+      this.logWarning(
+        `Could not look up app ${appId} on the local control plane: ${errorMessage(error)}`,
+        flags,
+      );
+      return undefined;
     }
   }
 

--- a/src/commands/accounts/switch.ts
+++ b/src/commands/accounts/switch.ts
@@ -6,6 +6,7 @@ import { ControlBaseCommand } from "../../control-base-command.js";
 import { endpointFlag } from "../../flags.js";
 import { type AccountSummary } from "../../services/control-api.js";
 import { formatResource } from "../../utils/output.js";
+import { formatEndpointUrl } from "../../utils/server-url.js";
 import { pickUniqueAlias, slugifyAccountName } from "../../utils/slugify.js";
 
 export default class AccountsSwitch extends ControlBaseCommand {
@@ -283,12 +284,22 @@ export default class AccountsSwitch extends ControlBaseCommand {
       this.configManager.getAuthMethod() === "apiKey" &&
       !this.configManager.getControlUrl()
     ) {
-      const endpoint = this.configManager.getEndpoint();
+      const dataPlane = this.configManager.getDataPlane();
+      const url = formatEndpointUrl(dataPlane);
       if (this.shouldOutputJson(flags)) {
-        this.logJsonResult({ account: { alias, authMethod: "apiKey" } }, flags);
+        this.logJsonResult(
+          {
+            account: {
+              alias,
+              authMethod: "apiKey",
+              ...(dataPlane ? { dataPlane: { ...dataPlane, url } } : {}),
+            },
+          },
+          flags,
+        );
       } else {
         this.logSuccessMessage(
-          `Switched to local server ${formatResource(alias)}${endpoint ? ` (${endpoint})` : ""}.`,
+          `Switched to local server ${formatResource(alias)}${url ? ` (${url})` : ""}.`,
           flags,
         );
       }

--- a/src/commands/accounts/switch.ts
+++ b/src/commands/accounts/switch.ts
@@ -276,6 +276,25 @@ export default class AccountsSwitch extends ControlBaseCommand {
       this.configManager.storeEndpoint(flags.endpoint as string);
     }
 
+    // A local server account with no control plane has no /me endpoint to
+    // verify against, so report the switch and stop rather than emitting a
+    // spurious token-verification warning.
+    if (
+      this.configManager.getAuthMethod() === "apiKey" &&
+      !this.configManager.getControlUrl()
+    ) {
+      const endpoint = this.configManager.getEndpoint();
+      if (this.shouldOutputJson(flags)) {
+        this.logJsonResult({ account: { alias, authMethod: "apiKey" } }, flags);
+      } else {
+        this.logSuccessMessage(
+          `Switched to local server ${formatResource(alias)}${endpoint ? ` (${endpoint})` : ""}.`,
+          flags,
+        );
+      }
+      return;
+    }
+
     // Verify the account is valid by making an API call.
     try {
       const controlApi = this.createControlApi(flags);

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -19,6 +19,11 @@ export default class Login extends ControlBaseCommand {
     // cached-client cleanup. AccountsLogin is run manually so its finally
     // doesn't emit a duplicate completed signal.
     const accountsLogin = new AccountsLogin(this.argv, this.config);
+    // oclif only assigns an id to commands it dispatches itself, so the
+    // manually constructed delegate would label its JSON records "unknown".
+    // Inherit this command's id so they read "login", matching the completed
+    // signal that this command's own finally() emits.
+    accountsLogin.id = this.id;
     await accountsLogin.run();
   }
 }

--- a/src/control-base-command.ts
+++ b/src/control-base-command.ts
@@ -13,20 +13,24 @@ export abstract class ControlBaseCommand extends AblyBaseCommand {
   // token even when --control-host points elsewhere).
   static globalFlags = { ...controlApiFlags, ...oauthHostFlag };
 
+  protected override get usesControlApi(): boolean {
+    return true;
+  }
+
   /**
    * Create a Control API instance for making requests
    */
   protected createControlApi(flags: BaseFlags): ControlApi {
     let accessToken = process.env.ABLY_ACCESS_TOKEN;
     let tokenRefreshMiddleware: TokenRefreshMiddleware | undefined;
-    const account = accessToken
-      ? undefined
-      : this.configManager.getCurrentAccount();
 
-    // Routing is resolved from the selected account even when the token comes
+    // Routing is resolved from the selected profile even when the token comes
     // from the environment — the local control plane URL is a property of the
-    // profile, not of the credentials.
-    const currentAccount = this.configManager.getCurrentAccount();
+    // profile, not of the credentials. `account` is the narrower thing: the
+    // profile we also take the token from, which ABLY_ACCESS_TOKEN replaces.
+    const profile = this.configManager.getCurrentAccount();
+    const account = accessToken ? undefined : profile;
+
     const hasHostOverride = Boolean(
       flags["control-host"] || process.env.ABLY_CONTROL_HOST,
     );
@@ -37,13 +41,9 @@ export abstract class ControlBaseCommand extends AblyBaseCommand {
     // A local server account only reaches a control plane if one was given at
     // login. Fail with a pointer rather than silently querying the managed
     // Control API while a local profile is selected.
-    if (
-      currentAccount?.authMethod === "apiKey" &&
-      !controlUrl &&
-      !hasHostOverride
-    ) {
+    if (profile?.authMethod === "apiKey" && !controlUrl && !hasHostOverride) {
       this.fail(
-        `Control API commands aren't available for local server "${this.configManager.getCurrentAccountAlias()}" because it was configured without a control plane URL.\nRe-run "ably accounts login --local" with --control-url if you are running the control plane locally, or switch to a managed account with "ably accounts switch".`,
+        `Control API commands aren't available for local server "${this.configManager.getCurrentAccountAlias()}" because it was configured without a control plane URL.\nRe-run "ably accounts login --local" with --control-url if you are running the control plane locally, set ABLY_CONTROL_HOST to send just this command to a hosted control plane, or switch to a managed account with "ably accounts switch".`,
         flags,
         "auth",
       );

--- a/src/control-base-command.ts
+++ b/src/control-base-command.ts
@@ -23,6 +23,32 @@ export abstract class ControlBaseCommand extends AblyBaseCommand {
       ? undefined
       : this.configManager.getCurrentAccount();
 
+    // Routing is resolved from the selected account even when the token comes
+    // from the environment — the local control plane URL is a property of the
+    // profile, not of the credentials.
+    const currentAccount = this.configManager.getCurrentAccount();
+    const hasHostOverride = Boolean(
+      flags["control-host"] || process.env.ABLY_CONTROL_HOST,
+    );
+    const controlUrl = hasHostOverride
+      ? undefined
+      : this.configManager.getControlUrl();
+
+    // A local server account only reaches a control plane if one was given at
+    // login. Fail with a pointer rather than silently querying the managed
+    // Control API while a local profile is selected.
+    if (
+      currentAccount?.authMethod === "apiKey" &&
+      !controlUrl &&
+      !hasHostOverride
+    ) {
+      this.fail(
+        `Control API commands aren't available for local server "${this.configManager.getCurrentAccountAlias()}" because it was configured without a control plane URL.\nRe-run "ably accounts login --local" with --control-url if you are running the control plane locally, or switch to a managed account with "ably accounts switch".`,
+        flags,
+        "auth",
+      );
+    }
+
     if (!accessToken) {
       if (!account) {
         this.fail(
@@ -77,6 +103,7 @@ export abstract class ControlBaseCommand extends AblyBaseCommand {
     return new ControlApi({
       accessToken,
       controlHost,
+      controlUrl,
       tokenRefreshMiddleware,
     });
   }

--- a/src/data/env-vars.ts
+++ b/src/data/env-vars.ts
@@ -306,7 +306,18 @@ const ABLY_ENDPOINT = new EnvVarEntry(
     `export ABLY_ENDPOINT="custom-endpoint.example.com"`,
     `ably channels publish my-channel "Hello"`,
   ]),
-  [],
+  [
+    new DetailSection("Local servers", [
+      {
+        kind: "paragraph",
+        text: "Sets the **host only** — there is no environment variable for the port. Pair it with the hidden `--port`, `--tls-port` and `--tls` flags for one-off use.",
+      },
+      {
+        kind: "important",
+        text: "To store host, port and TLS together so they apply to every command, run `ably accounts login --local --url http://localhost:8081` instead.",
+      },
+    ]),
+  ],
 );
 
 const AUTH_RESOLUTION_ORDER = new CrossCuttingSection(

--- a/src/data/env-vars.ts
+++ b/src/data/env-vars.ts
@@ -299,7 +299,7 @@ const ABLY_ENDPOINT = new EnvVarEntry(
   "Override Realtime/REST API endpoint",
   "Hostname or URL (passed as-is, no normalization)",
   "SDK default",
-  "**`ABLY_ENDPOINT`** > account config endpoint > SDK default",
+  "`--url` > **`ABLY_URL`** > **`ABLY_ENDPOINT`** > account config endpoint > SDK default",
   ["channels", "rooms", "spaces", "connections", "bench", "logs"],
   "Override the Ably Realtime/REST API endpoint for all data plane commands.",
   new Example([
@@ -307,14 +307,46 @@ const ABLY_ENDPOINT = new EnvVarEntry(
     `ably channels publish my-channel "Hello"`,
   ]),
   [
-    new DetailSection("Local servers", [
+    new DetailSection("Host only", [
       {
         kind: "paragraph",
-        text: "Sets the **host only** — there is no environment variable for the port. Pair it with the hidden `--port`, `--tls-port` and `--tls` flags for one-off use.",
+        text: "Sets the **host only**, keeping the port and TLS setting from the current profile.",
       },
       {
         kind: "important",
-        text: "To store host, port and TLS together so they apply to every command, run `ably accounts login --local --url http://localhost:8081` instead.",
+        text: "To set host, port and TLS together — what pointing at a local server needs — use `ABLY_URL` instead.",
+      },
+    ]),
+  ],
+);
+
+const ABLY_URL = new EnvVarEntry(
+  "ABLY_URL",
+  "Host Override",
+  "Route Realtime/REST API calls to a URL",
+  "Full URL, e.g. `http://localhost:8081` (scheme optional for loopback hosts)",
+  "SDK default",
+  "`--url` > **`ABLY_URL`** > `ABLY_ENDPOINT` > account config endpoint > SDK default",
+  ["channels", "rooms", "spaces", "connections", "bench", "logs"],
+  "Point all data plane commands at a specific server, typically one running locally.",
+  new Example([
+    `export ABLY_URL="http://localhost:8081"`,
+    `export ABLY_API_KEY="appId.keyId:keySecret"`,
+    `ably channels publish my-channel "Hello"`,
+  ]),
+  [
+    new DetailSection("Behaviour", [
+      {
+        kind: "paragraph",
+        text: "Sets host, port and TLS in one value, unlike `ABLY_ENDPOINT` which sets only the host. A missing scheme defaults to `http` for loopback hosts and `https` otherwise, so `localhost:8081` and `http://localhost:8081` are equivalent.",
+      },
+      {
+        kind: "paragraph",
+        text: "The URL must not include a path — Ably routes by host, so a path would be silently discarded.",
+      },
+      {
+        kind: "important",
+        text: "For repeated use, `ably accounts login --local --url http://localhost:8081` stores the same routing as a profile so no environment variable is needed.",
       },
     ]),
   ],
@@ -509,6 +541,7 @@ export const ENV_VARS_DATA: EnvVarsData = new EnvVarsData(
     ABLY_API_KEY,
     ABLY_TOKEN,
     ABLY_ACCESS_TOKEN,
+    ABLY_URL,
     ABLY_ENDPOINT,
     ABLY_APP_ID,
     ABLY_CLI_CONFIG_DIR,

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -87,6 +87,32 @@ export const oauthHostFlag = {
 };
 
 /**
+ * Local server flags for `accounts login` only.
+ *
+ * `--url` and `--control-url` are full URLs rather than the SDK's separate
+ * host/port/tls options: one value is easier to supply and is decomposed by
+ * `parseServerUrl()` at login time.
+ */
+export const localServerFlags = {
+  // No default: oclif's dependsOn treats a defaulted flag as always present,
+  // which would stop it rejecting --url without --local.
+  local: Flags.boolean({
+    description:
+      "Log in to a locally-running Ably server instead of the managed service",
+  }),
+  url: Flags.string({
+    dependsOn: ["local"],
+    description:
+      "Data plane URL of the local server (e.g. http://localhost:8081)",
+  }),
+  "control-url": Flags.string({
+    dependsOn: ["local"],
+    description:
+      "Control plane URL of the local server, if you are running it locally (e.g. http://localhost:8082)",
+  }),
+};
+
+/**
  * endpoint flag for login / accounts switch commands only.
  */
 export const endpointFlag = {

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -25,9 +25,17 @@ export const coreGlobalFlags = {
 };
 
 /**
- * Hidden flags for product API (Ably SDK) commands — port, tls, tls-port.
+ * Hidden flags for product API (Ably SDK) commands — url, port, tls, tls-port.
+ *
+ * `--url` sets host, port and TLS together, which is what pointing at a local
+ * server needs. The individual flags below override single fields on top of it.
  */
 export const hiddenProductApiFlags = {
+  url: Flags.string({
+    description:
+      "Route product API calls to this URL, e.g. http://localhost:8081",
+    hidden: process.env.ABLY_SHOW_DEV_FLAGS !== "true",
+  }),
   port: Flags.integer({
     description: "Override the port for product API calls",
     hidden: process.env.ABLY_SHOW_DEV_FLAGS !== "true",

--- a/src/interactive-base-command.ts
+++ b/src/interactive-base-command.ts
@@ -4,6 +4,24 @@ import isTestMode from "./utils/test-mode.js";
 type PrettyPrintableError = Interfaces.PrettyPrintableError;
 
 /**
+ * The error thrown in place of exiting the process, in test and interactive
+ * mode.
+ *
+ * It carries oclif's `exit` metadata for the same reason `error()` below does:
+ * an exit is a decision that has already been reported to the user, so any
+ * catch block it unwinds through — `runControlCommand`, a command's own
+ * try/catch — must re-throw it rather than reporting it a second time.
+ */
+function exitError(code: number): Error {
+  const error = new Error(`Command exited with code ${code}`);
+  return Object.assign(error, {
+    code: "EEXIT",
+    exitCode: code,
+    oclif: { exit: code },
+  });
+}
+
+/**
  * Base command class that provides interactive-mode-safe error handling.
  * When running in interactive mode, this class converts process.exit calls
  * to thrown errors that can be caught and handled gracefully.
@@ -72,19 +90,14 @@ export abstract class InteractiveBaseCommand extends Command {
   exit(code = 0): never {
     if (isTestMode()) {
       if (code !== 0) {
-        const error = new Error(`Command exited with code ${code}`);
-        Object.assign(error, { exitCode: code, code: "EEXIT" });
-        throw error;
+        throw exitError(code);
       }
       // @ts-expect-error TS2322: suppress type assignment error — success exit is a no-op in tests
       return;
     }
 
     if (process.env.ABLY_INTERACTIVE_MODE === "true") {
-      const error = new Error(`Command exited with code ${code}`);
-      (error as Error & { exitCode?: number; code?: string }).exitCode = code;
-      (error as Error & { exitCode?: number; code?: string }).code = "EEXIT";
-      throw error;
+      throw exitError(code);
     }
 
     super.exit(code);

--- a/src/services/config-manager.ts
+++ b/src/services/config-manager.ts
@@ -14,9 +14,23 @@ export interface AppConfig {
   keyName?: string;
 }
 
+/**
+ * Data plane routing for an account, as supplied by `--endpoint` (managed) or
+ * decomposed from `--url` (local server). Mirrors the SDK's client options:
+ * `endpoint` is a bare hostname, and the port applies to `tlsPort` or `port`
+ * depending on `tls`.
+ */
+export interface DataPlaneConfig {
+  endpoint?: string;
+  port?: number;
+  tls?: boolean;
+}
+
 export interface AccountConfig {
   // Legacy: pre-OAuth configs store the access token directly on the account.
   // OAuth accounts use oauthSessionKey to reference a shared OAuthSession instead.
+  // Local server accounts reuse this field for the Control API access token,
+  // which has no refresh flow.
   // Do not remove — needed for backward compatibility with existing configs.
   accessToken?: string;
   accessTokenExpiresAt?: number;
@@ -25,10 +39,16 @@ export interface AccountConfig {
   apps?: {
     [appId: string]: AppConfig;
   };
-  authMethod?: "oauth";
+  authMethod?: "apiKey" | "oauth";
   controlHost?: string;
+  // Full base URL (scheme, host, port, optional path prefix) for a locally-run
+  // control plane. Takes precedence over controlHost, which cannot express a
+  // port or a plaintext scheme.
+  controlUrl?: string;
   currentAppId?: string;
   endpoint?: string;
+  port?: number;
+  tls?: boolean;
   // OAuth authorization server host (ably.com or a review-app override).
   // Kept separate from controlHost so the session key and token-refresh
   // traffic always targets the host that actually minted the tokens.
@@ -79,6 +99,15 @@ export interface ConfigManager {
       userEmail: string;
     },
   ): void;
+  storeLocalAccount(
+    alias: string,
+    info: {
+      accessToken?: string;
+      accountName: string;
+      controlUrl?: string;
+      dataPlane: DataPlaneConfig;
+    },
+  ): void;
   switchAccount(alias: string): boolean;
   removeAccount(alias: string): boolean;
 
@@ -107,7 +136,7 @@ export interface ConfigManager {
       }
     | undefined;
   isAccessTokenExpired(): boolean;
-  getAuthMethod(alias?: string): "oauth" | undefined;
+  getAuthMethod(alias?: string): "apiKey" | "oauth" | undefined;
   getAliasesForOAuthSession(alias: string): string[];
   clearOAuthSession(alias?: string): void;
 
@@ -135,6 +164,8 @@ export interface ConfigManager {
   // Endpoint management
   getEndpoint(alias?: string): string | undefined;
   storeEndpoint(endpoint: string, alias?: string): void;
+  getDataPlane(alias?: string): DataPlaneConfig | undefined;
+  getControlUrl(alias?: string): string | undefined;
 
   // Help context (AI conversation)
   getHelpContext():
@@ -263,6 +294,36 @@ export class TomlConfigManager implements ConfigManager {
 
     const currentAccount = this.getCurrentAccount();
     return currentAccount?.endpoint;
+  }
+
+  // Get the full data plane routing config for the current account or alias
+  public getDataPlane(alias?: string): DataPlaneConfig | undefined {
+    const account = alias
+      ? this.config.accounts[alias]
+      : this.getCurrentAccount();
+    if (!account) return undefined;
+
+    if (
+      account.endpoint === undefined &&
+      account.port === undefined &&
+      account.tls === undefined
+    ) {
+      return undefined;
+    }
+
+    return {
+      endpoint: account.endpoint,
+      port: account.port,
+      tls: account.tls,
+    };
+  }
+
+  // Get the control plane base URL for the current account or alias
+  public getControlUrl(alias?: string): string | undefined {
+    const account = alias
+      ? this.config.accounts[alias]
+      : this.getCurrentAccount();
+    return account?.controlUrl;
   }
 
   // Get path to config file
@@ -478,6 +539,52 @@ export class TomlConfigManager implements ConfigManager {
     }
 
     this.config.accounts[targetAlias].endpoint = endpoint;
+    this.saveConfig();
+  }
+
+  // Store a local server account. Unlike storeOAuthTokens there is no
+  // authorization server involved: the API key is supplied directly by the
+  // user, and the optional Control API token is stored on the account itself
+  // because a local control plane has no refresh flow.
+  public storeLocalAccount(
+    alias: string,
+    info: {
+      accessToken?: string;
+      accountName: string;
+      controlUrl?: string;
+      dataPlane: DataPlaneConfig;
+    },
+  ): void {
+    const existing = this.config.accounts[alias];
+
+    this.config.accounts[alias] = {
+      ...existing,
+      accessToken: info.accessToken,
+      accountId: existing?.accountId ?? "",
+      accountName: info.accountName,
+      apps: existing?.apps ?? {},
+      authMethod: "apiKey",
+      controlUrl: info.controlUrl,
+      currentAppId: existing?.currentAppId,
+      endpoint: info.dataPlane.endpoint,
+      port: info.dataPlane.port,
+      tls: info.dataPlane.tls,
+      userEmail: existing?.userEmail ?? "",
+    };
+
+    // A local account never references an OAuth session. Drop any fields
+    // carried over by the spread so re-logging in over a previous managed
+    // account with the same alias cannot leave stale OAuth state behind.
+    delete this.config.accounts[alias].accessTokenExpiresAt;
+    delete this.config.accounts[alias].controlHost;
+    delete this.config.accounts[alias].oauthHost;
+    delete this.config.accounts[alias].oauthSessionKey;
+    delete this.config.accounts[alias].tokenId;
+
+    if (!this.config.current || !this.config.current.account) {
+      this.config.current = { account: alias };
+    }
+
     this.saveConfig();
   }
 
@@ -703,7 +810,7 @@ export class TomlConfigManager implements ConfigManager {
   }
 
   // Get the auth method for the current account or specific alias
-  public getAuthMethod(alias?: string): "oauth" | undefined {
+  public getAuthMethod(alias?: string): "apiKey" | "oauth" | undefined {
     const account = alias
       ? this.config.accounts[alias]
       : this.getCurrentAccount();

--- a/src/services/control-api.ts
+++ b/src/services/control-api.ts
@@ -7,6 +7,10 @@ import type { TokenRefreshMiddleware } from "./token-refresh-middleware.js";
 export interface ControlApiOptions {
   accessToken: string;
   controlHost?: string;
+  // Full base URL for a locally-run control plane, e.g.
+  // "http://localhost:8082". Takes precedence over controlHost, which is only
+  // a hostname and so cannot express a port or a plaintext scheme.
+  controlUrl?: string;
   logErrors?: boolean;
   tokenRefreshMiddleware?: TokenRefreshMiddleware;
 }
@@ -188,12 +192,14 @@ export interface AccountSummary {
 export class ControlApi {
   private accessToken: string;
   private controlHost: string;
+  private controlUrl?: string;
   private logErrors: boolean;
   private tokenRefreshMiddleware?: TokenRefreshMiddleware;
 
   constructor(options: ControlApiOptions) {
     this.accessToken = options.accessToken;
     this.controlHost = options.controlHost || "control.ably.net";
+    this.controlUrl = options.controlUrl;
     this.tokenRefreshMiddleware = options.tokenRefreshMiddleware;
     // Explicit options.logErrors overrides env var; otherwise suppress in CI/test
     if (options.logErrors === undefined) {
@@ -205,6 +211,33 @@ export class ControlApi {
     } else {
       this.logErrors = options.logErrors;
     }
+  }
+
+  /**
+   * Resolve the base URL that request paths are appended to.
+   *
+   * The dedicated Control API service (control.ably.net) serves at `/v1/`,
+   * while the website itself (ably.com and Heroku review apps) proxies the
+   * Control API at `/api/v1/`. For host-only configuration we infer which is
+   * which; an explicit controlUrl states it directly, and a locally-run
+   * control plane is the dedicated service, so it defaults to `/v1`.
+   */
+  private baseUrl(): string {
+    if (this.controlUrl) {
+      const base = this.controlUrl.replace(/\/+$/, "");
+      // A caller-supplied path is treated as the full prefix; only append the
+      // default when the URL is a bare origin.
+      const hasPath = new URL(base).pathname !== "/";
+      return hasPath ? base : `${base}/v1`;
+    }
+
+    // Match hosts whose first label starts with "control" so both `control.`
+    // and `control-*.` variants route correctly, case insensitively so
+    // ABLY_CONTROL_HOST values aren't locale-sensitive.
+    const isControlService = /^control[-.]/i.test(this.controlHost);
+    const scheme = this.controlHost.includes("local") ? "http" : "https";
+    const prefix = isControlService ? "/v1" : "/api/v1";
+    return `${scheme}://${this.controlHost}${prefix}`;
   }
 
   // Ask a question to the Ably AI agent
@@ -566,15 +599,7 @@ export class ControlApi {
         await this.tokenRefreshMiddleware.getValidAccessToken();
     }
 
-    // The dedicated Control API service (control.ably.net) serves at `/v1/`.
-    // The website itself (ably.com and Heroku review apps) proxies the
-    // Control API at `/api/v1/`. Match hosts whose first label starts with
-    // "control" so both `control.` and `control-*.` variants route correctly,
-    // case insensitively so ABLY_CONTROL_HOST values aren't locale-sensitive.
-    const isControlService = /^control[-.]/i.test(this.controlHost);
-    const scheme = this.controlHost.includes("local") ? "http" : "https";
-    const prefix = isControlService ? "/v1" : "/api/v1";
-    const url = `${scheme}://${this.controlHost}${prefix}${path}`;
+    const url = `${this.baseUrl()}${path}`;
 
     const isFormData = body instanceof FormData;
     const options: RequestInit = {

--- a/src/services/control-api.ts
+++ b/src/services/control-api.ts
@@ -189,6 +189,48 @@ export interface AccountSummary {
   name: string;
 }
 
+/**
+ * Scheme used to reach a control plane host. A locally-run control plane is
+ * served over plaintext; everything else is HTTPS. Exported so the "Using:"
+ * banner renders the same URL the requests will actually go to.
+ */
+export function controlHostScheme(host: string): "http" | "https" {
+  return host.includes("local") ? "http" : "https";
+}
+
+/**
+ * Normalise a control plane base URL, once, so a malformed stored value fails
+ * with a diagnosable message at construction rather than as a raw TypeError
+ * from inside every request.
+ *
+ * The dedicated Control API service (control.ably.net, and a locally-run
+ * control plane) serves at `/v1/`, so a bare origin gets that suffix; a
+ * caller-supplied path is taken as the full prefix and left alone.
+ */
+function normalizeControlBaseUrl(raw: string): string {
+  const base = raw.replace(/\/+$/, "");
+
+  let parsed: URL | undefined;
+  try {
+    parsed = new URL(base);
+  } catch {
+    // Fall through to the shared error below.
+  }
+
+  // "localhost:8082" parses, as a URL whose scheme is "localhost" — so the
+  // scheme has to be checked, not just the parse.
+  if (
+    !parsed ||
+    (parsed.protocol !== "http:" && parsed.protocol !== "https:")
+  ) {
+    throw new Error(
+      `Invalid control plane URL "${raw}". Expected a value like http://localhost:8082.`,
+    );
+  }
+
+  return parsed.pathname === "/" ? `${base}/v1` : base;
+}
+
 export class ControlApi {
   private accessToken: string;
   private controlHost: string;
@@ -199,7 +241,10 @@ export class ControlApi {
   constructor(options: ControlApiOptions) {
     this.accessToken = options.accessToken;
     this.controlHost = options.controlHost || "control.ably.net";
-    this.controlUrl = options.controlUrl;
+    this.controlUrl =
+      options.controlUrl === undefined
+        ? undefined
+        : normalizeControlBaseUrl(options.controlUrl);
     this.tokenRefreshMiddleware = options.tokenRefreshMiddleware;
     // Explicit options.logErrors overrides env var; otherwise suppress in CI/test
     if (options.logErrors === undefined) {
@@ -216,28 +261,21 @@ export class ControlApi {
   /**
    * Resolve the base URL that request paths are appended to.
    *
-   * The dedicated Control API service (control.ably.net) serves at `/v1/`,
-   * while the website itself (ably.com and Heroku review apps) proxies the
-   * Control API at `/api/v1/`. For host-only configuration we infer which is
-   * which; an explicit controlUrl states it directly, and a locally-run
-   * control plane is the dedicated service, so it defaults to `/v1`.
+   * An explicit controlUrl states the base directly (normalised at
+   * construction). For host-only configuration the prefix is inferred: the
+   * dedicated Control API service (control.ably.net) serves at `/v1/`, while
+   * the website itself (ably.com and Heroku review apps) proxies the Control
+   * API at `/api/v1/`.
    */
   private baseUrl(): string {
-    if (this.controlUrl) {
-      const base = this.controlUrl.replace(/\/+$/, "");
-      // A caller-supplied path is treated as the full prefix; only append the
-      // default when the URL is a bare origin.
-      const hasPath = new URL(base).pathname !== "/";
-      return hasPath ? base : `${base}/v1`;
-    }
+    if (this.controlUrl) return this.controlUrl;
 
     // Match hosts whose first label starts with "control" so both `control.`
     // and `control-*.` variants route correctly, case insensitively so
     // ABLY_CONTROL_HOST values aren't locale-sensitive.
     const isControlService = /^control[-.]/i.test(this.controlHost);
-    const scheme = this.controlHost.includes("local") ? "http" : "https";
     const prefix = isControlService ? "/v1" : "/api/v1";
-    return `${scheme}://${this.controlHost}${prefix}`;
+    return `${controlHostScheme(this.controlHost)}://${this.controlHost}${prefix}`;
   }
 
   // Ask a question to the Ably AI agent

--- a/src/types/cli.ts
+++ b/src/types/cli.ts
@@ -7,7 +7,10 @@ export interface BaseFlags {
   "api-key"?: string; // Not a CLI flag; set internally by ensureAppAndKey
   "client-id"?: string;
   "control-host"?: string;
+  "control-url"?: string;
   "dashboard-host"?: string;
+  local?: boolean;
+  url?: string;
   "oauth-host"?: string;
   endpoint?: string;
   port?: number;

--- a/src/utils/api-key.ts
+++ b/src/utils/api-key.ts
@@ -7,6 +7,17 @@ export function extractAppIdFromApiKey(apiKey: string): string {
 }
 
 /**
+ * True when the value has the full `APP_ID.KEY_ID:KEY_SECRET` shape.
+ *
+ * `extractAppIdFromApiKey` is deliberately lenient — it returns the whole
+ * string for input with no separators — so callers that accept a key straight
+ * from the user should check the shape first.
+ */
+export function isValidApiKey(apiKey: string): boolean {
+  return /^[^\s.:]+\.[^\s.:]+:\S+$/.test(apiKey);
+}
+
+/**
  * Returns the "key name" portion — everything before the `:` separator
  * (i.e. `APP_ID.KEY_ID`). Empty string if the input is not a valid key.
  */

--- a/src/utils/prompt-value.ts
+++ b/src/utils/prompt-value.ts
@@ -1,0 +1,33 @@
+import { input, password } from "@inquirer/prompts";
+
+const requireNonEmpty = (value: string) =>
+  value.trim().length > 0 || "A value is required";
+
+/**
+ * Prompt for a free-text value, re-asking until a non-empty answer is given.
+ *
+ * @param message - Label shown before the input
+ * @param options.defaultValue - Returned when the user submits an empty line
+ * @param options.secret - Mask the input, for credentials that should not be
+ *   echoed into terminal scrollback
+ */
+export async function promptForValue(
+  message: string,
+  options: { defaultValue?: string; secret?: boolean } = {},
+): Promise<string> {
+  if (options.secret) {
+    const answer = await password({
+      mask: true,
+      message,
+      validate: requireNonEmpty,
+    });
+    return answer.trim();
+  }
+
+  const answer = await input({
+    default: options.defaultValue,
+    message,
+    validate: requireNonEmpty,
+  });
+  return answer.trim();
+}

--- a/src/utils/server-url.ts
+++ b/src/utils/server-url.ts
@@ -66,6 +66,21 @@ export function parseServerUrl(raw: string): ServerUrl {
     );
   }
 
+  // Nothing downstream can carry these, and dropping them silently would
+  // resurface later as an unrelated auth or routing error. Rejecting them is
+  // the same choice made for paths below.
+  if (url.username || url.password) {
+    throw new Error(
+      `Credentials are not supported in "${raw}". Pass the API key separately.`,
+    );
+  }
+
+  if (url.search || url.hash) {
+    throw new Error(
+      `Query strings and fragments are not supported in "${raw}". Expected a value like http://localhost:8081.`,
+    );
+  }
+
   const path = url.pathname === "/" ? "" : url.pathname.replace(/\/+$/, "");
 
   return {
@@ -84,4 +99,28 @@ export function formatServerUrl(server: ServerUrl): string {
   const scheme = server.tls ? "https" : "http";
   const port = server.port === undefined ? "" : `:${server.port}`;
   return `${scheme}://${server.host}${port}${server.path}`;
+}
+
+/**
+ * Render stored routing — the SDK's `endpoint`/`port`/`tls` triple, as held on
+ * an account or resolved from flags and environment — as a URL, or undefined
+ * when no endpoint is configured.
+ *
+ * Every place that reports which server a command is pointed at goes through
+ * this, so a server is always identified the same way: by URL, never by a bare
+ * hostname that hides the port and the scheme.
+ */
+export function formatEndpointUrl(routing?: {
+  endpoint?: string;
+  port?: number;
+  tls?: boolean;
+}): string | undefined {
+  if (!routing?.endpoint) return undefined;
+
+  return formatServerUrl({
+    host: routing.endpoint,
+    path: "",
+    port: routing.port,
+    tls: routing.tls ?? true,
+  });
 }

--- a/src/utils/server-url.ts
+++ b/src/utils/server-url.ts
@@ -1,0 +1,87 @@
+/**
+ * Parsing for local server URLs supplied to `ably accounts login --local`.
+ *
+ * The Ably SDK takes routing as three separate client options (`endpoint`,
+ * `port`/`tlsPort`, `tls`) rather than a URL, and the Control API takes a bare
+ * host. A single `--url http://localhost:8081` is far easier to type and to
+ * remember than three flags, so we accept a URL and decompose it here.
+ */
+
+/** A local server URL decomposed into the parts the SDK and Control API need. */
+export interface ServerUrl {
+  /** Hostname with no scheme, port, or path — the SDK's `endpoint` option. */
+  host: string;
+  /** Path component, normalised to "" when the URL has none. */
+  path: string;
+  /** Port, or undefined when the URL relies on the scheme default. */
+  port?: number;
+  /** True for https, false for http. */
+  tls: boolean;
+}
+
+const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "[::1]", "::1"]);
+
+const SCHEME_PATTERN = /^[a-z][\d+.a-z-]*:\/\//i;
+
+function isLoopback(host: string): boolean {
+  return LOOPBACK_HOSTS.has(host.toLowerCase());
+}
+
+/**
+ * Parse a local server URL into its SDK-facing parts.
+ *
+ * Accepts a full URL ("http://localhost:8081") or a bare host and port
+ * ("localhost:8081"). Schemeless input defaults to http for loopback hosts and
+ * https for everything else, so the common local case needs no scheme while a
+ * remote host is never silently downgraded to plaintext.
+ *
+ * @throws Error with a user-facing message when the input cannot be parsed.
+ */
+export function parseServerUrl(raw: string): ServerUrl {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    throw new Error("URL cannot be empty.");
+  }
+
+  const hasScheme = SCHEME_PATTERN.test(trimmed);
+
+  let url: URL;
+  try {
+    url = new URL(hasScheme ? trimmed : `http://${trimmed}`);
+  } catch {
+    throw new Error(
+      `Invalid URL "${raw}". Expected a value like http://localhost:8081.`,
+    );
+  }
+
+  if (hasScheme && url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error(
+      `Unsupported scheme "${url.protocol.replace(":", "")}" in "${raw}". Use http:// or https://.`,
+    );
+  }
+
+  if (!url.hostname) {
+    throw new Error(
+      `Invalid URL "${raw}". Expected a value like http://localhost:8081.`,
+    );
+  }
+
+  const path = url.pathname === "/" ? "" : url.pathname.replace(/\/+$/, "");
+
+  return {
+    host: url.hostname,
+    path,
+    port: url.port ? Number.parseInt(url.port, 10) : undefined,
+    tls: hasScheme ? url.protocol === "https:" : !isLoopback(url.hostname),
+  };
+}
+
+/**
+ * Render a parsed server URL back to a canonical string, for display and for
+ * storing the control plane base URL in config.
+ */
+export function formatServerUrl(server: ServerUrl): string {
+  const scheme = server.tls ? "https" : "http";
+  const port = server.port === undefined ? "" : `:${server.port}`;
+  return `${scheme}://${server.host}${port}${server.path}`;
+}

--- a/test/helpers/mock-config-manager.ts
+++ b/test/helpers/mock-config-manager.ts
@@ -24,6 +24,7 @@ import type {
   AccountConfig,
   AppConfig,
   ConfigManager,
+  DataPlaneConfig,
 } from "../../src/services/config-manager.js";
 
 // Kept in sync with DEFAULT_OAUTH_HOST in src/services/oauth-client.ts.
@@ -277,6 +278,34 @@ export class MockConfigManager implements ConfigManager {
     return currentAccount?.endpoint;
   }
 
+  public getDataPlane(alias?: string): DataPlaneConfig | undefined {
+    const account = alias
+      ? this.config.accounts[alias]
+      : this.getCurrentAccount();
+    if (!account) return undefined;
+
+    if (
+      account.endpoint === undefined &&
+      account.port === undefined &&
+      account.tls === undefined
+    ) {
+      return undefined;
+    }
+
+    return {
+      endpoint: account.endpoint,
+      port: account.port,
+      tls: account.tls,
+    };
+  }
+
+  public getControlUrl(alias?: string): string | undefined {
+    const account = alias
+      ? this.config.accounts[alias]
+      : this.getCurrentAccount();
+    return account?.controlUrl;
+  }
+
   public getCurrentAccount(): AccountConfig | undefined {
     const currentAlias = this.getCurrentAccountAlias();
     if (!currentAlias) return undefined;
@@ -446,6 +475,43 @@ export class MockConfigManager implements ConfigManager {
     }
 
     this.config.accounts[targetAlias].endpoint = endpoint;
+  }
+
+  public storeLocalAccount(
+    alias: string,
+    info: {
+      accessToken?: string;
+      accountName: string;
+      controlUrl?: string;
+      dataPlane: DataPlaneConfig;
+    },
+  ): void {
+    const existing = this.config.accounts[alias];
+
+    this.config.accounts[alias] = {
+      ...existing,
+      accessToken: info.accessToken,
+      accountId: existing?.accountId ?? "",
+      accountName: info.accountName,
+      apps: existing?.apps ?? {},
+      authMethod: "apiKey",
+      controlUrl: info.controlUrl,
+      currentAppId: existing?.currentAppId,
+      endpoint: info.dataPlane.endpoint,
+      port: info.dataPlane.port,
+      tls: info.dataPlane.tls,
+      userEmail: existing?.userEmail ?? "",
+    };
+
+    delete this.config.accounts[alias].accessTokenExpiresAt;
+    delete this.config.accounts[alias].controlHost;
+    delete this.config.accounts[alias].oauthHost;
+    delete this.config.accounts[alias].oauthSessionKey;
+    delete this.config.accounts[alias].tokenId;
+
+    if (!this.config.current || !this.config.current.account) {
+      this.config.current = { account: alias };
+    }
   }
 
   public storeAppInfo(
@@ -644,7 +710,7 @@ export class MockConfigManager implements ConfigManager {
     return Date.now() >= expiresAt - 60_000;
   }
 
-  public getAuthMethod(alias?: string): "oauth" | undefined {
+  public getAuthMethod(alias?: string): "apiKey" | "oauth" | undefined {
     const account = alias
       ? this.config.accounts[alias]
       : this.getCurrentAccount();

--- a/test/integration/env.test.ts
+++ b/test/integration/env.test.ts
@@ -5,6 +5,8 @@ import { promisify } from "node:util";
 
 import { beforeAll, describe, expect, it } from "vitest";
 
+import { ENV_VARS_DATA } from "../../src/data/env-vars.js";
+
 const execAsync = promisify(exec);
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -67,7 +69,10 @@ describe("env command (integration)", () => {
       expect(result.type).toBe("result");
       expect(result.command).toBe("env");
       expect(result.success).toBe(true);
-      expect(result.envVars).toHaveLength(9);
+      // Compare against the registry rather than a literal: the count is
+      // already pinned by the unit tests, and duplicating it here only adds
+      // another place to forget when a variable is added.
+      expect(result.envVars).toHaveLength(ENV_VARS_DATA.variables.length);
     },
     timeout,
   );

--- a/test/unit/base/auth-info-display.test.ts
+++ b/test/unit/base/auth-info-display.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { Config } from "@oclif/core";
 import nock from "nock";
+import stripAnsi from "strip-ansi";
 
 import { AblyBaseCommand } from "../../../src/base-command.js";
 import { BaseFlags } from "../../../src/types/cli.js";
@@ -8,6 +9,13 @@ import { ConfigManager } from "../../../src/services/config-manager.js";
 
 // Test implementation of AblyBaseCommand for testing protected methods
 class TestCommand extends AblyBaseCommand {
+  /** Stands in for extending ControlBaseCommand, which overrides this. */
+  public controlApiCommand = false;
+
+  protected override get usesControlApi(): boolean {
+    return this.controlApiCommand;
+  }
+
   // Implement the abstract run method required by oclif
   async run(): Promise<void> {
     // No-op for testing
@@ -75,14 +83,21 @@ describe("Auth Info Display", function () {
   let logStub: ReturnType<typeof vi.fn>;
   let debugStub: ReturnType<typeof vi.fn>;
 
-  /** Run displayAuthInfo and return the rendered "Using:" line. */
-  const usingLine = async (showAppInfo = true): Promise<string> => {
-    await command.testDisplayAuthInfo({}, showAppInfo);
+  /**
+   * Run displayAuthInfo and return the rendered "Using:" line, with colour
+   * stripped — labels and values are coloured separately, so assertions on
+   * "Endpoint=<value>" only see contiguous text once the codes are gone.
+   */
+  const usingLine = async (
+    showAppInfo = true,
+    flags: BaseFlags = {},
+  ): Promise<string> => {
+    await command.testDisplayAuthInfo(flags, showAppInfo);
     const outputCalls = logStub.mock.calls.map((call) => call[0]);
     const line = outputCalls.find(
       (output) => typeof output === "string" && output.includes("Using:"),
     );
-    return typeof line === "string" ? line : "";
+    return typeof line === "string" ? stripAnsi(line) : "";
   };
 
   beforeEach(function () {
@@ -215,30 +230,33 @@ describe("Auth Info Display", function () {
       expect(outputWithUsingPrefix).toContain("Account=");
     });
 
-    describe("endpoint override display", function () {
+    describe("endpoint display", function () {
       beforeEach(function () {
         shouldHideAccountInfoStub.mockReturnValue(false);
         delete process.env.ABLY_ENDPOINT;
+        delete process.env.ABLY_URL;
         delete process.env.ABLY_CONTROL_HOST;
       });
 
       afterEach(function () {
         delete process.env.ABLY_ENDPOINT;
+        delete process.env.ABLY_URL;
         delete process.env.ABLY_CONTROL_HOST;
       });
 
-      it("omits the endpoint for a profile with its own routing", async function () {
-        // A local server profile is a deliberate choice — not worth repeating.
+      it("shows the profile's own endpoint as a URL", async function () {
+        // Running against a local server must never look identical to running
+        // against production, so the profile's routing is always stated.
         configManagerStub.getDataPlane.mockReturnValue({
           endpoint: "localhost",
           port: 8081,
           tls: false,
         });
 
-        expect(await usingLine()).not.toContain("Endpoint=");
+        expect(await usingLine()).toContain("Endpoint=http://localhost:8081");
       });
 
-      it("omits the endpoint for a managed account with no override", async function () {
+      it("omits the endpoint for a managed account on Ably's own endpoints", async function () {
         configManagerStub.getDataPlane.mockReturnValue();
 
         expect(await usingLine()).not.toContain("Endpoint=");
@@ -268,31 +286,57 @@ describe("Auth Info Display", function () {
         );
       });
 
-      it("omits the endpoint when ABLY_ENDPOINT matches the profile", async function () {
-        process.env.ABLY_ENDPOINT = "localhost";
+      it("shows the endpoint from --url", async function () {
+        configManagerStub.getDataPlane.mockReturnValue();
+
+        expect(
+          await usingLine(true, { url: "http://localhost:9000" }),
+        ).toContain("Endpoint=http://localhost:9000");
+      });
+
+      it("shows the stored control URL on control plane commands", async function () {
+        command.controlApiCommand = true;
+        configManagerStub.getControlUrl.mockReturnValue(
+          "http://localhost:8082",
+        );
+
+        expect(await usingLine(false)).toContain(
+          "Endpoint=http://localhost:8082",
+        );
+      });
+
+      it("shows ABLY_CONTROL_HOST as a URL on control plane commands", async function () {
+        command.controlApiCommand = true;
+        process.env.ABLY_CONTROL_HOST = "control.example.com";
+
+        expect(await usingLine(false)).toContain(
+          "Endpoint=https://control.example.com",
+        );
+      });
+
+      it("omits the endpoint on control plane commands with no override", async function () {
+        command.controlApiCommand = true;
+
+        expect(await usingLine(false)).not.toContain("Endpoint=");
+      });
+
+      it("names the control plane, not the data plane, for control commands that show app info", async function () {
+        // `apps list` reports app and key context but talks to a control plane.
+        command.controlApiCommand = true;
+        configManagerStub.getControlUrl.mockReturnValue(
+          "http://localhost:8082",
+        );
         configManagerStub.getDataPlane.mockReturnValue({
           endpoint: "localhost",
           port: 8081,
           tls: false,
         });
 
-        expect(await usingLine()).not.toContain("Endpoint=");
-      });
+        const banner = await usingLine();
 
-      it("shows ABLY_CONTROL_HOST on control plane commands", async function () {
-        process.env.ABLY_CONTROL_HOST = "control.example.com";
-
-        expect(await usingLine(false)).toContain(
-          "Endpoint=control.example.com",
-        );
-      });
-
-      it("omits the endpoint on control plane commands with no override", async function () {
-        configManagerStub.getControlUrl.mockReturnValue(
-          "http://localhost:8082",
-        );
-
-        expect(await usingLine(false)).not.toContain("Endpoint=");
+        expect(banner).toContain("Endpoint=http://localhost:8082");
+        expect(banner).not.toContain("8081");
+        expect(banner).toContain("App=");
       });
     });
 

--- a/test/unit/base/auth-info-display.test.ts
+++ b/test/unit/base/auth-info-display.test.ts
@@ -63,6 +63,8 @@ describe("Auth Info Display", function () {
     getAppName: ReturnType<typeof vi.fn>;
     getApiKey: ReturnType<typeof vi.fn>;
     getEndpoint: ReturnType<typeof vi.fn>;
+    getDataPlane: ReturnType<typeof vi.fn>;
+    getControlUrl: ReturnType<typeof vi.fn>;
     getKeyName: ReturnType<typeof vi.fn>;
     getAccessToken: ReturnType<typeof vi.fn>;
     getAppConfig: ReturnType<typeof vi.fn>;
@@ -73,6 +75,16 @@ describe("Auth Info Display", function () {
   let logStub: ReturnType<typeof vi.fn>;
   let debugStub: ReturnType<typeof vi.fn>;
 
+  /** Run displayAuthInfo and return the rendered "Using:" line. */
+  const usingLine = async (showAppInfo = true): Promise<string> => {
+    await command.testDisplayAuthInfo({}, showAppInfo);
+    const outputCalls = logStub.mock.calls.map((call) => call[0]);
+    const line = outputCalls.find(
+      (output) => typeof output === "string" && output.includes("Using:"),
+    );
+    return typeof line === "string" ? line : "";
+  };
+
   beforeEach(function () {
     // Create mock config manager
     configManagerStub = {
@@ -81,6 +93,8 @@ describe("Auth Info Display", function () {
       getAppName: vi.fn(),
       getApiKey: vi.fn(),
       getEndpoint: vi.fn(),
+      getDataPlane: vi.fn(),
+      getControlUrl: vi.fn(),
       getKeyName: vi.fn(),
       getAccessToken: vi.fn(),
       getAppConfig: vi.fn(),
@@ -199,6 +213,87 @@ describe("Auth Info Display", function () {
         (output) => typeof output === "string" && output.includes("Using:"),
       );
       expect(outputWithUsingPrefix).toContain("Account=");
+    });
+
+    describe("endpoint override display", function () {
+      beforeEach(function () {
+        shouldHideAccountInfoStub.mockReturnValue(false);
+        delete process.env.ABLY_ENDPOINT;
+        delete process.env.ABLY_CONTROL_HOST;
+      });
+
+      afterEach(function () {
+        delete process.env.ABLY_ENDPOINT;
+        delete process.env.ABLY_CONTROL_HOST;
+      });
+
+      it("omits the endpoint for a profile with its own routing", async function () {
+        // A local server profile is a deliberate choice — not worth repeating.
+        configManagerStub.getDataPlane.mockReturnValue({
+          endpoint: "localhost",
+          port: 8081,
+          tls: false,
+        });
+
+        expect(await usingLine()).not.toContain("Endpoint=");
+      });
+
+      it("omits the endpoint for a managed account with no override", async function () {
+        configManagerStub.getDataPlane.mockReturnValue();
+
+        expect(await usingLine()).not.toContain("Endpoint=");
+      });
+
+      it("shows the endpoint when ABLY_ENDPOINT redirects a managed account", async function () {
+        process.env.ABLY_ENDPOINT = "other.example.com";
+        configManagerStub.getDataPlane.mockReturnValue();
+
+        expect(await usingLine()).toContain(
+          "Endpoint=https://other.example.com",
+        );
+      });
+
+      it("shows the endpoint when ABLY_ENDPOINT redirects away from the profile", async function () {
+        process.env.ABLY_ENDPOINT = "other.example.com";
+        configManagerStub.getDataPlane.mockReturnValue({
+          endpoint: "localhost",
+          port: 8081,
+          tls: false,
+        });
+
+        // Port and TLS still come from the profile, so the displayed URL is
+        // the combination traffic will actually use.
+        expect(await usingLine()).toContain(
+          "Endpoint=http://other.example.com:8081",
+        );
+      });
+
+      it("omits the endpoint when ABLY_ENDPOINT matches the profile", async function () {
+        process.env.ABLY_ENDPOINT = "localhost";
+        configManagerStub.getDataPlane.mockReturnValue({
+          endpoint: "localhost",
+          port: 8081,
+          tls: false,
+        });
+
+        expect(await usingLine()).not.toContain("Endpoint=");
+      });
+
+      it("shows ABLY_CONTROL_HOST on control plane commands", async function () {
+        process.env.ABLY_CONTROL_HOST = "control.example.com";
+
+        expect(await usingLine(false)).toContain(
+          "Endpoint=control.example.com",
+        );
+      });
+
+      it("omits the endpoint on control plane commands with no override", async function () {
+        configManagerStub.getControlUrl.mockReturnValue(
+          "http://localhost:8082",
+        );
+
+        expect(await usingLine(false)).not.toContain("Endpoint=");
+      });
     });
 
     it("should not display anything when there are no parts to show", async function () {

--- a/test/unit/base/auth-info-display.test.ts
+++ b/test/unit/base/auth-info-display.test.ts
@@ -404,6 +404,38 @@ describe("Auth Info Display", function () {
         nock.cleanAll();
       }
     });
+
+    describe("unresolved app name", function () {
+      beforeEach(function () {
+        shouldHideAccountInfoStub.mockReturnValue(false);
+        configManagerStub.getCurrentAppId.mockReturnValue("3p4xqQ");
+        configManagerStub.getAppName.mockReturnValue();
+        configManagerStub.getApiKey.mockReturnValue("3p4xqQ.keyid:secret");
+      });
+
+      it("shows the bare app ID rather than inventing a name", async function () {
+        // A local server account with no control plane has nowhere to look the
+        // name up. The ID is known, so pairing it with a placeholder would be
+        // stating something false.
+        configManagerStub.getAuthMethod.mockReturnValue("apiKey");
+        configManagerStub.getControlUrl.mockReturnValue();
+
+        const banner = await usingLine();
+
+        expect(banner).toContain("App=3p4xqQ");
+        expect(banner).not.toContain("Unknown App");
+        expect(banner).not.toContain("(3p4xqQ)");
+      });
+
+      it("pairs name and ID once the name is known", async function () {
+        configManagerStub.getAppName.mockReturnValue("My App");
+
+        const banner = await usingLine();
+
+        expect(banner).toContain("App=My App");
+        expect(banner).toContain("(3p4xqQ)");
+      });
+    });
   });
 
   describe("showAuthInfoIfNeeded", function () {

--- a/test/unit/base/base-command.test.ts
+++ b/test/unit/base/base-command.test.ts
@@ -766,6 +766,96 @@ describe("AblyBaseCommand", function () {
       delete process.env.ABLY_ENDPOINT;
     });
 
+    it("applies ABLY_URL as host, port and TLS together", function () {
+      process.env.ABLY_URL = "http://localhost:8081";
+      configManagerStub.getDataPlane.mockReturnValue();
+
+      const clientOptions = command.testGetClientOptions({});
+
+      expect(clientOptions.endpoint).toBe("localhost");
+      expect(clientOptions.tls).toBe(false);
+      expect(clientOptions.port).toBe(8081);
+      expect(clientOptions.tlsPort).toBeUndefined();
+
+      delete process.env.ABLY_URL;
+    });
+
+    it("accepts a schemeless ABLY_URL for loopback hosts", function () {
+      process.env.ABLY_URL = "localhost:8081";
+      configManagerStub.getDataPlane.mockReturnValue();
+
+      const clientOptions = command.testGetClientOptions({});
+
+      expect(clientOptions.endpoint).toBe("localhost");
+      expect(clientOptions.tls).toBe(false);
+      expect(clientOptions.port).toBe(8081);
+
+      delete process.env.ABLY_URL;
+    });
+
+    it("lets ABLY_URL win over ABLY_ENDPOINT and the profile", function () {
+      process.env.ABLY_URL = "http://localhost:9091";
+      process.env.ABLY_ENDPOINT = "ignored.example.com";
+      configManagerStub.getDataPlane.mockReturnValue({
+        endpoint: "localhost",
+        port: 8081,
+        tls: false,
+      });
+
+      const clientOptions = command.testGetClientOptions({});
+
+      expect(clientOptions.endpoint).toBe("localhost");
+      expect(clientOptions.port).toBe(9091);
+
+      delete process.env.ABLY_URL;
+      delete process.env.ABLY_ENDPOINT;
+    });
+
+    it("lets --url win over ABLY_URL", function () {
+      process.env.ABLY_URL = "http://localhost:9091";
+      configManagerStub.getDataPlane.mockReturnValue();
+
+      const clientOptions = command.testGetClientOptions({
+        url: "http://localhost:7071",
+      });
+
+      expect(clientOptions.port).toBe(7071);
+
+      delete process.env.ABLY_URL;
+    });
+
+    it("lets an explicit --port override a --url port", function () {
+      configManagerStub.getDataPlane.mockReturnValue();
+
+      const clientOptions = command.testGetClientOptions({
+        port: 1234,
+        url: "http://localhost:8081",
+      });
+
+      expect(clientOptions.endpoint).toBe("localhost");
+      expect(clientOptions.port).toBe(1234);
+    });
+
+    it("fails on an ABLY_URL that includes a path", function () {
+      process.env.ABLY_URL = "http://localhost:8081/realtime";
+      configManagerStub.getDataPlane.mockReturnValue();
+
+      expect(() => command.testGetClientOptions({})).toThrow(
+        /must not include a path/,
+      );
+
+      delete process.env.ABLY_URL;
+    });
+
+    it("fails on an unparseable ABLY_URL, naming the source", function () {
+      process.env.ABLY_URL = "ws://localhost:8081";
+      configManagerStub.getDataPlane.mockReturnValue();
+
+      expect(() => command.testGetClientOptions({})).toThrow(/ABLY_URL/);
+
+      delete process.env.ABLY_URL;
+    });
+
     it("leaves routing options unset for a managed account", function () {
       // A managed account has no routing overrides stored.
       configManagerStub.getDataPlane.mockReturnValue();

--- a/test/unit/base/base-command.test.ts
+++ b/test/unit/base/base-command.test.ts
@@ -96,6 +96,7 @@ type MockConfigManager = ConfigManager & {
   getApiKey: ReturnType<typeof vi.fn>;
   getAccessToken: ReturnType<typeof vi.fn>;
   getEndpoint: ReturnType<typeof vi.fn>;
+  getDataPlane: ReturnType<typeof vi.fn>;
   selectKey: ReturnType<typeof vi.fn>;
   selectApp: ReturnType<typeof vi.fn>;
   setCurrentApp: ReturnType<typeof vi.fn>;
@@ -135,6 +136,7 @@ describe("AblyBaseCommand", function () {
       getApiKey: vi.fn(),
       getAccessToken: vi.fn(),
       getEndpoint: vi.fn(),
+      getDataPlane: vi.fn(),
       selectKey: vi.fn(),
       selectApp: vi.fn(),
       setCurrentApp: vi.fn(),
@@ -675,6 +677,105 @@ describe("AblyBaseCommand", function () {
 
       delete process.env.ABLY_ENDPOINT;
       delete process.env.ABLY_API_KEY;
+    });
+  });
+
+  describe("local server data plane resolution", function () {
+    beforeEach(function () {
+      delete process.env.ABLY_ENDPOINT;
+      process.env.ABLY_API_KEY = "test-key:secret";
+    });
+
+    afterEach(function () {
+      delete process.env.ABLY_API_KEY;
+    });
+
+    it("applies a stored plaintext endpoint, port and tls setting", function () {
+      configManagerStub.getDataPlane.mockReturnValue({
+        endpoint: "localhost",
+        port: 8081,
+        tls: false,
+      });
+
+      const clientOptions = command.testGetClientOptions({});
+
+      expect(clientOptions.endpoint).toBe("localhost");
+      expect(clientOptions.tls).toBe(false);
+      expect(clientOptions.port).toBe(8081);
+      // With TLS off the SDK reads `port`, so tlsPort must stay unset.
+      expect(clientOptions.tlsPort).toBeUndefined();
+    });
+
+    it("routes a stored port to tlsPort when TLS is on", function () {
+      configManagerStub.getDataPlane.mockReturnValue({
+        endpoint: "server.example.com",
+        port: 8443,
+        tls: true,
+      });
+
+      const clientOptions = command.testGetClientOptions({});
+
+      expect(clientOptions.tls).toBe(true);
+      expect(clientOptions.tlsPort).toBe(8443);
+      expect(clientOptions.port).toBeUndefined();
+    });
+
+    it("treats an unset tls value as TLS enabled", function () {
+      configManagerStub.getDataPlane.mockReturnValue({
+        endpoint: "server.example.com",
+        port: 8443,
+      });
+
+      const clientOptions = command.testGetClientOptions({});
+
+      expect(clientOptions.tlsPort).toBe(8443);
+      expect(clientOptions.port).toBeUndefined();
+    });
+
+    it("lets explicit flags override stored values", function () {
+      configManagerStub.getDataPlane.mockReturnValue({
+        endpoint: "localhost",
+        port: 8081,
+        tls: false,
+      });
+
+      const clientOptions = command.testGetClientOptions({
+        port: 9999,
+        tls: "true",
+        "tls-port": 8443,
+      });
+
+      expect(clientOptions.tls).toBe(true);
+      expect(clientOptions.port).toBe(9999);
+      expect(clientOptions.tlsPort).toBe(8443);
+    });
+
+    it("lets ABLY_ENDPOINT override the stored endpoint but keep the stored port", function () {
+      process.env.ABLY_ENDPOINT = "other.example.com";
+      configManagerStub.getDataPlane.mockReturnValue({
+        endpoint: "localhost",
+        port: 8081,
+        tls: false,
+      });
+
+      const clientOptions = command.testGetClientOptions({});
+
+      expect(clientOptions.endpoint).toBe("other.example.com");
+      expect(clientOptions.port).toBe(8081);
+
+      delete process.env.ABLY_ENDPOINT;
+    });
+
+    it("leaves routing options unset for a managed account", function () {
+      // A managed account has no routing overrides stored.
+      configManagerStub.getDataPlane.mockReturnValue();
+
+      const clientOptions = command.testGetClientOptions({});
+
+      expect(clientOptions.endpoint).toBeUndefined();
+      expect(clientOptions.tls).toBeUndefined();
+      expect(clientOptions.port).toBeUndefined();
+      expect(clientOptions.tlsPort).toBeUndefined();
     });
   });
 });

--- a/test/unit/base/local-server-control-guard.test.ts
+++ b/test/unit/base/local-server-control-guard.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Control plane behaviour for local server accounts.
+ *
+ * A local server account only reaches a Control API if one was configured at
+ * login, so control commands must fail with an actionable message rather than
+ * silently querying the managed Control API.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { runCommand } from "@oclif/test";
+import nock from "nock";
+import { getMockConfigManager } from "../../helpers/mock-config-manager.js";
+import { parseNdjsonLines } from "../../helpers/ndjson.js";
+
+describe("local server control plane guard", () => {
+  beforeEach(() => {
+    nock.cleanAll();
+    delete process.env.ABLY_ACCESS_TOKEN;
+    delete process.env.ABLY_CONTROL_HOST;
+
+    const mock = getMockConfigManager();
+    mock.clearAccounts();
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
+    delete process.env.ABLY_ACCESS_TOKEN;
+    delete process.env.ABLY_CONTROL_HOST;
+  });
+
+  it("fails control commands for a local account with no control plane", async () => {
+    const mock = getMockConfigManager();
+    mock.storeLocalAccount("local", {
+      accountName: "local",
+      dataPlane: { endpoint: "localhost", port: 8081, tls: false },
+    });
+    mock.switchAccount("local");
+
+    const { stdout } = await runCommand(
+      ["apps:list", "--json"],
+      import.meta.url,
+    );
+
+    const result = parseNdjsonLines(stdout).find((r) => r.type === "error")!;
+    expect(result.error.message).toContain("aren't available for local server");
+    expect(result.error.message).toContain("--control-url");
+  });
+
+  it("routes control commands to the stored control URL when one is configured", async () => {
+    const mock = getMockConfigManager();
+    mock.storeLocalAccount("local", {
+      accessToken: "local-control-token",
+      accountName: "local",
+      controlUrl: "http://localhost:8082",
+      dataPlane: { endpoint: "localhost", port: 8081, tls: false },
+    });
+    mock.switchAccount("local");
+
+    nock("http://localhost:8082")
+      .get("/v1/me")
+      .reply(200, {
+        account: { id: "local-account", name: "Local" },
+        user: { email: "dev@localhost" },
+      });
+    nock("http://localhost:8082")
+      .get("/v1/accounts/local-account/apps")
+      .reply(200, [
+        {
+          accountId: "local-account",
+          created: 1_700_000_000_000,
+          id: "localapp",
+          modified: 1_700_000_000_000,
+          name: "Local App",
+          status: "enabled",
+          tlsOnly: false,
+        },
+      ]);
+
+    const { stdout } = await runCommand(
+      ["apps:list", "--json"],
+      import.meta.url,
+    );
+
+    const result = parseNdjsonLines(stdout).find((r) => r.type === "result")!;
+    expect(result).toHaveProperty("success", true);
+    expect(JSON.stringify(result)).toContain("localapp");
+  });
+});

--- a/test/unit/base/local-server-control-guard.test.ts
+++ b/test/unit/base/local-server-control-guard.test.ts
@@ -40,9 +40,16 @@ describe("local server control plane guard", () => {
       import.meta.url,
     );
 
-    const result = parseNdjsonLines(stdout).find((r) => r.type === "error")!;
-    expect(result.error.message).toContain("aren't available for local server");
-    expect(result.error.message).toContain("--control-url");
+    const errors = parseNdjsonLines(stdout).filter((r) => r.type === "error");
+    // One failure, one record: the exit that fail() performs must not be
+    // reported a second time by the enclosing catch in runControlCommand.
+    expect(errors).toHaveLength(1);
+    expect(errors[0].error.message).toContain(
+      "aren't available for local server",
+    );
+    expect(errors[0].error.message).toContain("--control-url");
+    expect(errors[0].error.message).toContain("ABLY_CONTROL_HOST");
+    expect(JSON.stringify(errors)).not.toContain("Command exited with code");
   });
 
   it("routes control commands to the stored control URL when one is configured", async () => {

--- a/test/unit/commands/accounts/current.test.ts
+++ b/test/unit/commands/accounts/current.test.ts
@@ -1,15 +1,36 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { runCommand } from "@oclif/test";
+import nock from "nock";
+import stripAnsi from "strip-ansi";
 import {
   nockControl,
   controlApiCleanup,
 } from "../../../helpers/control-api-test-helpers.js";
 import { getMockConfigManager } from "../../../helpers/mock-config-manager.js";
+import { parseNdjsonLines } from "../../../helpers/ndjson.js";
 import {
   standardHelpTests,
   standardArgValidationTests,
   standardFlagTests,
 } from "../../../helpers/standard-tests.js";
+
+/**
+ * Select a local server profile, optionally with a control plane. Without one
+ * there is no /me endpoint to verify the account against.
+ */
+function storeLocalAccount(controlUrl?: string) {
+  const mock = getMockConfigManager();
+  mock.clearAccounts();
+  mock.storeLocalAccount("local", {
+    accountName: "local",
+    controlUrl,
+    dataPlane: { endpoint: "localhost", port: 8081, tls: false },
+  });
+  mock.switchAccount("local");
+  mock.setCurrentApp("localapp");
+  mock.storeAppKey("localapp", "localapp.keyid:secret");
+  return mock;
+}
 
 describe("accounts:current command", () => {
   const mockAccountId = "test-account-id";
@@ -96,6 +117,76 @@ describe("accounts:current command", () => {
 
       const combined = stdout + stderr;
       expect(combined).toContain("ably accounts login");
+    });
+  });
+
+  describe("local server accounts", () => {
+    it("reports the stored server without claiming the token expired", async () => {
+      storeLocalAccount();
+
+      const { stdout, stderr } = await runCommand(
+        ["accounts:current"],
+        import.meta.url,
+      );
+
+      const combined = stripAnsi(stdout + stderr);
+      expect(combined).toContain("Endpoint:");
+      expect(combined).toContain("http://localhost:8081");
+      expect(combined).not.toMatch(/expired|Unable to verify/i);
+      expect(combined).not.toContain("aren't available for local server");
+    });
+
+    it("emits one success record carrying the server, and no error record", async () => {
+      storeLocalAccount();
+
+      const { stdout } = await runCommand(
+        ["accounts:current", "--json"],
+        import.meta.url,
+      );
+
+      const records = parseNdjsonLines(stdout);
+      expect(records.some((r) => r.type === "error")).toBe(false);
+
+      const result = records.find((r) => r.type === "result")!;
+      expect(result).toHaveProperty("success", true);
+      const account = result.account as Record<string, unknown>;
+      expect(account).toHaveProperty("alias", "local");
+      expect(account).toHaveProperty("authMethod", "apiKey");
+      expect(account.dataPlane).toEqual({
+        endpoint: "localhost",
+        port: 8081,
+        tls: false,
+        url: "http://localhost:8081",
+      });
+    });
+
+    it("names the app once when there is no control plane to resolve a name", async () => {
+      storeLocalAccount();
+
+      const { stdout } = await runCommand(
+        ["accounts:current"],
+        import.meta.url,
+      );
+
+      expect(stripAnsi(stdout)).toContain("Current App: localapp");
+      expect(stripAnsi(stdout)).not.toContain("localapp (localapp)");
+    });
+
+    it("suggests a local re-login when a local account's token has expired", async () => {
+      storeLocalAccount("http://localhost:8082");
+      nock("http://localhost:8082")
+        .get("/v1/me")
+        .replyWithError("Network error");
+
+      const { stdout, stderr } = await runCommand(
+        ["accounts:current"],
+        import.meta.url,
+      );
+
+      const combined = stripAnsi(stdout + stderr);
+      expect(combined).toContain("ably accounts login --local");
+      expect(combined).toContain("--url http://localhost:8081");
+      expect(combined).toContain("--control-url http://localhost:8082");
     });
   });
 

--- a/test/unit/commands/accounts/list.test.ts
+++ b/test/unit/commands/accounts/list.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { runCommand } from "@oclif/test";
+import stripAnsi from "strip-ansi";
 import { getMockConfigManager } from "../../../helpers/mock-config-manager.js";
 import {
   standardHelpTests,
@@ -74,6 +75,58 @@ describe("accounts:list command", () => {
       expect(currentAccount.isCurrent).toBe(true);
       expect(currentAccount).toHaveProperty("alias");
       expect(currentAccount).toHaveProperty("appsConfigured");
+    });
+  });
+
+  describe("local server accounts", () => {
+    beforeEach(() => {
+      const mock = getMockConfigManager();
+      mock.clearAccounts();
+      mock.storeLocalAccount("local", {
+        accountName: "local",
+        dataPlane: { endpoint: "localhost", port: 8081, tls: false },
+      });
+      mock.storeLocalAccount("other", {
+        accountName: "other",
+        controlUrl: "http://localhost:8092",
+        dataPlane: { endpoint: "localhost", port: 8091, tls: false },
+      });
+      mock.switchAccount("local");
+    });
+
+    it("shows the server URL, which is what tells two local profiles apart", async () => {
+      const { stdout } = await runCommand(["accounts:list"], import.meta.url);
+
+      const output = stripAnsi(stdout);
+      expect(output).toContain("Endpoint: http://localhost:8081");
+      expect(output).toContain("Endpoint: http://localhost:8091");
+      expect(output).toContain("Control plane: http://localhost:8092");
+    });
+
+    it("carries the routing in JSON and omits the empty account ID and user", async () => {
+      const { stdout } = await runCommand(
+        ["accounts:list", "--json"],
+        import.meta.url,
+      );
+
+      const result = parseJsonOutput(stdout);
+      const local = result.accounts.find(
+        (a: { alias: string }) => a.alias === "local",
+      );
+      expect(local.dataPlane).toEqual({
+        endpoint: "localhost",
+        port: 8081,
+        tls: false,
+        url: "http://localhost:8081",
+      });
+      expect(local).toHaveProperty("authMethod", "apiKey");
+      expect(local).not.toHaveProperty("id");
+      expect(local).not.toHaveProperty("user");
+
+      const other = result.accounts.find(
+        (a: { alias: string }) => a.alias === "other",
+      );
+      expect(other).toHaveProperty("controlUrl", "http://localhost:8092");
     });
   });
 

--- a/test/unit/commands/accounts/login.test.ts
+++ b/test/unit/commands/accounts/login.test.ts
@@ -522,4 +522,204 @@ describe("accounts:login command", () => {
       expect(authEvent).toHaveProperty("verificationUri");
     });
   });
+
+  describe("local server login", () => {
+    const localApiKey = "localapp.keyid:keysecret";
+
+    beforeEach(() => {
+      process.env.ABLY_API_KEY = localApiKey;
+    });
+
+    afterEach(() => {
+      delete process.env.ABLY_API_KEY;
+      delete process.env.ABLY_ACCESS_TOKEN;
+    });
+
+    it("stores a data-plane-only profile from a URL and ABLY_API_KEY", async () => {
+      const { stdout } = await runCommand(
+        [
+          "accounts:login",
+          "--local",
+          "--url",
+          "http://localhost:8081",
+          "--json",
+        ],
+        import.meta.url,
+      );
+
+      const result = parseNdjsonLines(stdout).find((r) => r.type === "result")!;
+      expect(result).toHaveProperty("success", true);
+      const account = result.account as Record<string, unknown>;
+      expect(account).toHaveProperty("alias", "local");
+      expect(account).toHaveProperty("authMethod", "apiKey");
+      expect(account).not.toHaveProperty("controlUrl");
+      expect(account.dataPlane).toEqual({
+        endpoint: "localhost",
+        port: 8081,
+        tls: false,
+        url: "http://localhost:8081",
+      });
+      expect(account.app).toEqual({ id: "localapp" });
+
+      const config = getMockConfigManager().getConfig();
+      expect(config.current?.account).toBe("local");
+      const stored = config.accounts.local;
+      expect(stored.authMethod).toBe("apiKey");
+      expect(stored.endpoint).toBe("localhost");
+      expect(stored.port).toBe(8081);
+      expect(stored.tls).toBe(false);
+      expect(stored.currentAppId).toBe("localapp");
+      expect(stored.apps?.localapp?.apiKey).toBe(localApiKey);
+    });
+
+    it("stores the control plane URL and token when --control-url is given", async () => {
+      process.env.ABLY_ACCESS_TOKEN = "local-control-token";
+
+      // getApp resolves the name via /me then the account's apps list.
+      nock("http://localhost:8082")
+        .get("/v1/me")
+        .reply(200, {
+          account: { id: "local-account", name: "Local" },
+          user: { email: "dev@localhost" },
+        });
+      nock("http://localhost:8082")
+        .get("/v1/accounts/local-account/apps")
+        .reply(200, [
+          { accountId: "local-account", id: "localapp", name: "Local App" },
+        ]);
+
+      const { stdout } = await runCommand(
+        [
+          "accounts:login",
+          "--local",
+          "--url",
+          "http://localhost:8081",
+          "--control-url",
+          "http://localhost:8082",
+          "--json",
+        ],
+        import.meta.url,
+      );
+
+      const result = parseNdjsonLines(stdout).find((r) => r.type === "result")!;
+      const account = result.account as Record<string, unknown>;
+      expect(account).toHaveProperty("controlUrl", "http://localhost:8082");
+      expect(account.app).toEqual({ id: "localapp", name: "Local App" });
+
+      const stored = getMockConfigManager().getConfig().accounts.local;
+      expect(stored.controlUrl).toBe("http://localhost:8082");
+      expect(stored.accessToken).toBe("local-control-token");
+      expect(stored.apps?.localapp?.appName).toBe("Local App");
+    });
+
+    it("uses --alias when provided", async () => {
+      const { stdout } = await runCommand(
+        [
+          "accounts:login",
+          "--local",
+          "--url",
+          "http://localhost:8081",
+          "--alias",
+          "dev-server",
+          "--json",
+        ],
+        import.meta.url,
+      );
+
+      const result = parseNdjsonLines(stdout).find((r) => r.type === "result")!;
+      expect(result.account).toHaveProperty("alias", "dev-server");
+      expect(
+        getMockConfigManager().getConfig().accounts["dev-server"],
+      ).toBeDefined();
+    });
+
+    it("errors when --url is omitted in JSON mode", async () => {
+      const { stdout } = await runCommand(
+        ["accounts:login", "--local", "--json"],
+        import.meta.url,
+      );
+
+      const result = parseNdjsonLines(stdout).find((r) => r.type === "error")!;
+      expect(result.error.message).toContain("--url");
+    });
+
+    it("errors when no API key is available in JSON mode", async () => {
+      delete process.env.ABLY_API_KEY;
+
+      const { stdout } = await runCommand(
+        [
+          "accounts:login",
+          "--local",
+          "--url",
+          "http://localhost:8081",
+          "--json",
+        ],
+        import.meta.url,
+      );
+
+      const result = parseNdjsonLines(stdout).find((r) => r.type === "error")!;
+      expect(result.error.message).toContain("ABLY_API_KEY");
+    });
+
+    it("errors when the data plane URL includes a path", async () => {
+      const { stdout } = await runCommand(
+        [
+          "accounts:login",
+          "--local",
+          "--url",
+          "http://localhost:8081/realtime",
+          "--json",
+        ],
+        import.meta.url,
+      );
+
+      const result = parseNdjsonLines(stdout).find((r) => r.type === "error")!;
+      expect(result.error.message).toContain("must not include a path");
+    });
+
+    it("errors when the API key has no app ID", async () => {
+      process.env.ABLY_API_KEY = "not-a-valid-key";
+
+      const { stdout } = await runCommand(
+        [
+          "accounts:login",
+          "--local",
+          "--url",
+          "http://localhost:8081",
+          "--json",
+        ],
+        import.meta.url,
+      );
+
+      const result = parseNdjsonLines(stdout).find((r) => r.type === "error")!;
+      expect(result.error.message).toContain("app ID");
+    });
+
+    it("errors when no control API token is available in JSON mode", async () => {
+      const { stdout } = await runCommand(
+        [
+          "accounts:login",
+          "--local",
+          "--url",
+          "http://localhost:8081",
+          "--control-url",
+          "http://localhost:8082",
+          "--json",
+        ],
+        import.meta.url,
+      );
+
+      const result = parseNdjsonLines(stdout).find((r) => r.type === "error")!;
+      expect(result.error.message).toContain("ABLY_ACCESS_TOKEN");
+    });
+
+    it("rejects --url without --local", async () => {
+      const { error } = await runCommand(
+        ["accounts:login", "--url", "http://localhost:8081", "--json"],
+        import.meta.url,
+      );
+
+      expect(error?.message).toContain("local");
+    });
+  });
 });

--- a/test/unit/commands/accounts/login.test.ts
+++ b/test/unit/commands/accounts/login.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { runCommand } from "@oclif/test";
 import nock from "nock";
+import stripAnsi from "strip-ansi";
 import {
   nockControl,
   controlApiCleanup,
@@ -720,6 +721,81 @@ describe("accounts:login command", () => {
       );
 
       expect(error?.message).toContain("local");
+    });
+
+    it("names the app once when there is no control plane to resolve a name", async () => {
+      const { stderr } = await runCommand(
+        ["accounts:login", "--local", "--url", "http://localhost:8081"],
+        import.meta.url,
+      );
+
+      const output = stripAnsi(stderr);
+      expect(output).toContain("Using app localapp.");
+      expect(output).not.toContain("localapp (localapp)");
+    });
+
+    it("pairs app name and ID when a control plane resolved the name", async () => {
+      process.env.ABLY_ACCESS_TOKEN = "local-control-token";
+
+      nock("http://localhost:8082")
+        .get("/v1/me")
+        .reply(200, {
+          account: { id: "local-account", name: "Local" },
+          user: { email: "dev@localhost" },
+        });
+      nock("http://localhost:8082")
+        .get("/v1/accounts/local-account/apps")
+        .reply(200, [
+          { accountId: "local-account", id: "localapp", name: "Local App" },
+        ]);
+
+      const { stderr } = await runCommand(
+        [
+          "accounts:login",
+          "--local",
+          "--url",
+          "http://localhost:8081",
+          "--control-url",
+          "http://localhost:8082",
+        ],
+        import.meta.url,
+      );
+
+      expect(stripAnsi(stderr)).toContain("Using app Local App (localapp).");
+    });
+
+    it("names the alias without an empty account when replacing an unnamed managed account", async () => {
+      const mock = getMockConfigManager();
+      mock.storeAccount("managed-token", "local", {
+        accountId: "",
+        accountName: "",
+        userEmail: "",
+      });
+
+      const { stderr } = await runCommand(
+        ["accounts:login", "--local", "--url", "http://localhost:8081"],
+        import.meta.url,
+      );
+
+      const output = stripAnsi(stderr);
+      expect(output).toContain("is currently a managed account");
+      expect(output).not.toContain("account  and");
+    });
+
+    it("rejects a URL carrying credentials rather than dropping them", async () => {
+      const { stdout } = await runCommand(
+        [
+          "accounts:login",
+          "--local",
+          "--url",
+          "http://user:pass@localhost:8081",
+          "--json",
+        ],
+        import.meta.url,
+      );
+
+      const result = parseNdjsonLines(stdout).find((r) => r.type === "error")!;
+      expect(result.error.message).toContain("Credentials are not supported");
     });
   });
 });

--- a/test/unit/commands/accounts/switch.test.ts
+++ b/test/unit/commands/accounts/switch.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { runCommand } from "@oclif/test";
 import nock from "nock";
+import stripAnsi from "strip-ansi";
 import {
   nockControl,
   controlApiCleanup,
@@ -269,6 +270,44 @@ describe("accounts:switch command", () => {
       expect(result).toHaveProperty("success", true);
       expect(result.account.alias).toBe("oauth-json");
       expect(result.account.id).toBe("json-account-id");
+    });
+  });
+
+  describe("local server account switching", () => {
+    beforeEach(() => {
+      const mock = getMockConfigManager();
+      mock.storeLocalAccount("local", {
+        accountName: "local",
+        dataPlane: { endpoint: "localhost", port: 8081, tls: false },
+      });
+    });
+
+    it("reports the server by URL, not by bare hostname", async () => {
+      const { stderr } = await runCommand(
+        ["accounts:switch", "local"],
+        import.meta.url,
+      );
+
+      const output = stripAnsi(stderr);
+      expect(output).toContain(
+        "Switched to local server local (http://localhost:8081).",
+      );
+      expect(output).not.toContain("(localhost)");
+    });
+
+    it("carries the routing in JSON", async () => {
+      const { stdout } = await runCommand(
+        ["accounts:switch", "local", "--json"],
+        import.meta.url,
+      );
+
+      const result = parseJsonOutput(stdout);
+      expect(result.account.dataPlane).toEqual({
+        endpoint: "localhost",
+        port: 8081,
+        tls: false,
+        url: "http://localhost:8081",
+      });
     });
   });
 

--- a/test/unit/commands/env.test.ts
+++ b/test/unit/commands/env.test.ts
@@ -81,14 +81,15 @@ describe("env command", () => {
       expect(result).toHaveProperty("type", "result");
       expect(result).toHaveProperty("command", "env");
       expect(result).toHaveProperty("success", true);
-      expect(result.envVars).toHaveLength(9);
+      expect(result.envVars).toHaveLength(10);
       expect(result.envVars[0]).toMatchObject({
         name: "ABLY_API_KEY",
         category: "Authentication",
         format: "APP_ID.KEY_ID:KEY_SECRET",
       });
-      expect(result.envVars[3].name).toBe("ABLY_ENDPOINT");
-      expect(result.envVars[8].name).toBe("ABLY_CLI_NON_INTERACTIVE");
+      expect(result.envVars[3].name).toBe("ABLY_URL");
+      expect(result.envVars[4].name).toBe("ABLY_ENDPOINT");
+      expect(result.envVars[9].name).toBe("ABLY_CLI_NON_INTERACTIVE");
       expect(result.crossCutting).toBeDefined();
       expect(result.crossCutting.authResolutionOrder.heading).toBe(
         "Authentication Resolution Order",

--- a/test/unit/commands/login.test.ts
+++ b/test/unit/commands/login.test.ts
@@ -1,10 +1,11 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
 import { runCommand } from "@oclif/test";
 import {
   standardHelpTests,
   standardArgValidationTests,
   standardFlagTests,
 } from "../../helpers/standard-tests.js";
+import { parseNdjsonLines } from "../../helpers/ndjson.js";
 
 describe("login command", () => {
   standardHelpTests("login", import.meta.url);
@@ -18,6 +19,31 @@ describe("login command", () => {
 
       expect(stdout).toBeDefined();
       expect(stdout).toContain("Log in to your Ably account");
+    });
+
+    describe("JSON envelope labelling", () => {
+      afterEach(() => {
+        delete process.env.ABLY_API_KEY;
+      });
+
+      it("labels delegated records with this command's id, not 'unknown'", async () => {
+        // The delegate is constructed directly rather than dispatched by oclif,
+        // so without an inherited id its records fall back to "unknown".
+        // --local is used because it completes without network access.
+        process.env.ABLY_API_KEY = "localapp.keyid:keysecret";
+
+        const { stdout } = await runCommand(
+          ["login", "--local", "--url", "http://localhost:8081", "--json"],
+          import.meta.url,
+        );
+
+        const records = parseNdjsonLines(stdout);
+        const result = records.find((r) => r.type === "result")!;
+        const completed = records.find((r) => r.type === "status")!;
+
+        expect(result).toHaveProperty("command", "login");
+        expect(completed).toHaveProperty("command", "login");
+      });
     });
   });
 

--- a/test/unit/data/env-vars.test.ts
+++ b/test/unit/data/env-vars.test.ts
@@ -14,6 +14,7 @@ const CANONICAL_NAMES = [
   "ABLY_API_KEY",
   "ABLY_TOKEN",
   "ABLY_ACCESS_TOKEN",
+  "ABLY_URL",
   "ABLY_ENDPOINT",
   "ABLY_APP_ID",
   "ABLY_CLI_CONFIG_DIR",
@@ -27,8 +28,8 @@ describe("ENV_VARS_DATA", () => {
     expect(ENV_VARS_DATA).toBeInstanceOf(EnvVarsData);
   });
 
-  it("lists exactly 9 variables in canonical order", () => {
-    expect(ENV_VARS_DATA.variables).toHaveLength(9);
+  it("lists exactly 10 variables in canonical order", () => {
+    expect(ENV_VARS_DATA.variables).toHaveLength(10);
     expect(ENV_VARS_DATA.variables.map((v) => v.name)).toEqual(CANONICAL_NAMES);
   });
 
@@ -77,6 +78,7 @@ describe("ENV_VARS_DATA", () => {
     expect(byName.ABLY_CLI_DEFAULT_DURATION.details).toHaveLength(0);
     expect(byName.ABLY_CLI_NON_INTERACTIVE.details).toHaveLength(1);
     expect(byName.ABLY_ENDPOINT.details).toHaveLength(1);
+    expect(byName.ABLY_URL.details).toHaveLength(1);
   });
 
   it("only the documented primary URLs appear inline in variable entries", () => {

--- a/test/unit/data/env-vars.test.ts
+++ b/test/unit/data/env-vars.test.ts
@@ -76,7 +76,7 @@ describe("ENV_VARS_DATA", () => {
     expect(byName.ABLY_HISTORY_FILE.details).toHaveLength(1);
     expect(byName.ABLY_CLI_DEFAULT_DURATION.details).toHaveLength(0);
     expect(byName.ABLY_CLI_NON_INTERACTIVE.details).toHaveLength(1);
-    expect(byName.ABLY_ENDPOINT.details).toHaveLength(0);
+    expect(byName.ABLY_ENDPOINT.details).toHaveLength(1);
   });
 
   it("only the documented primary URLs appear inline in variable entries", () => {

--- a/test/unit/services/config-manager.test.ts
+++ b/test/unit/services/config-manager.test.ts
@@ -406,4 +406,99 @@ accessToken = "testaccesstoken"
       expect(configManager.switchAccount("nonexistentaccount")).toBe(false);
     });
   });
+
+  // Tests for local server accounts
+  describe("#storeLocalAccount", () => {
+    it("should store data plane routing and mark the account as apiKey auth", () => {
+      configManager.storeLocalAccount("local", {
+        accountName: "local",
+        dataPlane: { endpoint: "localhost", port: 8081, tls: false },
+      });
+
+      expect(configManager.getAuthMethod("local")).toBe("apiKey");
+      expect(configManager.getDataPlane("local")).toEqual({
+        endpoint: "localhost",
+        port: 8081,
+        tls: false,
+      });
+      expect(configManager.getEndpoint("local")).toBe("localhost");
+      expect(configManager.getControlUrl("local")).toBeUndefined();
+    });
+
+    it("should store the control plane URL and access token when supplied", () => {
+      configManager.storeLocalAccount("local", {
+        accessToken: "local-control-token",
+        accountName: "local",
+        controlUrl: "http://localhost:8082",
+        dataPlane: { endpoint: "localhost", port: 8081, tls: false },
+      });
+
+      configManager.switchAccount("local");
+
+      expect(configManager.getControlUrl()).toBe("http://localhost:8082");
+      expect(configManager.getAccessToken()).toBe("local-control-token");
+    });
+
+    it("should drop OAuth state when replacing a managed account", () => {
+      configManager.storeOAuthTokens(
+        "local",
+        {
+          accessToken: "oauth-token",
+          expiresAt: Date.now() + 3_600_000,
+          refreshToken: "refresh-token",
+          userEmail: "test@example.com",
+        },
+        { accountId: "acc-1", accountName: "Managed" },
+      );
+
+      configManager.storeLocalAccount("local", {
+        accountName: "local",
+        dataPlane: { endpoint: "localhost", port: 8081, tls: false },
+      });
+
+      configManager.switchAccount("local");
+
+      expect(configManager.getAuthMethod("local")).toBe("apiKey");
+      expect(configManager.getOAuthTokens("local")).toBeUndefined();
+      expect(configManager.getAccessToken()).toBeUndefined();
+    });
+
+    it("should preserve stored apps when repointing an existing local account", () => {
+      configManager.storeLocalAccount("local", {
+        accountName: "local",
+        dataPlane: { endpoint: "localhost", port: 8081, tls: false },
+      });
+      configManager.switchAccount("local");
+      configManager.setCurrentApp("appid");
+      configManager.storeAppKey("appid", "appid.keyid:secret");
+
+      configManager.storeLocalAccount("local", {
+        accountName: "local",
+        dataPlane: { endpoint: "localhost", port: 9091, tls: false },
+      });
+
+      expect(configManager.getDataPlane("local")?.port).toBe(9091);
+      expect(configManager.getApiKey("appid")).toBe("appid.keyid:secret");
+    });
+  });
+
+  describe("#getDataPlane", () => {
+    it("should return undefined for an account with no routing overrides", () => {
+      expect(configManager.getDataPlane("default")).toBeUndefined();
+    });
+
+    it("should return undefined for an unknown alias", () => {
+      expect(configManager.getDataPlane("nonexistentaccount")).toBeUndefined();
+    });
+
+    it("should return the endpoint alone when only an endpoint is stored", () => {
+      configManager.storeEndpoint("custom.example.com", "default");
+
+      expect(configManager.getDataPlane("default")).toEqual({
+        endpoint: "custom.example.com",
+        port: undefined,
+        tls: undefined,
+      });
+    });
+  });
 });

--- a/test/unit/services/control-api.test.ts
+++ b/test/unit/services/control-api.test.ts
@@ -57,6 +57,51 @@ describe("ControlApi", function () {
         expect(scope.isDone()).toBe(true);
       });
     });
+
+    it("should serve a controlUrl origin at /v1", function () {
+      const localApi = new ControlApi({
+        accessToken,
+        controlUrl: "http://localhost:8082",
+        logErrors: false,
+      });
+
+      const scope = nock("http://localhost:8082")
+        .get("/v1/me")
+        .reply(200, { account: { id: "test-account-id" } });
+
+      return localApi.getMe().then(() => {
+        expect(scope.isDone()).toBe(true);
+      });
+    });
+
+    it("should treat a controlUrl path as the full prefix", function () {
+      const localApi = new ControlApi({
+        accessToken,
+        controlUrl: "http://localhost:8082/api/v1/",
+        logErrors: false,
+      });
+
+      const scope = nock("http://localhost:8082")
+        .get("/api/v1/me")
+        .reply(200, { account: { id: "test-account-id" } });
+
+      return localApi.getMe().then(() => {
+        expect(scope.isDone()).toBe(true);
+      });
+    });
+
+    it("should reject a malformed controlUrl with a diagnosable error", function () {
+      // Validating at construction beats a raw TypeError from inside every
+      // request, which carries no URL and no context.
+      expect(
+        () =>
+          new ControlApi({
+            accessToken,
+            controlUrl: "localhost:8082",
+            logErrors: false,
+          }),
+      ).toThrow(/Invalid control plane URL "localhost:8082"/);
+    });
   });
 
   describe("#listApps", function () {

--- a/test/unit/utils/server-url.test.ts
+++ b/test/unit/utils/server-url.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from "vitest";
+import {
+  formatServerUrl,
+  parseServerUrl,
+} from "../../../src/utils/server-url.js";
+
+describe("parseServerUrl", () => {
+  it("decomposes a plaintext local URL", () => {
+    expect(parseServerUrl("http://localhost:8081")).toEqual({
+      host: "localhost",
+      path: "",
+      port: 8081,
+      tls: false,
+    });
+  });
+
+  it("decomposes an https URL", () => {
+    expect(parseServerUrl("https://server.example.com:8443")).toEqual({
+      host: "server.example.com",
+      path: "",
+      port: 8443,
+      tls: true,
+    });
+  });
+
+  it("leaves port undefined when the URL relies on the scheme default", () => {
+    expect(parseServerUrl("https://server.example.com").port).toBeUndefined();
+  });
+
+  it("leaves port undefined when the port matches the scheme default", () => {
+    // URL parsing drops a redundant default port; the SDK supplies the same
+    // value, so the result is identical.
+    expect(
+      parseServerUrl("https://server.example.com:443").port,
+    ).toBeUndefined();
+  });
+
+  it("defaults schemeless loopback input to http", () => {
+    expect(parseServerUrl("localhost:8081")).toEqual({
+      host: "localhost",
+      path: "",
+      port: 8081,
+      tls: false,
+    });
+  });
+
+  it("defaults schemeless 127.0.0.1 input to http", () => {
+    expect(parseServerUrl("127.0.0.1:8081").tls).toBe(false);
+  });
+
+  it("defaults schemeless non-loopback input to https", () => {
+    expect(parseServerUrl("server.example.com:8081")).toEqual({
+      host: "server.example.com",
+      path: "",
+      port: 8081,
+      tls: true,
+    });
+  });
+
+  it("honours an explicit http scheme on a non-loopback host", () => {
+    expect(parseServerUrl("http://server.example.com").tls).toBe(false);
+  });
+
+  it("preserves an IPv6 host in bracketed form", () => {
+    // The SDK treats any endpoint containing "::" as a literal host, so the
+    // brackets must survive parsing.
+    expect(parseServerUrl("http://[::1]:8081").host).toBe("[::1]");
+  });
+
+  it("returns a normalised path when one is present", () => {
+    expect(parseServerUrl("http://localhost:8082/api/v1").path).toBe("/api/v1");
+  });
+
+  it("strips a trailing slash from the path", () => {
+    expect(parseServerUrl("http://localhost:8082/api/").path).toBe("/api");
+  });
+
+  it("reports an empty path for a bare origin", () => {
+    expect(parseServerUrl("http://localhost:8082/").path).toBe("");
+  });
+
+  it("throws on empty input", () => {
+    expect(() => parseServerUrl("   ")).toThrow("URL cannot be empty");
+  });
+
+  it("throws on an unsupported scheme", () => {
+    expect(() => parseServerUrl("ws://localhost:8081")).toThrow(
+      /Unsupported scheme "ws"/,
+    );
+  });
+
+  it("throws on unparseable input", () => {
+    expect(() => parseServerUrl("http://")).toThrow(/Invalid URL/);
+  });
+});
+
+describe("formatServerUrl", () => {
+  it("renders a plaintext URL with a port", () => {
+    expect(
+      formatServerUrl({ host: "localhost", path: "", port: 8081, tls: false }),
+    ).toBe("http://localhost:8081");
+  });
+
+  it("renders an https URL without a port", () => {
+    expect(formatServerUrl({ host: "example.com", path: "", tls: true })).toBe(
+      "https://example.com",
+    );
+  });
+
+  it("includes the path when present", () => {
+    expect(
+      formatServerUrl({
+        host: "localhost",
+        path: "/api/v1",
+        port: 8082,
+        tls: false,
+      }),
+    ).toBe("http://localhost:8082/api/v1");
+  });
+
+  it("round-trips a parsed URL", () => {
+    const raw = "http://localhost:8081";
+    expect(formatServerUrl(parseServerUrl(raw))).toBe(raw);
+  });
+});

--- a/test/unit/utils/server-url.test.ts
+++ b/test/unit/utils/server-url.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
+  formatEndpointUrl,
   formatServerUrl,
   parseServerUrl,
 } from "../../../src/utils/server-url.js";
@@ -91,6 +92,45 @@ describe("parseServerUrl", () => {
 
   it("throws on unparseable input", () => {
     expect(() => parseServerUrl("http://")).toThrow(/Invalid URL/);
+  });
+
+  it("throws on embedded credentials rather than dropping them", () => {
+    // Silently discarded credentials resurface later as an unrelated auth
+    // error, which is much harder to diagnose than a rejection here.
+    expect(() => parseServerUrl("http://user:pass@localhost:8081")).toThrow(
+      /Credentials are not supported/,
+    );
+  });
+
+  it("throws on a query string", () => {
+    expect(() => parseServerUrl("http://localhost:8081?x=1")).toThrow(
+      /Query strings and fragments are not supported/,
+    );
+  });
+
+  it("throws on a fragment", () => {
+    expect(() => parseServerUrl("http://localhost:8081#frag")).toThrow(
+      /Query strings and fragments are not supported/,
+    );
+  });
+});
+
+describe("formatEndpointUrl", () => {
+  it("renders stored routing as a URL", () => {
+    expect(
+      formatEndpointUrl({ endpoint: "localhost", port: 8081, tls: false }),
+    ).toBe("http://localhost:8081");
+  });
+
+  it("defaults to https when the profile does not say", () => {
+    expect(formatEndpointUrl({ endpoint: "example.com" })).toBe(
+      "https://example.com",
+    );
+  });
+
+  it("returns undefined when there is no endpoint to report", () => {
+    expect(formatEndpointUrl()).toBeUndefined();
+    expect(formatEndpointUrl({ port: 8081 })).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary

Adds first-class support for pointing the CLI at a locally-running Ably server (e.g. [`ably-server`](https://github.com/ably/ably-server)), via either a stored profile or environment variables.

Previously this was possible but awkward: `ABLY_ENDPOINT` sets the **host only**, there was no environment variable for the port, and the SDK's `endpoint` option rejects `localhost:8081` as a hostname. The shortest throwaway invocation was:

```bash
ABLY_ENDPOINT=localhost ably channels publish ch msg --tls=false --port 8081
```

with the port flags needing repeating on every command.

## What you can do now

**Stored profile** — a local server becomes an ordinary account, so `accounts list`/`current`/`switch` and every data plane command work unchanged:

```bash
ably accounts login --local                                      # guided prompts
ably accounts login --local --url http://localhost:8081          # data plane only
ably accounts login --local --url http://localhost:8081 \
                            --control-url http://localhost:8082  # both planes
```

**No profile** — two environment variables, or a flag:

```bash
ABLY_URL=http://localhost:8081 ABLY_API_KEY=appId.keyId:secret ably channels publish ch msg
ably channels publish ch msg --url http://localhost:8081
```

## Design notes

- **The API key is the only data plane credential.** There is no OAuth flow and no account directory on a local server, so the app ID is read out of the key. `isValidApiKey()` was added because `extractAppIdFromApiKey` is deliberately lenient and would otherwise store `not-a-valid-key` as an app ID.
- **URLs, not three flags.** `--url` / `ABLY_URL` are decomposed into the SDK's `endpoint`/`port`/`tls`. The scheme is optional for loopback hosts; a path is rejected rather than silently discarded, since Ably routes by host.
- **Precedence:** `--url` > `ABLY_URL` > `ABLY_ENDPOINT` > profile > SDK default, with `--port`/`--tls-port`/`--tls` applied on top so they still override a single field. `ABLY_ENDPOINT` keeps its host-only semantics, so existing usage is unaffected.
- **The alias is the account name.** A local server has no server-side identity, so several local profiles stay distinguishable in the `Using:` banner the same way managed accounts are.
- **Control plane is optional.** Without `--control-url`, control commands fail fast with a pointer instead of silently querying `control.ably.net` while a local profile is selected. `ControlApi` gained a `controlUrl` option because it inferred scheme and path prefix from the host string, which `localhost:8082` does not match.

## Drive-by fixes

Both predate this work and affect managed accounts too, so they are separate commits:

- `ably login --json` labelled its result record `"command":"unknown"` — the delegate is constructed directly, so oclif never assigned it an id, while the completed signal correctly read `login`. A single stream disagreed with itself.
- The `Using:` banner rendered `App=Unknown App (abc123)` whenever the name could not be resolved, pairing a real ID with an invented name. It now shows the bare ID.

## Verification

Tested end to end against a real `ably-server` instance (memory mode, port 8099): REST publish/history, WebSocket subscribe, `--rewind`, presence enter/get, and realtime presence `present`/`enter`/`leave` all work, via stored profile, `ABLY_URL`, and `--url`. Control commands correctly refuse. Unsupported surfaces (`channels list`, `rooms`) surface the server's own `40400` rather than masking it.

- `pnpm prepare`, `pnpm generate-doc` — pass
- `pnpm exec eslint src test` — 0 errors (4 pre-existing deprecation warnings in untouched code)
- `pnpm test:unit` — 2594 passed, up 25
- `pnpm test:tty` — 5 passed

New docs at `docs/Local-Server.md`; `ABLY_URL` documented in `ably env`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
